### PR TITLE
[Maze] Add dedicated maze place and shared camp session flow

### DIFF
--- a/packages/shared/src/Config/SessionConfig.luau
+++ b/packages/shared/src/Config/SessionConfig.luau
@@ -2,6 +2,7 @@ local SessionConfig = {
     PlaceIds = {
         Lobby = 0,
         Run = 0,
+        Maze = 0,
     },
     MinPlayers = 1,
     MaxPlayers = 4,

--- a/packages/shared/src/Runtime/InventoryService.luau
+++ b/packages/shared/src/Runtime/InventoryService.luau
@@ -1,0 +1,73 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+
+local Inventory = Gameplay.Inventory
+
+local InventoryService = {}
+InventoryService.__index = InventoryService
+
+function InventoryService.new(capacity)
+    return setmetatable({
+        Capacity = capacity,
+        ByUserId = {},
+    }, InventoryService)
+end
+
+function InventoryService:addPlayer(player)
+    self.ByUserId[player.UserId] = Inventory.new(self.Capacity)
+end
+
+function InventoryService:removePlayer(player)
+    self.ByUserId[player.UserId] = nil
+end
+
+function InventoryService:get(player)
+    return self.ByUserId[player.UserId]
+end
+
+function InventoryService:pickup(player, itemDef)
+    local inventory = self:get(player)
+    if not inventory then
+        return false, 'MissingInventory'
+    end
+
+    return inventory:add(itemDef)
+end
+
+function InventoryService:deposit(player)
+    local inventory = self:get(player)
+    if not inventory then
+        return 0
+    end
+
+    local totalValue = inventory:getTotalValue()
+    inventory:clear()
+    return totalValue
+end
+
+function InventoryService:reset()
+    for _, inventory in pairs(self.ByUserId) do
+        inventory:clear()
+    end
+end
+
+function InventoryService:getSummary(player)
+    local inventory = self:get(player)
+    if not inventory then
+        return {
+            Weight = 0,
+            Count = 0,
+            Value = 0,
+        }
+    end
+
+    return {
+        Weight = inventory.Weight,
+        Count = #inventory.Order,
+        Value = inventory:getTotalValue(),
+    }
+end
+
+return InventoryService

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -1,0 +1,106 @@
+local Players = game:GetService('Players')
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local RunService = game:GetService('RunService')
+local Workspace = game:GetService('Workspace')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+
+local MonsterLogic = Gameplay.Monsters.MonsterLogic
+
+local MonsterService = {}
+MonsterService.__index = MonsterService
+
+function MonsterService.new(monsterDefinition, isExpeditionActiveCallback)
+    return setmetatable({
+        Definition = monsterDefinition,
+        IsExpeditionActive = isExpeditionActiveCallback,
+        PatrolPoints = {},
+        PatrolIndex = 1,
+        MonsterPart = nil,
+        Connection = nil,
+    }, MonsterService)
+end
+
+function MonsterService:destroy()
+    if self.Connection then
+        self.Connection:Disconnect()
+        self.Connection = nil
+    end
+
+    if self.MonsterPart then
+        self.MonsterPart:Destroy()
+        self.MonsterPart = nil
+    end
+end
+
+function MonsterService:spawn(patrolPoints)
+    self:destroy()
+    self.PatrolPoints = patrolPoints
+    self.PatrolIndex = 1
+
+    if #patrolPoints == 0 then
+        return
+    end
+
+    local monster = Instance.new('Part')
+    monster.Name = self.Definition.Name
+    monster.Shape = Enum.PartType.Ball
+    monster.Size = Vector3.new(4, 4, 4)
+    monster.Anchored = true
+    monster.CanCollide = false
+    monster.Material = Enum.Material.Neon
+    monster.Color = Color3.fromRGB(214, 91, 91)
+    monster.Position = patrolPoints[1] + Vector3.new(0, 4, 0)
+    monster.Parent = Workspace
+
+    self.MonsterPart = monster
+
+    self.Connection = RunService.Heartbeat:Connect(function(dt)
+        self:update(dt)
+    end)
+end
+
+function MonsterService:update(dt)
+    if not self.MonsterPart or not self.IsExpeditionActive() then
+        return
+    end
+
+    local playerPositions = {}
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        local character = player.Character
+        local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+        if rootPart then
+            playerPositions[player] = rootPart.Position
+        end
+    end
+
+    local currentPosition = self.MonsterPart.Position
+    local targetPlayer =
+        MonsterLogic.pickNearestTarget(currentPosition, playerPositions, self.Definition.SightRange)
+    local nextPosition
+
+    if targetPlayer then
+        nextPosition = MonsterLogic.stepToward(
+            currentPosition,
+            playerPositions[targetPlayer],
+            self.Definition.Speed,
+            dt
+        )
+    elseif #self.PatrolPoints > 0 then
+        local patrolTarget = self.PatrolPoints[self.PatrolIndex] + Vector3.new(0, 4, 0)
+        nextPosition =
+            MonsterLogic.stepToward(currentPosition, patrolTarget, self.Definition.Speed * 0.45, dt)
+
+        if (nextPosition - patrolTarget).Magnitude <= 2 then
+            self.PatrolIndex = (self.PatrolIndex % #self.PatrolPoints) + 1
+        end
+    end
+
+    if nextPosition then
+        self.MonsterPart.CFrame = CFrame.new(nextPosition)
+    end
+end
+
+return MonsterService

--- a/packages/shared/src/Runtime/RoleService.luau
+++ b/packages/shared/src/Runtime/RoleService.luau
@@ -1,0 +1,82 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+
+local SharedPackage = Packages:WaitForChild('Shared')
+local VisibilityUtil = require(SharedPackage:WaitForChild('Util'):WaitForChild('Visibility'))
+local RoleAllocator = Gameplay.Roles.RoleAllocator
+
+local RoleService = {}
+RoleService.__index = RoleService
+
+local function countAssignments(assignments)
+    local count = 0
+    for _ in pairs(assignments) do
+        count += 1
+    end
+
+    return count
+end
+
+local function nextRoleDefinition(roleDefinitions, assignmentCount)
+    local index = (assignmentCount % #roleDefinitions) + 1
+    return roleDefinitions[index]
+end
+
+function RoleService.new(roleDefinitions)
+    return setmetatable({
+        RoleDefinitions = roleDefinitions,
+        Assignments = {},
+    }, RoleService)
+end
+
+function RoleService:assign(players)
+    self.Assignments = RoleAllocator.assign(table.clone(players), self.RoleDefinitions)
+    return self.Assignments
+end
+
+function RoleService:assignPlayer(player)
+    local existing = self.Assignments[player.UserId]
+    if existing then
+        existing.Name = player.DisplayName
+        return existing
+    end
+
+    local roleDefinition =
+        nextRoleDefinition(self.RoleDefinitions, countAssignments(self.Assignments))
+    local assignment = {
+        UserId = player.UserId,
+        Name = player.DisplayName,
+        RoleId = roleDefinition.Id,
+        PublicRole = roleDefinition.PublicRole,
+        PrivateRole = roleDefinition.PrivateRole,
+        PermissionTags = table.clone(roleDefinition.PermissionTags),
+    }
+
+    self.Assignments[player.UserId] = assignment
+    return assignment
+end
+
+function RoleService:removePlayer(player)
+    self.Assignments[player.UserId] = nil
+end
+
+function RoleService:getVisibleRoster(player)
+    return VisibilityUtil.filterRoster(self.Assignments, player.UserId)
+end
+
+function RoleService:getPrivateState(player)
+    local entry = self.Assignments[player.UserId]
+    if not entry then
+        return nil
+    end
+
+    return {
+        RoleId = entry.RoleId,
+        PrivateRole = entry.PrivateRole,
+        PermissionTags = entry.PermissionTags,
+    }
+end
+
+return RoleService

--- a/packages/shared/src/Runtime/init.luau
+++ b/packages/shared/src/Runtime/init.luau
@@ -1,0 +1,5 @@
+return {
+    InventoryService = require(script.InventoryService),
+    MonsterService = require(script.MonsterService),
+    RoleService = require(script.RoleService),
+}

--- a/packages/shared/src/Session/CampMazeSessionContract.luau
+++ b/packages/shared/src/Session/CampMazeSessionContract.luau
@@ -1,0 +1,204 @@
+local CampMazeSessionContract = {}
+
+local MAZE_STATUS = {
+    Idle = 'idle',
+    Active = 'active',
+    Completed = 'completed',
+}
+
+local function cloneArray(list)
+    local result = {}
+
+    for index, entry in ipairs(list or {}) do
+        result[index] = table.clone(entry)
+    end
+
+    return result
+end
+
+local function cloneTable(input)
+    return table.clone(input or {})
+end
+
+local function sortPlayers(players)
+    table.sort(players, function(left, right)
+        if left.UserId == right.UserId then
+            return (left.Name or '') < (right.Name or '')
+        end
+
+        return left.UserId < right.UserId
+    end)
+end
+
+local function sortSummaries(summaries)
+    table.sort(summaries, function(left, right)
+        if left.UserId == right.UserId then
+            return (left.ReturnReason or '') < (right.ReturnReason or '')
+        end
+
+        return left.UserId < right.UserId
+    end)
+end
+
+function CampMazeSessionContract.normalizeCampSession(session)
+    local normalized = {
+        SessionId = session and session.SessionId or 'local-debug-camp',
+        CampAccessCode = session and session.CampAccessCode or 'local-debug-camp',
+        GateOpen = session ~= nil and session.GateOpen == true or false,
+        MazeStatus = session and session.MazeStatus or MAZE_STATUS.Idle,
+        MazeAccessCode = session and session.MazeAccessCode or nil,
+        PlayersInMaze = cloneArray(session and session.PlayersInMaze or {}),
+        ReturnedPlayerSummaries = cloneArray(session and session.ReturnedPlayerSummaries or {}),
+    }
+
+    sortPlayers(normalized.PlayersInMaze)
+    sortSummaries(normalized.ReturnedPlayerSummaries)
+
+    return normalized
+end
+
+function CampMazeSessionContract.newCampSession(params)
+    return CampMazeSessionContract.normalizeCampSession(params)
+end
+
+function CampMazeSessionContract.buildReturnSummary(params)
+    return {
+        UserId = params.UserId,
+        Name = params.Name,
+        ReturnReason = params.ReturnReason,
+        Value = params.Value or 0,
+        ItemCount = params.ItemCount or 0,
+        Weight = params.Weight or 0,
+        WasExtracted = params.WasExtracted == true,
+        WasSettled = params.WasSettled == true,
+    }
+end
+
+function CampMazeSessionContract.markPlayerEntered(session, player)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    local nextPlayers = {}
+
+    for _, entry in ipairs(nextSession.PlayersInMaze) do
+        if entry.UserId ~= player.UserId then
+            table.insert(nextPlayers, entry)
+        end
+    end
+
+    table.insert(nextPlayers, {
+        UserId = player.UserId,
+        Name = player.Name,
+    })
+    sortPlayers(nextPlayers)
+    nextSession.PlayersInMaze = nextPlayers
+
+    local nextSummaries = {}
+    for _, entry in ipairs(nextSession.ReturnedPlayerSummaries) do
+        if entry.UserId ~= player.UserId then
+            table.insert(nextSummaries, entry)
+        end
+    end
+    sortSummaries(nextSummaries)
+    nextSession.ReturnedPlayerSummaries = nextSummaries
+
+    nextSession.MazeStatus = MAZE_STATUS.Active
+
+    return nextSession
+end
+
+function CampMazeSessionContract.applyReturn(session, summary, mazeCompleted)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    local nextPlayers = {}
+
+    for _, entry in ipairs(nextSession.PlayersInMaze) do
+        if entry.UserId ~= summary.UserId then
+            table.insert(nextPlayers, entry)
+        end
+    end
+
+    nextSession.PlayersInMaze = nextPlayers
+
+    local nextSummaries = {}
+    for _, entry in ipairs(nextSession.ReturnedPlayerSummaries) do
+        if entry.UserId ~= summary.UserId then
+            table.insert(nextSummaries, entry)
+        end
+    end
+
+    table.insert(nextSummaries, table.clone(summary))
+    sortPlayers(nextPlayers)
+    sortSummaries(nextSummaries)
+    nextSession.ReturnedPlayerSummaries = nextSummaries
+
+    if mazeCompleted then
+        nextSession.MazeStatus = MAZE_STATUS.Completed
+        nextSession.PlayersInMaze = {}
+    elseif nextSession.MazeAccessCode then
+        nextSession.MazeStatus = MAZE_STATUS.Active
+    else
+        nextSession.MazeStatus = MAZE_STATUS.Idle
+    end
+
+    return nextSession
+end
+
+function CampMazeSessionContract.buildLobbyToCampTeleportData(params)
+    return {
+        SessionConfig = cloneTable(params.SessionConfig),
+        CampSession = CampMazeSessionContract.newCampSession({
+            SessionId = params.SessionId,
+            CampAccessCode = params.CampAccessCode,
+            GateOpen = false,
+            MazeStatus = MAZE_STATUS.Idle,
+            MazeAccessCode = nil,
+            PlayersInMaze = {},
+            ReturnedPlayerSummaries = {},
+        }),
+        Entry = {
+            Kind = 'LobbyLaunch',
+        },
+    }
+end
+
+function CampMazeSessionContract.buildCampToMazeTeleportData(params)
+    return {
+        SessionConfig = cloneTable(params.SessionConfig),
+        CampSession = CampMazeSessionContract.normalizeCampSession(params.CampSession),
+        MazeSession = {
+            SessionId = params.CampSession.SessionId,
+            CampAccessCode = params.CampSession.CampAccessCode,
+            MazeAccessCode = params.CampSession.MazeAccessCode,
+            EntryReason = params.EntryReason or 'camp_gate',
+            EnteringPlayer = table.clone(params.EnteringPlayer),
+        },
+    }
+end
+
+function CampMazeSessionContract.buildMazeToCampTeleportData(params)
+    return {
+        SessionConfig = cloneTable(params.SessionConfig),
+        CampSession = CampMazeSessionContract.normalizeCampSession(params.CampSession),
+        MazeReturn = {
+            MazeCompleted = params.MazeCompleted == true,
+            Summaries = cloneArray(params.Summaries),
+        },
+    }
+end
+
+function CampMazeSessionContract.findReturnSummary(teleportData, userId)
+    local mazeReturn = teleportData and teleportData.MazeReturn
+    if type(mazeReturn) ~= 'table' then
+        return nil
+    end
+
+    for _, summary in ipairs(mazeReturn.Summaries or {}) do
+        if summary.UserId == userId then
+            return summary
+        end
+    end
+
+    return nil
+end
+
+CampMazeSessionContract.MazeStatus = MAZE_STATUS
+
+return CampMazeSessionContract

--- a/packages/shared/src/Session/init.luau
+++ b/packages/shared/src/Session/init.luau
@@ -1,0 +1,3 @@
+return {
+    CampMazeSessionContract = require(script.CampMazeSessionContract),
+}

--- a/packages/shared/src/init.luau
+++ b/packages/shared/src/init.luau
@@ -2,5 +2,7 @@ return {
     Config = require(script.Config),
     Enums = require(script.Enums),
     Network = require(script.Network),
+    Runtime = require(script.Runtime),
+    Session = require(script.Session),
     Util = require(script.Util),
 }

--- a/places/lobby/src/ServerScriptService/Lobby/LobbyService.luau
+++ b/places/lobby/src/ServerScriptService/Lobby/LobbyService.luau
@@ -1,4 +1,5 @@
 local Players = game:GetService('Players')
+local HttpService = game:GetService('HttpService')
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 local TeleportService = game:GetService('TeleportService')
 
@@ -7,6 +8,7 @@ local Shared = require(Packages:WaitForChild('Shared'))
 
 local SessionConfig = Shared.Config.SessionConfig
 local Remotes = Shared.Network.Remotes.ensure()
+local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
 
 local LobbyService = {}
 LobbyService.__index = LobbyService
@@ -86,9 +88,11 @@ function LobbyService:_teleportToRun()
 
     self.Seed = Random.new():NextInteger(100000, 999999)
 
-    local options = Instance.new('TeleportOptions')
-    options.ShouldReserveServer = true
-    options:SetTeleportData({
+    local campAccessCode = TeleportService:ReserveServer(SessionConfig.PlaceIds.Run)
+    local sessionId = HttpService:GenerateGUID(false)
+    local teleportData = CampMazeSessionContract.buildLobbyToCampTeleportData({
+        SessionId = sessionId,
+        CampAccessCode = campAccessCode,
         SessionConfig = {
             Seed = self.Seed,
             Quota = SessionConfig.DefaultQuota,
@@ -101,7 +105,13 @@ function LobbyService:_teleportToRun()
     self:_broadcast()
 
     local success, message = pcall(function()
-        TeleportService:TeleportAsync(SessionConfig.PlaceIds.Run, players, options)
+        TeleportService:TeleportToPrivateServer(
+            SessionConfig.PlaceIds.Run,
+            campAccessCode,
+            players,
+            nil,
+            teleportData
+        )
     end)
 
     if not success then

--- a/places/maze/default.project.json
+++ b/places/maze/default.project.json
@@ -1,0 +1,32 @@
+{
+  "name": "roblox-experience-maze",
+  "tree": {
+    "$className": "DataModel",
+    "ReplicatedStorage": {
+      "$className": "ReplicatedStorage",
+      "Packages": {
+        "$className": "Folder",
+        "Shared": {
+          "$path": "../../packages/shared/src"
+        },
+        "Gameplay": {
+          "$path": "../../packages/gameplay/src"
+        },
+        "UI": {
+          "$path": "../../packages/ui/src"
+        }
+      }
+    },
+    "ServerScriptService": {
+      "$className": "ServerScriptService",
+      "$path": "src/ServerScriptService"
+    },
+    "StarterPlayer": {
+      "$className": "StarterPlayer",
+      "StarterPlayerScripts": {
+        "$className": "StarterPlayerScripts",
+        "$path": "src/StarterPlayer/StarterPlayerScripts"
+      }
+    }
+  }
+}

--- a/places/maze/src/ServerScriptService/Bootstrap.server.luau
+++ b/places/maze/src/ServerScriptService/Bootstrap.server.luau
@@ -1,0 +1,3 @@
+local MazeSessionService = require(script.Parent.Maze.MazeSessionService)
+
+MazeSessionService.new():start()

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -1,0 +1,457 @@
+local Players = game:GetService('Players')
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local TeleportService = game:GetService('TeleportService')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Shared = require(Packages:WaitForChild('Shared'))
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+
+local SessionConfig = Shared.Config.SessionConfig
+local RunState = Shared.Enums.RunState
+local Remotes = Shared.Network.Remotes.ensure()
+local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
+local InventoryService = Shared.Runtime.InventoryService
+local MonsterService = Shared.Runtime.MonsterService
+local RoleService = Shared.Runtime.RoleService
+
+local MazeWorldBuilder = require(script.Parent.MazeWorldBuilder)
+
+local MazeSessionService = {}
+MazeSessionService.__index = MazeSessionService
+
+local EXTRACTION_DELAY_SECONDS = 2
+
+local function bindCharacterTeleport(self, player)
+    player.CharacterAdded:Connect(function(character)
+        task.wait()
+        if self.World and character.Parent then
+            character:PivotTo(self.World.SpawnCFrame)
+        end
+    end)
+end
+
+function MazeSessionService.new()
+    local self = setmetatable({}, MazeSessionService)
+
+    self.Remotes = Remotes
+    self.SessionData = {
+        Seed = SessionConfig.DefaultSeed,
+        Quota = SessionConfig.DefaultQuota,
+        RunDurationSeconds = SessionConfig.DefaultRunDurationSeconds,
+        InventoryCapacity = SessionConfig.InventoryCapacity,
+    }
+    self.CampSession = CampMazeSessionContract.newCampSession({
+        MazeAccessCode = 'local-debug-maze',
+        MazeStatus = CampMazeSessionContract.MazeStatus.Active,
+    })
+    self.Status = 'Direct boot: use the expedition console to begin the maze run.'
+    self.IsDirectBoot = true
+    self.IsLaunched = false
+    self.IsCompleted = false
+    self.World = nil
+    self.SnapshotThread = nil
+    self.InventoryService = InventoryService.new(self.SessionData.InventoryCapacity)
+    self.RoleService = RoleService.new(Gameplay.Config.Roles)
+    self.StateMachine = Gameplay.Session.SessionStateMachine.new(RunState.Camp)
+    self.MonsterService = MonsterService.new(Gameplay.Config.Monsters[1], function()
+        return self.StateMachine.Current == RunState.Expedition
+    end)
+
+    return self
+end
+
+function MazeSessionService:_readTeleportData(player)
+    local joinData = player:GetJoinData()
+    return joinData and joinData.TeleportData
+end
+
+function MazeSessionService:_loadSessionDataFromJoin()
+    local players = Players:GetPlayers()
+    if #players == 0 then
+        return
+    end
+
+    local teleportData = self:_readTeleportData(players[1])
+    local incoming = teleportData and teleportData.SessionConfig
+    if type(incoming) == 'table' then
+        if type(incoming.Seed) == 'number' then
+            self.SessionData.Seed = incoming.Seed
+        end
+        if type(incoming.Quota) == 'number' then
+            self.SessionData.Quota = incoming.Quota
+        end
+        if type(incoming.RunDurationSeconds) == 'number' then
+            self.SessionData.RunDurationSeconds = incoming.RunDurationSeconds
+        end
+        if type(incoming.InventoryCapacity) == 'number' then
+            self.SessionData.InventoryCapacity = incoming.InventoryCapacity
+        end
+    end
+
+    if type(teleportData) == 'table' and type(teleportData.CampSession) == 'table' then
+        self.CampSession = CampMazeSessionContract.normalizeCampSession(teleportData.CampSession)
+        self.IsDirectBoot = false
+        self.Status = 'Maze session is ready. Use the expedition console to deploy the crew.'
+    end
+
+    self.InventoryService = InventoryService.new(self.SessionData.InventoryCapacity)
+end
+
+function MazeSessionService:_addPlayerState(player)
+    self.InventoryService:addPlayer(player)
+    self.RoleService:assignPlayer(player)
+end
+
+function MazeSessionService:_removePlayerState(player)
+    self.InventoryService:removePlayer(player)
+    self.RoleService:removePlayer(player)
+end
+
+function MazeSessionService:_buildVisibleRoster(player)
+    local rosterByUserId = self.RoleService:getVisibleRoster(player)
+    local roster = {}
+
+    for _, entry in pairs(rosterByUserId) do
+        table.insert(roster, entry)
+    end
+
+    table.sort(roster, function(left, right)
+        return left.Name < right.Name
+    end)
+
+    return roster
+end
+
+function MazeSessionService:_setStatus(status)
+    self.Status = status
+    self:_broadcastSnapshot()
+end
+
+function MazeSessionService:_getPlayerArea(player)
+    if not self.IsLaunched or not self.World then
+        return 'Maze Spawn'
+    end
+
+    local character = player.Character
+    local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+    if not rootPart then
+        return 'Maze Spawn'
+    end
+
+    local room = self.World.FindRoomByPosition(rootPart.Position)
+    if not room then
+        return 'Maze Spawn'
+    end
+
+    return string.format('%s Room', room.Kind)
+end
+
+function MazeSessionService:_getObjectiveFor()
+    if self.StateMachine.Current == RunState.Camp then
+        return 'Use the expedition console to deploy into the maze, or return to camp.'
+    end
+
+    if self.StateMachine.Current == RunState.Expedition then
+        return 'Collect loot and reach the settlement pad at the extraction room.'
+    end
+
+    if self.StateMachine.Current == RunState.Extraction then
+        return 'Settlement is underway. Hold position while the camp prepares your return.'
+    end
+
+    return 'Returning the crew to camp.'
+end
+
+function MazeSessionService:_broadcastSnapshot()
+    for _, player in ipairs(Players:GetPlayers()) do
+        self.Remotes.RunSnapshot:FireClient(player, {
+            IsLaunched = self.IsLaunched,
+            Status = self.Status,
+            Area = self:_getPlayerArea(player),
+            Objective = self:_getObjectiveFor(),
+            State = self.StateMachine.Current,
+            Inventory = self.InventoryService:getSummary(player),
+            Roster = self:_buildVisibleRoster(player),
+            SessionId = self.CampSession.SessionId,
+            MazeAccessCode = self.CampSession.MazeAccessCode,
+            MazeStatus = self.CampSession.MazeStatus,
+            IsDirectBoot = self.IsDirectBoot,
+        })
+
+        self.Remotes.PrivateState:FireClient(player, self.RoleService:getPrivateState(player))
+    end
+end
+
+function MazeSessionService:_rebuildWorld()
+    self.World = MazeWorldBuilder.build(self.SessionData.Seed, SessionConfig.ProcGen)
+    self:_bindWorldInteractions()
+end
+
+function MazeSessionService:_bindWorldInteractions()
+    self.World.DeployPrompt.Triggered:Connect(function(player)
+        self:_deployCrew(player)
+    end)
+
+    self.World.ReturnPrompt.Triggered:Connect(function(player)
+        self:_returnPlayerToCamp(player, 'early_return')
+    end)
+
+    self.World.ExtractionPrompt.Triggered:Connect(function(player)
+        self:_startExtraction(player)
+    end)
+
+    for roomId, lootEntry in pairs(self.World.LootPrompts) do
+        lootEntry.Prompt.Triggered:Connect(function(player)
+            self:_pickupLoot(player, roomId)
+        end)
+    end
+end
+
+function MazeSessionService:_deployCrew(player)
+    if self.StateMachine.Current ~= RunState.Camp then
+        self:_setStatus(
+            string.format(
+                '%s checked the expedition console, but the run is already active.',
+                player.DisplayName
+            )
+        )
+        return
+    end
+
+    self.StateMachine:transition(RunState.Expedition)
+    self.MonsterService:spawn(self.World.PatrolPoints)
+    self:_setStatus(string.format('%s deployed the crew into the maze.', player.DisplayName))
+end
+
+function MazeSessionService:_pickupLoot(player, roomId)
+    if self.StateMachine.Current ~= RunState.Expedition then
+        self:_setStatus('Loot can only be collected during the expedition phase.')
+        return
+    end
+
+    local lootEntry = self.World.LootPrompts[roomId]
+    if not lootEntry or lootEntry.Collected then
+        return
+    end
+
+    local success, reason = self.InventoryService:pickup(player, lootEntry.ItemDef)
+    if not success then
+        self:_setStatus(
+            string.format(
+                '%s could not carry %s (%s).',
+                player.DisplayName,
+                lootEntry.ItemDef.Name,
+                tostring(reason)
+            )
+        )
+        return
+    end
+
+    lootEntry.Collected = true
+    local promptPart = lootEntry.Prompt.Parent
+    if promptPart then
+        promptPart:Destroy()
+    end
+
+    local inventorySummary = self.InventoryService:getSummary(player)
+    self:_setStatus(
+        string.format(
+            '%s collected %s. Inventory value now %d.',
+            player.DisplayName,
+            lootEntry.ItemDef.Name,
+            inventorySummary.Value
+        )
+    )
+end
+
+function MazeSessionService:_canReturnToCamp()
+    return SessionConfig.PlaceIds.Run ~= 0 and self.CampSession.CampAccessCode ~= 'local-debug-camp'
+end
+
+function MazeSessionService:_teleportToCamp(players, summaries, mazeCompleted)
+    if not self:_canReturnToCamp() then
+        self:_setStatus(
+            'Camp return is unavailable in direct boot. Set SessionConfig.PlaceIds.Run and enter from camp.'
+        )
+        return false
+    end
+
+    local nextCampSession = self.CampSession
+    for _, summary in ipairs(summaries) do
+        nextCampSession =
+            CampMazeSessionContract.applyReturn(nextCampSession, summary, mazeCompleted)
+    end
+
+    local teleportData = CampMazeSessionContract.buildMazeToCampTeleportData({
+        SessionConfig = self.SessionData,
+        CampSession = nextCampSession,
+        Summaries = summaries,
+        MazeCompleted = mazeCompleted,
+    })
+
+    local success, message = pcall(function()
+        TeleportService:TeleportToPrivateServer(
+            SessionConfig.PlaceIds.Run,
+            nextCampSession.CampAccessCode,
+            players,
+            nil,
+            teleportData
+        )
+    end)
+
+    if not success then
+        self:_setStatus(string.format('Camp return failed: %s', tostring(message)))
+        return false
+    end
+
+    self.CampSession = nextCampSession
+    if mazeCompleted then
+        self.IsCompleted = true
+    end
+
+    return true
+end
+
+function MazeSessionService:_buildSummaryFor(player, returnReason, isSettled)
+    local inventorySummary = self.InventoryService:getSummary(player)
+    self.InventoryService:deposit(player)
+
+    return CampMazeSessionContract.buildReturnSummary({
+        UserId = player.UserId,
+        Name = player.DisplayName,
+        ReturnReason = returnReason,
+        Value = inventorySummary.Value,
+        ItemCount = inventorySummary.Count,
+        Weight = inventorySummary.Weight,
+        WasExtracted = returnReason == 'extracted' or returnReason == 'settled',
+        WasSettled = isSettled == true,
+    })
+end
+
+function MazeSessionService:_returnPlayerToCamp(player, returnReason)
+    if self.IsCompleted then
+        return
+    end
+
+    local summary = self:_buildSummaryFor(player, returnReason, false)
+    if self:_teleportToCamp({ player }, { summary }, false) then
+        self:_setStatus(
+            string.format(
+                '%s is returning to camp with %d value.',
+                player.DisplayName,
+                summary.Value
+            )
+        )
+    end
+end
+
+function MazeSessionService:_completeSettlement(player)
+    if self.IsCompleted then
+        return
+    end
+
+    if self.StateMachine.Current == RunState.Extraction then
+        self.StateMachine:transition(RunState.Settlement)
+    end
+
+    local players = Players:GetPlayers()
+    local summaries = {}
+
+    for _, currentPlayer in ipairs(players) do
+        table.insert(summaries, self:_buildSummaryFor(currentPlayer, 'settled', true))
+    end
+
+    if self:_teleportToCamp(players, summaries, true) then
+        self:_setStatus(
+            string.format(
+                '%s completed settlement. Returning the crew to camp.',
+                player.DisplayName
+            )
+        )
+    end
+end
+
+function MazeSessionService:_startExtraction(player)
+    if self.StateMachine.Current ~= RunState.Expedition then
+        self:_setStatus('The settlement pad is only available during the expedition phase.')
+        return
+    end
+
+    self.StateMachine:transition(RunState.Extraction)
+    self:_setStatus(
+        string.format('%s activated the settlement pad. Hold tight.', player.DisplayName)
+    )
+
+    task.delay(EXTRACTION_DELAY_SECONDS, function()
+        self:_completeSettlement(player)
+    end)
+end
+
+function MazeSessionService:_launchMaze()
+    if self.IsLaunched then
+        return
+    end
+
+    self.IsLaunched = true
+    Players.CharacterAutoLoads = true
+
+    self:_rebuildWorld()
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        player:LoadCharacter()
+    end
+
+    self:_startSnapshotLoop()
+    self:_broadcastSnapshot()
+end
+
+function MazeSessionService:_startSnapshotLoop()
+    if self.SnapshotThread then
+        return
+    end
+
+    self.SnapshotThread = task.spawn(function()
+        while true do
+            task.wait(1)
+
+            if self.IsLaunched then
+                self:_broadcastSnapshot()
+            end
+        end
+    end)
+end
+
+function MazeSessionService:start()
+    self:_loadSessionDataFromJoin()
+    Players.CharacterAutoLoads = false
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        bindCharacterTeleport(self, player)
+        self:_addPlayerState(player)
+
+        if player.Character then
+            player.Character:Destroy()
+        end
+    end
+
+    Players.PlayerAdded:Connect(function(player)
+        bindCharacterTeleport(self, player)
+        self:_addPlayerState(player)
+
+        if self.IsLaunched then
+            player:LoadCharacter()
+            self:_setStatus(string.format('%s joined the shared maze session.', player.DisplayName))
+        end
+
+        self:_broadcastSnapshot()
+    end)
+
+    Players.PlayerRemoving:Connect(function(player)
+        self:_removePlayerState(player)
+        self:_broadcastSnapshot()
+    end)
+
+    self:_launchMaze()
+end
+
+return MazeSessionService

--- a/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
@@ -1,0 +1,327 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local Workspace = game:GetService('Workspace')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+
+local Items = Gameplay.Config.Items
+local MazeBuilder = Gameplay.ProcGen.MazeBuilder
+
+local MazeWorldBuilder = {}
+
+local WALL_HEIGHT = 16
+local WALL_THICKNESS = 2
+local DOOR_GAP = 10
+local MARKER_HEIGHT = 1
+
+local DIRECTIONS = {
+    North = Vector3.new(0, 0, -1),
+    South = Vector3.new(0, 0, 1),
+    East = Vector3.new(1, 0, 0),
+    West = Vector3.new(-1, 0, 0),
+}
+
+local ROOM_KIND_COLORS = {
+    Camp = Color3.fromRGB(83, 126, 78),
+    Loot = Color3.fromRGB(88, 92, 112),
+    Extraction = Color3.fromRGB(145, 119, 73),
+}
+
+local function createPart(config, parent)
+    local part = Instance.new('Part')
+    part.Name = config.Name
+    part.Anchored = true
+    part.Size = config.Size
+    part.CFrame = config.CFrame
+    part.Color = config.Color
+    part.Material = config.Material or Enum.Material.SmoothPlastic
+    part.Transparency = config.Transparency or 0
+    part.CanCollide = config.CanCollide ~= false
+    part.Shape = config.Shape or Enum.PartType.Block
+    part.Parent = parent
+    return part
+end
+
+local function createPromptPart(config, parent)
+    local part = createPart({
+        Name = config.Name,
+        Size = config.Size or Vector3.new(4, 4, 4),
+        CFrame = config.CFrame,
+        Color = config.Color,
+        Material = config.Material or Enum.Material.Metal,
+        Transparency = config.Transparency or 0,
+        CanCollide = config.CanCollide,
+        Shape = config.Shape,
+    }, parent)
+
+    local prompt = Instance.new('ProximityPrompt')
+    prompt.ActionText = config.ActionText
+    prompt.ObjectText = config.ObjectText
+    prompt.HoldDuration = 0
+    prompt.MaxActivationDistance = config.MaxActivationDistance or 10
+    prompt.RequiresLineOfSight = false
+    prompt.Parent = part
+
+    return part, prompt
+end
+
+local function buildPositionIndex(layout)
+    local index = {}
+
+    for roomId, room in pairs(layout.Rooms) do
+        index[string.format('%d:%d:%d', room.Position.X, room.Position.Y, room.Position.Z)] = roomId
+    end
+
+    return index
+end
+
+local function wallHasOpening(positionIndex, room, roomSpacing, directionName)
+    local direction = DIRECTIONS[directionName]
+    local neighborPosition = room.Position + (direction * roomSpacing)
+    local key =
+        string.format('%d:%d:%d', neighborPosition.X, neighborPosition.Y, neighborPosition.Z)
+
+    return positionIndex[key] ~= nil
+end
+
+local function createNorthSouthWall(parent, room, roomSize, isNorth, hasOpening)
+    local zOffset = (roomSize.Z / 2) * (isNorth and -1 or 1)
+    local center = room.Position + Vector3.new(0, WALL_HEIGHT / 2, zOffset)
+
+    if not hasOpening then
+        createPart({
+            Name = isNorth and 'NorthWall' or 'SouthWall',
+            Size = Vector3.new(roomSize.X, WALL_HEIGHT, WALL_THICKNESS),
+            CFrame = CFrame.new(center),
+            Color = Color3.fromRGB(83, 69, 56),
+            Material = Enum.Material.WoodPlanks,
+        }, parent)
+        return
+    end
+
+    local segmentWidth = (roomSize.X - DOOR_GAP) / 2
+    local xOffset = (DOOR_GAP / 2) + (segmentWidth / 2)
+
+    for _, direction in ipairs({ -1, 1 }) do
+        createPart({
+            Name = isNorth and 'NorthWallSegment' or 'SouthWallSegment',
+            Size = Vector3.new(segmentWidth, WALL_HEIGHT, WALL_THICKNESS),
+            CFrame = CFrame.new(center + Vector3.new(xOffset * direction, 0, 0)),
+            Color = Color3.fromRGB(83, 69, 56),
+            Material = Enum.Material.WoodPlanks,
+        }, parent)
+    end
+end
+
+local function createEastWestWall(parent, room, roomSize, isEast, hasOpening)
+    local xOffset = (roomSize.X / 2) * (isEast and 1 or -1)
+    local center = room.Position + Vector3.new(xOffset, WALL_HEIGHT / 2, 0)
+
+    if not hasOpening then
+        createPart({
+            Name = isEast and 'EastWall' or 'WestWall',
+            Size = Vector3.new(WALL_THICKNESS, WALL_HEIGHT, roomSize.Z),
+            CFrame = CFrame.new(center),
+            Color = Color3.fromRGB(83, 69, 56),
+            Material = Enum.Material.WoodPlanks,
+        }, parent)
+        return
+    end
+
+    local segmentDepth = (roomSize.Z - DOOR_GAP) / 2
+    local zOffset = (DOOR_GAP / 2) + (segmentDepth / 2)
+
+    for _, direction in ipairs({ -1, 1 }) do
+        createPart({
+            Name = isEast and 'EastWallSegment' or 'WestWallSegment',
+            Size = Vector3.new(WALL_THICKNESS, WALL_HEIGHT, segmentDepth),
+            CFrame = CFrame.new(center + Vector3.new(0, 0, zOffset * direction)),
+            Color = Color3.fromRGB(83, 69, 56),
+            Material = Enum.Material.WoodPlanks,
+        }, parent)
+    end
+end
+
+local function createRoomMarker(parent, room, roomSize)
+    createPart({
+        Name = 'RoomMarker',
+        Size = Vector3.new(roomSize.X - 4, MARKER_HEIGHT, roomSize.Z - 4),
+        CFrame = CFrame.new(room.Position + Vector3.new(0, MARKER_HEIGHT / 2, 0)),
+        Color = ROOM_KIND_COLORS[room.Kind] or Color3.fromRGB(112, 112, 112),
+        Material = Enum.Material.SmoothPlastic,
+        Transparency = 0.35,
+        CanCollide = false,
+    }, parent)
+end
+
+local function buildRoom(parent, room, roomSize, positionIndex, roomSpacing)
+    local roomFolder = Instance.new('Folder')
+    roomFolder.Name = room.Id
+    roomFolder.Parent = parent
+
+    createPart({
+        Name = 'Floor',
+        Size = Vector3.new(roomSize.X, 1, roomSize.Z),
+        CFrame = CFrame.new(room.Position + Vector3.new(0, -0.5, 0)),
+        Color = Color3.fromRGB(61, 72, 81),
+        Material = Enum.Material.Slate,
+    }, roomFolder)
+
+    createPart({
+        Name = 'Ceiling',
+        Size = Vector3.new(roomSize.X, 1, roomSize.Z),
+        CFrame = CFrame.new(room.Position + Vector3.new(0, WALL_HEIGHT + 0.5, 0)),
+        Color = Color3.fromRGB(52, 44, 38),
+        Material = Enum.Material.WoodPlanks,
+    }, roomFolder)
+
+    createNorthSouthWall(
+        roomFolder,
+        room,
+        roomSize,
+        true,
+        wallHasOpening(positionIndex, room, roomSpacing, 'North')
+    )
+    createNorthSouthWall(
+        roomFolder,
+        room,
+        roomSize,
+        false,
+        wallHasOpening(positionIndex, room, roomSpacing, 'South')
+    )
+    createEastWestWall(
+        roomFolder,
+        room,
+        roomSize,
+        true,
+        wallHasOpening(positionIndex, room, roomSpacing, 'East')
+    )
+    createEastWestWall(
+        roomFolder,
+        room,
+        roomSize,
+        false,
+        wallHasOpening(positionIndex, room, roomSpacing, 'West')
+    )
+
+    createRoomMarker(roomFolder, room, roomSize)
+
+    return roomFolder
+end
+
+function MazeWorldBuilder.build(seed, config)
+    local existing = Workspace:FindFirstChild('GeneratedMazeWorld')
+    if existing then
+        existing:Destroy()
+    end
+
+    local layout = MazeBuilder.build(seed, config)
+    local roomSize = config.RoomSize or Vector3.new(28, 16, 28)
+    local roomSpacing = config.RoomSpacing or 40
+    local positionIndex = buildPositionIndex(layout)
+
+    local worldFolder = Instance.new('Folder')
+    worldFolder.Name = 'GeneratedMazeWorld'
+    worldFolder.Parent = Workspace
+
+    local campRoom = layout.Rooms[layout.CampRoomId]
+    local extractionRoom = layout.Rooms[layout.ExtractionRoomId]
+    local patrolPoints = {}
+    local lootPrompts = {}
+    local roomOrder = {}
+
+    for roomId in pairs(layout.Rooms) do
+        table.insert(roomOrder, roomId)
+    end
+    table.sort(roomOrder)
+
+    local itemIndex = 1
+    for _, roomId in ipairs(roomOrder) do
+        local room = layout.Rooms[roomId]
+        local roomFolder = buildRoom(worldFolder, room, roomSize, positionIndex, roomSpacing)
+
+        if room.Kind == 'Loot' then
+            local itemDef = Items[itemIndex]
+            itemIndex = (itemIndex % #Items) + 1
+            local _, prompt = createPromptPart({
+                Name = string.format('Loot_%s', roomId),
+                Size = Vector3.new(3, 3, 3),
+                CFrame = CFrame.new(room.Position + Vector3.new(0, 1.5, 0)),
+                Color = itemDef.Color,
+                Material = Enum.Material.Neon,
+                ActionText = 'Collect',
+                ObjectText = itemDef.Name,
+                CanCollide = false,
+            }, roomFolder)
+
+            lootPrompts[roomId] = {
+                ItemDef = itemDef,
+                Prompt = prompt,
+                Position = room.Position,
+            }
+            table.insert(patrolPoints, room.Position)
+        end
+    end
+
+    local _, deployPrompt = createPromptPart({
+        Name = 'DeployConsole',
+        Size = Vector3.new(4, 4, 4),
+        CFrame = CFrame.new(campRoom.Position + Vector3.new(-6, 2, 0)),
+        Color = Color3.fromRGB(93, 196, 176),
+        Material = Enum.Material.Metal,
+        ActionText = 'Deploy',
+        ObjectText = 'Expedition Console',
+    }, worldFolder)
+
+    local _, returnPrompt = createPromptPart({
+        Name = 'ReturnMarker',
+        Size = Vector3.new(4, 1, 4),
+        CFrame = CFrame.new(campRoom.Position + Vector3.new(6, 0.5, 0)),
+        Color = Color3.fromRGB(77, 147, 196),
+        Material = Enum.Material.Neon,
+        ActionText = 'Return',
+        ObjectText = 'Camp Return',
+        CanCollide = false,
+    }, worldFolder)
+
+    local _, extractionPrompt = createPromptPart({
+        Name = 'ExtractionPad',
+        Size = Vector3.new(6, 1, 6),
+        CFrame = CFrame.new(extractionRoom.Position + Vector3.new(0, 0.5, 0)),
+        Color = Color3.fromRGB(214, 170, 94),
+        Material = Enum.Material.Neon,
+        ActionText = 'Extract',
+        ObjectText = 'Settlement Pad',
+        CanCollide = false,
+        MaxActivationDistance = 12,
+    }, worldFolder)
+
+    return {
+        Root = worldFolder,
+        Layout = layout,
+        SpawnCFrame = CFrame.new(campRoom.Position + Vector3.new(0, 4, 0)),
+        CampRoomId = layout.CampRoomId,
+        ExtractionRoomId = layout.ExtractionRoomId,
+        DeployPrompt = deployPrompt,
+        ReturnPrompt = returnPrompt,
+        ExtractionPrompt = extractionPrompt,
+        LootPrompts = lootPrompts,
+        PatrolPoints = patrolPoints,
+        FindRoomByPosition = function(position)
+            local nearestRoom = nil
+            local nearestDistance = math.huge
+
+            for _, room in pairs(layout.Rooms) do
+                local distance = (room.Position - position).Magnitude
+                if distance < nearestDistance then
+                    nearestRoom = room
+                    nearestDistance = distance
+                end
+            end
+
+            return nearestRoom
+        end,
+    }
+end
+
+return MazeWorldBuilder

--- a/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
+++ b/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
@@ -1,0 +1,118 @@
+local Players = game:GetService('Players')
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+local localPlayer = Players.LocalPlayer
+local playerGui = localPlayer:WaitForChild('PlayerGui')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Shared = require(Packages:WaitForChild('Shared'))
+local UI = require(Packages:WaitForChild('UI'))
+
+local Remotes = Shared.Network.Remotes.ensure()
+local Theme = UI.Hud.Theme
+
+local screenGui = Instance.new('ScreenGui')
+screenGui.Name = 'MazeHud'
+screenGui.IgnoreGuiInset = true
+screenGui.ResetOnSpawn = false
+screenGui.Parent = playerGui
+
+local function makeTextLabel(parent, size, color, textSize, bold)
+    local label = Instance.new('TextLabel')
+    label.Size = size
+    label.BackgroundTransparency = 1
+    label.Font = bold and Enum.Font.GothamBold or Theme.Font
+    label.TextColor3 = color
+    label.TextSize = textSize
+    label.TextWrapped = true
+    label.TextXAlignment = Enum.TextXAlignment.Left
+    label.TextYAlignment = Enum.TextYAlignment.Top
+    label.Parent = parent
+    return label
+end
+
+local panel = Instance.new('Frame')
+panel.Name = 'MazePanel'
+panel.AnchorPoint = Vector2.new(0, 0)
+panel.Position = UDim2.fromScale(0.03, 0.05)
+panel.Size = UDim2.fromOffset(440, 400)
+panel.BackgroundColor3 = Theme.Background
+panel.BorderSizePixel = 0
+panel.Parent = screenGui
+
+local panelCorner = Instance.new('UICorner')
+panelCorner.CornerRadius = UDim.new(0, 16)
+panelCorner.Parent = panel
+
+local panelPadding = Instance.new('UIPadding')
+panelPadding.PaddingTop = UDim.new(0, 18)
+panelPadding.PaddingLeft = UDim.new(0, 18)
+panelPadding.PaddingRight = UDim.new(0, 18)
+panelPadding.PaddingBottom = UDim.new(0, 18)
+panelPadding.Parent = panel
+
+local list = Instance.new('UIListLayout')
+list.Padding = UDim.new(0, 10)
+list.Parent = panel
+
+local eyebrow = makeTextLabel(panel, UDim2.new(1, 0, 0, 20), Theme.Accent, 16, true)
+eyebrow.Text = 'SHARED MAZE SESSION'
+
+local title = makeTextLabel(panel, UDim2.new(1, 0, 0, 36), Theme.Text, 28, true)
+title.Text = 'Maze Status'
+
+local statusLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 70), Theme.SubtleText, 18, false)
+statusLabel.Text = 'Waiting for maze snapshot...'
+
+local objectiveLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 64), Theme.Accent, 18, false)
+objectiveLabel.Text = 'Objective: --'
+
+local inventoryLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 48), Theme.Text, 16, false)
+inventoryLabel.Text = 'Inventory: --'
+
+local guideLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 72), Theme.Text, 16, false)
+guideLabel.Text =
+    'In-world prompts:\n- Expedition Console\n- Camp Return\n- Settlement Pad\n- Loot pickups in marked rooms'
+
+local rosterLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 90), Theme.SubtleText, 16, false)
+rosterLabel.Text = ''
+
+Remotes.PrivateState.OnClientEvent:Connect(function(privateState)
+    if type(privateState) ~= 'table' then
+        return
+    end
+
+    guideLabel.Text = string.format(
+        'In-world prompts:\n- Expedition Console\n- Camp Return\n- Settlement Pad\n- Loot pickups in marked rooms\n\nPrivate role: %s',
+        privateState.PrivateRole or '--'
+    )
+end)
+
+Remotes.RunSnapshot.OnClientEvent:Connect(function(snapshot)
+    statusLabel.Text = string.format(
+        '%s\nArea: %s | State: %s',
+        snapshot.Status,
+        snapshot.Area or '--',
+        snapshot.State or '--'
+    )
+
+    objectiveLabel.Text = string.format('Objective: %s', snapshot.Objective or '--')
+
+    local inventory = snapshot.Inventory or { Weight = 0, Count = 0, Value = 0 }
+    inventoryLabel.Text = string.format(
+        'Inventory: %d items | weight %d | value %d',
+        inventory.Count or 0,
+        inventory.Weight or 0,
+        inventory.Value or 0
+    )
+
+    local rosterLines = {}
+    for _, rosterEntry in ipairs(snapshot.Roster or {}) do
+        local marker = rosterEntry.UserId == localPlayer.UserId and ' (You)' or ''
+        local roleText = rosterEntry.PublicRole and string.format(' - %s', rosterEntry.PublicRole)
+            or ''
+        table.insert(rosterLines, string.format('%s%s%s', rosterEntry.Name, marker, roleText))
+    end
+
+    rosterLabel.Text = 'Crew in maze:\n' .. table.concat(rosterLines, '\n')
+end)

--- a/places/run/src/ServerScriptService/Run/OutdoorAreaBuilder.luau
+++ b/places/run/src/ServerScriptService/Run/OutdoorAreaBuilder.luau
@@ -108,8 +108,8 @@ function OutdoorAreaBuilder.build(worldFolder, createPart, createPromptPart)
         CFrame = CFrame.new(0, 0.5, 120),
         Color = Color3.fromRGB(154, 113, 214),
         Material = Enum.Material.Neon,
-        ActionText = 'Inspect',
-        ObjectText = 'Maze Run Gate (Soon)',
+        ActionText = 'Enter',
+        ObjectText = 'Shared Maze Gate',
         MaxActivationDistance = 12,
     }, outdoorFolder)
 

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -1,5 +1,6 @@
 local Players = game:GetService('Players')
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local TeleportService = game:GetService('TeleportService')
 local Workspace = game:GetService('Workspace')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
@@ -7,6 +8,7 @@ local Shared = require(Packages:WaitForChild('Shared'))
 
 local SessionConfig = Shared.Config.SessionConfig
 local Remotes = Shared.Network.Remotes.ensure()
+local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
 
 local RunWorldBuilder = require(script.Parent.RunWorldBuilder)
 
@@ -18,9 +20,14 @@ local DEFAULT_WORKSPACE_SHELL_NAMES = { 'Baseplate', 'SpawnLocation' }
 local function bindCharacterTeleport(self, player)
     player.CharacterAdded:Connect(function(character)
         task.wait()
-        if self.World and character.Parent then
-            character:PivotTo(self.World.SpawnCFrame)
+        if not self.World or not character.Parent then
+            return
         end
+
+        local targetCFrame = self.PendingSpawnByUserId[player.UserId] and self.World.ReturnCFrame
+            or self.World.SpawnCFrame
+        self.PendingSpawnByUserId[player.UserId] = nil
+        character:PivotTo(targetCFrame)
     end)
 end
 
@@ -33,20 +40,63 @@ local function clearDefaultWorkspaceShell()
     end
 end
 
+local function cloneArray(input)
+    local result = {}
+
+    for index, entry in ipairs(input or {}) do
+        result[index] = table.clone(entry)
+    end
+
+    return result
+end
+
 function RunSessionService.new()
     local self = setmetatable({}, RunSessionService)
 
     self.Remotes = Remotes
     self.SessionData = {
         Seed = SessionConfig.DefaultSeed,
+        Quota = SessionConfig.DefaultQuota,
+        RunDurationSeconds = SessionConfig.DefaultRunDurationSeconds,
+        InventoryCapacity = SessionConfig.InventoryCapacity,
     }
+    self.CampSession = CampMazeSessionContract.newCampSession({})
     self.Status = 'Select Single Player to enter the camp.'
     self.IsLaunched = false
+    self.ShouldAutoLaunch = false
     self.GateOpen = false
     self.World = nil
     self.SnapshotThread = nil
+    self.PendingSpawnByUserId = {}
 
     return self
+end
+
+function RunSessionService:_readTeleportData(player)
+    local joinData = player:GetJoinData()
+    return joinData and joinData.TeleportData
+end
+
+function RunSessionService:_syncCampSession()
+    self.CampSession = CampMazeSessionContract.normalizeCampSession(self.CampSession)
+    self.CampSession.GateOpen = self.GateOpen
+end
+
+function RunSessionService:_applyIncomingCampSession(teleportData)
+    if type(teleportData) ~= 'table' then
+        return nil
+    end
+
+    local incomingSession = teleportData.CampSession
+    if type(incomingSession) ~= 'table' then
+        return nil
+    end
+
+    self.CampSession = CampMazeSessionContract.normalizeCampSession(incomingSession)
+    self.GateOpen = self.CampSession.GateOpen
+    self.ShouldAutoLaunch = true
+
+    return teleportData
 end
 
 function RunSessionService:_loadSessionDataFromJoin()
@@ -55,12 +105,40 @@ function RunSessionService:_loadSessionDataFromJoin()
         return
     end
 
-    local joinData = players[1]:GetJoinData()
-    local teleportData = joinData and joinData.TeleportData
+    local teleportData = self:_readTeleportData(players[1])
     local incoming = teleportData and teleportData.SessionConfig
 
-    if type(incoming) == 'table' and type(incoming.Seed) == 'number' then
-        self.SessionData.Seed = incoming.Seed
+    if type(incoming) == 'table' then
+        if type(incoming.Seed) == 'number' then
+            self.SessionData.Seed = incoming.Seed
+        end
+        if type(incoming.Quota) == 'number' then
+            self.SessionData.Quota = incoming.Quota
+        end
+        if type(incoming.RunDurationSeconds) == 'number' then
+            self.SessionData.RunDurationSeconds = incoming.RunDurationSeconds
+        end
+        if type(incoming.InventoryCapacity) == 'number' then
+            self.SessionData.InventoryCapacity = incoming.InventoryCapacity
+        end
+    end
+
+    teleportData = self:_applyIncomingCampSession(teleportData)
+    if not teleportData then
+        return
+    end
+
+    local returnSummary = CampMazeSessionContract.findReturnSummary(teleportData, players[1].UserId)
+    if returnSummary then
+        self.PendingSpawnByUserId[players[1].UserId] = true
+        self.Status = string.format(
+            '%s returned from the maze with %d value (%s).',
+            players[1].DisplayName,
+            returnSummary.Value or 0,
+            returnSummary.ReturnReason or 'unknown'
+        )
+    else
+        self.Status = 'Camp is ready. Gather inside, then head outside when the group is ready.'
     end
 end
 
@@ -72,7 +150,11 @@ function RunSessionService:_teleportCharactersToSpawn()
     for _, player in ipairs(Players:GetPlayers()) do
         local character = player.Character
         if character and character.Parent then
-            character:PivotTo(self.World.SpawnCFrame)
+            local targetCFrame = self.PendingSpawnByUserId[player.UserId]
+                    and self.World.ReturnCFrame
+                or self.World.SpawnCFrame
+            self.PendingSpawnByUserId[player.UserId] = nil
+            character:PivotTo(targetCFrame)
         end
     end
 end
@@ -80,6 +162,9 @@ end
 function RunSessionService:_rebuildWorld()
     clearDefaultWorkspaceShell()
     self.World = RunWorldBuilder.build()
+    if self.GateOpen then
+        self.World.OpenGate()
+    end
     self:_bindWorldInteractions()
     self:_teleportCharactersToSpawn()
 end
@@ -112,12 +197,7 @@ function RunSessionService:_bindWorldInteractions()
     end)
 
     self.World.MazePrompt.Triggered:Connect(function(player)
-        self:_setStatus(
-            string.format(
-                '%s reached the maze gate. The dedicated maze run is not wired yet.',
-                player.DisplayName
-            )
-        )
+        self:_enterMaze(player)
     end)
 end
 
@@ -163,8 +243,20 @@ function RunSessionService:_getObjectiveFor(player)
         return 'Inspect the camp terminals and open the gate when the group is ready.'
     end
 
+    if self.CampSession.MazeStatus == CampMazeSessionContract.MazeStatus.Completed then
+        return 'The maze run is complete. Review the returned crew summaries in camp.'
+    end
+
+    if self.CampSession.MazeStatus == CampMazeSessionContract.MazeStatus.Active then
+        if area == 'Wilderness' then
+            return 'A maze session is active. Use the gate outside to join the shared expedition.'
+        end
+
+        return 'Head outside and use the maze gate to join the active shared expedition.'
+    end
+
     if area == 'Wilderness' then
-        return 'Explore the clearing and inspect the maze gate outside.'
+        return 'Inspect the maze gate outside to open the first maze session.'
     end
 
     return 'Step outside to the wilderness clearing and inspect the maze gate.'
@@ -177,6 +269,8 @@ end
 
 function RunSessionService:_broadcastSnapshot()
     local roster = self:_buildRoster()
+    local activeMazeRoster = cloneArray(self.CampSession.PlayersInMaze)
+    local returnedSummaries = cloneArray(self.CampSession.ReturnedPlayerSummaries)
 
     for _, player in ipairs(Players:GetPlayers()) do
         self.Remotes.RunSnapshot:FireClient(player, {
@@ -186,6 +280,10 @@ function RunSessionService:_broadcastSnapshot()
             GateOpen = self.GateOpen,
             Objective = self:_getObjectiveFor(player),
             Roster = roster,
+            SessionId = self.CampSession.SessionId,
+            MazeStatus = self.CampSession.MazeStatus,
+            PlayersInMaze = activeMazeRoster,
+            ReturnedPlayerSummaries = returnedSummaries,
         })
 
         self.Remotes.PrivateState:FireClient(player, nil)
@@ -199,6 +297,7 @@ function RunSessionService:_openGate(player)
 
     if not self.GateOpen then
         self.GateOpen = true
+        self:_syncCampSession()
         self.World.OpenGate()
         self:_setStatus(
             string.format(
@@ -217,14 +316,70 @@ function RunSessionService:_openGate(player)
     )
 end
 
+function RunSessionService:_enterMaze(player)
+    if SessionConfig.PlaceIds.Maze == 0 then
+        self:_setStatus('Set SessionConfig.PlaceIds.Maze before using the maze gate.')
+        return
+    end
+
+    if self.CampSession.MazeStatus == CampMazeSessionContract.MazeStatus.Completed then
+        self:_setStatus('The maze session is already complete for this camp.')
+        return
+    end
+
+    local previousSession = CampMazeSessionContract.normalizeCampSession(self.CampSession)
+    local mazeAccessCode = previousSession.MazeAccessCode
+        or TeleportService:ReserveServer(SessionConfig.PlaceIds.Maze)
+
+    previousSession.MazeAccessCode = mazeAccessCode
+    previousSession.GateOpen = self.GateOpen
+
+    local nextSession = CampMazeSessionContract.markPlayerEntered(previousSession, {
+        UserId = player.UserId,
+        Name = player.DisplayName,
+    })
+    nextSession.MazeAccessCode = mazeAccessCode
+    nextSession.GateOpen = self.GateOpen
+
+    local teleportData = CampMazeSessionContract.buildCampToMazeTeleportData({
+        SessionConfig = self.SessionData,
+        CampSession = nextSession,
+        EnteringPlayer = {
+            UserId = player.UserId,
+            Name = player.DisplayName,
+        },
+        EntryReason = 'maze_gate',
+    })
+
+    local success, message = pcall(function()
+        TeleportService:TeleportToPrivateServer(
+            SessionConfig.PlaceIds.Maze,
+            mazeAccessCode,
+            { player },
+            nil,
+            teleportData
+        )
+    end)
+
+    if not success then
+        self.CampSession = previousSession
+        self:_setStatus(string.format('Maze gate failed: %s', tostring(message)))
+        return
+    end
+
+    self.CampSession = nextSession
+    self:_setStatus(string.format('%s is entering the shared maze run.', player.DisplayName))
+end
+
 function RunSessionService:_launchRun(_player)
     if self.IsLaunched then
         return
     end
 
     self.IsLaunched = true
-    self.GateOpen = false
     Players.CharacterAutoLoads = true
+    self.GateOpen = self.CampSession.GateOpen == true
+    self:_syncCampSession()
 
     self:_rebuildWorld()
 
@@ -233,7 +388,13 @@ function RunSessionService:_launchRun(_player)
     end
 
     self:_startSnapshotLoop()
-    self:_setStatus('Camp is ready. Gather inside, then open the gate when you want to head out.')
+    if self.Status == 'Select Single Player to enter the camp.' then
+        self:_setStatus(
+            'Camp is ready. Gather inside, then open the gate when you want to head out.'
+        )
+    else
+        self:_broadcastSnapshot()
+    end
 end
 
 function RunSessionService:_startSnapshotLoop()
@@ -252,6 +413,40 @@ function RunSessionService:_startSnapshotLoop()
     end)
 end
 
+function RunSessionService:_handlePlayerTeleportData(player)
+    local teleportData = self:_readTeleportData(player)
+    if not teleportData then
+        return
+    end
+
+    local incomingSession = teleportData.CampSession
+    if type(incomingSession) == 'table' then
+        self.CampSession = CampMazeSessionContract.normalizeCampSession(incomingSession)
+        self.GateOpen = self.CampSession.GateOpen
+        self.PendingSpawnByUserId[player.UserId] = self.World and self.World.ReturnCFrame or true
+
+        local summary = CampMazeSessionContract.findReturnSummary(teleportData, player.UserId)
+        if summary then
+            if teleportData.MazeReturn and teleportData.MazeReturn.MazeCompleted == true then
+                self.Status = string.format(
+                    '%s returned from the completed maze run with %d value.',
+                    player.DisplayName,
+                    summary.Value or 0
+                )
+            else
+                self.Status = string.format(
+                    '%s returned from the maze with %d value (%s).',
+                    player.DisplayName,
+                    summary.Value or 0,
+                    summary.ReturnReason or 'unknown'
+                )
+            end
+        else
+            self.Status = string.format('%s joined the camp session.', player.DisplayName)
+        end
+    end
+end
+
 function RunSessionService:start()
     self:_loadSessionDataFromJoin()
     Players.CharacterAutoLoads = false
@@ -266,6 +461,7 @@ function RunSessionService:start()
 
     Players.PlayerAdded:Connect(function(player)
         bindCharacterTeleport(self, player)
+        self:_handlePlayerTeleportData(player)
 
         if self.IsLaunched then
             player:LoadCharacter()
@@ -296,6 +492,10 @@ function RunSessionService:start()
     end)
 
     self:_broadcastSnapshot()
+
+    if self.ShouldAutoLaunch then
+        self:_launchRun(nil)
+    end
 end
 
 return RunSessionService

--- a/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
+++ b/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
@@ -59,6 +59,7 @@ function RunWorldBuilder.build()
     return {
         Root = worldFolder,
         SpawnCFrame = CFrame.new(0, 4, -6),
+        ReturnCFrame = CFrame.new(0, 4, -2),
         OutdoorThresholdZ = OUTDOOR_THRESHOLD_Z,
         ShopPrompt = house.ShopPrompt,
         LoadoutPrompt = house.LoadoutPrompt,

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -69,7 +69,7 @@ menuTitle.Text = 'Enter the expedition camp'
 
 local menuBody = makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 78), Theme.SubtleText, 18, false)
 menuBody.Text =
-    'Start inside the camp house, meet up with the crew, and open the main gate when you are ready to step into the wilderness.'
+    'Start inside the camp house, meet up with the crew, and open the main gate when you are ready to step into the wilderness and the shared maze gate.'
 
 local singlePlayerButton = Instance.new('TextButton')
 singlePlayerButton.Size = UDim2.new(1, 0, 0, 52)
@@ -116,13 +116,13 @@ local function makePlaceholder(text)
 end
 
 makePlaceholder('Shop Terminal (Soon)')
-makePlaceholder('Maze Run Gate (Soon)')
+makePlaceholder('Shared Maze Gate')
 
 local panel = Instance.new('Frame')
 panel.Name = 'CampPanel'
 panel.AnchorPoint = Vector2.new(0, 0)
 panel.Position = UDim2.fromScale(0.03, 0.05)
-panel.Size = UDim2.fromOffset(420, 320)
+panel.Size = UDim2.fromOffset(440, 420)
 panel.BackgroundColor3 = Theme.Background
 panel.BorderSizePixel = 0
 panel.Visible = false
@@ -154,10 +154,13 @@ objectiveLabel.Text = 'Objective: --'
 
 local guideLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 60), Theme.Text, 16, false)
 guideLabel.Text =
-    'In-world prompts:\n- Shop Terminal (Soon)\n- Loadout Bench (Soon)\n- Camp Gate / Maze Run Gate'
+    'In-world prompts:\n- Shop Terminal (Soon)\n- Loadout Bench (Soon)\n- Camp Gate / Shared Maze Gate'
 
 local rosterLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 90), Theme.SubtleText, 16, false)
 rosterLabel.Text = ''
+
+local mazeLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 96), Theme.SubtleText, 16, false)
+mazeLabel.Text = ''
 
 singlePlayerButton.MouseButton1Click:Connect(function()
     singlePlayerButton.AutoButtonColor = false
@@ -188,10 +191,11 @@ Remotes.RunSnapshot.OnClientEvent:Connect(function(snapshot)
     end
 
     statusLabel.Text = string.format(
-        '%s\nArea: %s | Gate: %s',
+        '%s\nArea: %s | Gate: %s | Maze: %s',
         snapshot.Status,
         snapshot.Area,
-        snapshot.GateOpen and 'Open' or 'Closed'
+        snapshot.GateOpen and 'Open' or 'Closed',
+        snapshot.MazeStatus or 'idle'
     )
 
     objectiveLabel.Text = string.format('Objective: %s', snapshot.Objective)
@@ -203,4 +207,35 @@ Remotes.RunSnapshot.OnClientEvent:Connect(function(snapshot)
     end
 
     rosterLabel.Text = 'Camp roster:\n' .. table.concat(rosterLines, '\n')
+
+    local mazeLines = {}
+    local activeMazePlayers = snapshot.PlayersInMaze or {}
+    if #activeMazePlayers > 0 then
+        table.insert(mazeLines, 'In maze:')
+        for _, entry in ipairs(activeMazePlayers) do
+            table.insert(mazeLines, string.format('- %s', entry.Name))
+        end
+    end
+
+    local returnedSummaries = snapshot.ReturnedPlayerSummaries or {}
+    if #returnedSummaries > 0 then
+        if #mazeLines > 0 then
+            table.insert(mazeLines, '')
+        end
+        table.insert(mazeLines, 'Returned:')
+        for _, entry in ipairs(returnedSummaries) do
+            table.insert(
+                mazeLines,
+                string.format(
+                    '- %s: %d value (%s)',
+                    entry.Name,
+                    entry.Value or 0,
+                    entry.ReturnReason or 'unknown'
+                )
+            )
+        end
+    end
+
+    mazeLabel.Text = #mazeLines > 0 and table.concat(mazeLines, '\n')
+        or 'Maze summary:\n- No players have entered the maze yet.'
 end)

--- a/tests/src/Shared/CampMazeSessionContract.spec.luau
+++ b/tests/src/Shared/CampMazeSessionContract.spec.luau
@@ -1,0 +1,126 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local shared = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared'))
+    local contract = shared.Session.CampMazeSessionContract
+
+    local campSession = contract.newCampSession({
+        SessionId = 'camp-session-1',
+        CampAccessCode = 'camp-access-code',
+    })
+
+    assert(
+        campSession.MazeStatus == contract.MazeStatus.Idle,
+        'New camp sessions should start idle'
+    )
+
+    local entered = contract.markPlayerEntered(campSession, {
+        UserId = 42,
+        Name = 'Scout',
+    })
+    entered.MazeAccessCode = 'maze-access-code'
+
+    assert(
+        entered.MazeStatus == contract.MazeStatus.Active,
+        'Entering the maze should activate the maze status'
+    )
+    assert(#entered.PlayersInMaze == 1, 'Entering should track the player inside the maze')
+
+    local campToMaze = contract.buildCampToMazeTeleportData({
+        SessionConfig = {
+            Seed = 12345,
+            Quota = 120,
+            RunDurationSeconds = 180,
+            InventoryCapacity = 5,
+        },
+        CampSession = entered,
+        EnteringPlayer = {
+            UserId = 42,
+            Name = 'Scout',
+        },
+        EntryReason = 'maze_gate',
+    })
+
+    assert(
+        campToMaze.MazeSession.MazeAccessCode == 'maze-access-code',
+        'Maze access code should flow into the maze teleport payload'
+    )
+    assert(
+        campToMaze.CampSession.SessionId == 'camp-session-1',
+        'Camp session id should survive camp -> maze teleport shaping'
+    )
+
+    local earlyReturn = contract.buildReturnSummary({
+        UserId = 42,
+        Name = 'Scout',
+        ReturnReason = 'early_return',
+        Value = 18,
+        ItemCount = 1,
+        Weight = 2,
+    })
+    local resumed = contract.applyReturn(entered, earlyReturn, false)
+
+    assert(
+        #resumed.PlayersInMaze == 0,
+        'Returned players should be removed from the in-maze roster'
+    )
+    assert(
+        resumed.MazeStatus == contract.MazeStatus.Active,
+        'Maze stays active when it was opened but not completed'
+    )
+    assert(
+        resumed.ReturnedPlayerSummaries[1].Value == 18,
+        'Return summaries should preserve collected value'
+    )
+
+    local settled = contract.buildReturnSummary({
+        UserId = 7,
+        Name = 'Lead',
+        ReturnReason = 'settled',
+        Value = 42,
+        ItemCount = 2,
+        Weight = 4,
+        WasExtracted = true,
+        WasSettled = true,
+    })
+    local completed = contract.applyReturn(
+        contract.markPlayerEntered(resumed, {
+            UserId = 7,
+            Name = 'Lead',
+        }),
+        settled,
+        true
+    )
+
+    assert(
+        completed.MazeStatus == contract.MazeStatus.Completed,
+        'Completed maze sessions should lock into completed status'
+    )
+    assert(
+        #completed.PlayersInMaze == 0,
+        'Completed maze sessions should not retain active maze players'
+    )
+
+    local mazeToCamp = contract.buildMazeToCampTeleportData({
+        SessionConfig = {
+            Seed = 12345,
+            Quota = 120,
+            RunDurationSeconds = 180,
+            InventoryCapacity = 5,
+        },
+        CampSession = completed,
+        Summaries = completed.ReturnedPlayerSummaries,
+        MazeCompleted = true,
+    })
+
+    local returnedScout = contract.findReturnSummary(mazeToCamp, 42)
+    local returnedLead = contract.findReturnSummary(mazeToCamp, 7)
+
+    assert(
+        returnedScout.ReturnReason == 'early_return',
+        'findReturnSummary should locate the matching player summary'
+    )
+    assert(
+        returnedLead.WasSettled == true,
+        'Maze return payload should preserve settlement summaries'
+    )
+end


### PR DESCRIPTION
## Summary
- add a dedicated `places/maze` place for the procedural maze run instead of keeping maze gameplay inside the camp staging place
- introduce a shared camp/maze teleport session contract so camp -> maze -> camp round trips preserve the same camp session semantics
- wire the wilderness maze gate to create or join one shared maze session, and update both camp and maze HUDs to reflect live session state

## What Changed
- added `SessionConfig.PlaceIds.Maze` plus a shared `CampMazeSessionContract` to shape lobby->camp, camp->maze, and maze->camp teleport data
- updated lobby launch flow to reserve a private camp server explicitly and seed that server with a stable `SessionId` and `CampAccessCode`
- updated `places/run` to maintain camp session state, open/join the shared maze session from the outdoor gate, and resume returned players at the camp return point
- added `places/maze` with a dedicated bootstrap, procedural world builder, shared loop state, loot pickup, monster patrol, settlement flow, and early-return support
- moved reusable inventory / monster / role runtime services into shared runtime modules so both places can reuse the same logic
- added a deterministic spec for the camp/maze session contract and updated camp HUD text to show maze activity and returned-player summaries

## Validation
- `stylua --check .`
- `selene .`
- `rojo build places/run/default.project.json -o /tmp/run_place.rbxlx`
- `rojo build places/maze/default.project.json -o /tmp/maze_place.rbxlx`
- `rojo build tests/default.project.json -o /tmp/roblox_experience_tests.rbxlx`
- Studio MCP Luau assertions for `CampMazeSessionContract`, `MazeBuilder`, `SessionStateMachine`, `Inventory`, and `Visibility`

## Manual Checks Still Needed
- verify lobby -> camp teleport still works when `SessionConfig.PlaceIds.Run` is filled with a real place id
- verify the first player entering the wilderness maze gate creates the maze session and later players join the same maze server
- verify one player can early-return to camp while other players continue the shared maze run
- verify a settled maze run returns the crew to the same camp session semantics and the camp HUD shows returned summaries
- verify `SessionConfig.PlaceIds.Maze` is filled with a real place id before testing the full round trip

## Risk
- medium: this changes place-to-place session flow, teleport shaping, and run HUD behavior in one feature branch
- the repo still lacks a local `run-in-roblox` executable, so automated validation is currently limited to static checks, Rojo build validation, and Studio MCP logic assertions

## Rollback
- revert commit `35bea74`

Closes #15
Closes #16

Refs #14
Refs #17
Refs #18
Refs #19
