### PR TITLE
[Maze] Restore the standalone maze gameplay loop

### DIFF
--- a/packages/gameplay/src/Session/MazeRunTracker.luau
+++ b/packages/gameplay/src/Session/MazeRunTracker.luau
@@ -1,0 +1,122 @@
+local SessionStateMachine = require(script.Parent.SessionStateMachine)
+
+local MazeRunTracker = {}
+MazeRunTracker.__index = MazeRunTracker
+
+local function cloneSummary(summary)
+    return {
+        UserId = summary.UserId,
+        Name = summary.Name,
+        ReturnReason = summary.ReturnReason,
+        Value = summary.Value or 0,
+        ItemCount = summary.ItemCount or 0,
+        Weight = summary.Weight or 0,
+        WasExtracted = summary.WasExtracted == true,
+        WasSettled = summary.WasSettled == true,
+    }
+end
+
+function MazeRunTracker.new()
+    return setmetatable({
+        StateMachine = SessionStateMachine.new('Camp'),
+        ActivePlayersByUserId = {},
+        ReturnedSummaries = {},
+        IsCompleted = false,
+    }, MazeRunTracker)
+end
+
+function MazeRunTracker:addPlayer(playerInfo)
+    if self.IsCompleted then
+        return false, 'Completed'
+    end
+
+    self.ActivePlayersByUserId[playerInfo.UserId] = {
+        UserId = playerInfo.UserId,
+        Name = playerInfo.Name,
+    }
+
+    return true
+end
+
+function MazeRunTracker:removePlayer(userId)
+    self.ActivePlayersByUserId[userId] = nil
+end
+
+function MazeRunTracker:isPlayerActive(userId)
+    return self.ActivePlayersByUserId[userId] ~= nil
+end
+
+function MazeRunTracker:getActiveCount()
+    local count = 0
+    for _ in pairs(self.ActivePlayersByUserId) do
+        count += 1
+    end
+
+    return count
+end
+
+function MazeRunTracker:getState()
+    return self.StateMachine.Current
+end
+
+function MazeRunTracker:getReturnedSummaries()
+    local summaries = {}
+
+    for index, summary in ipairs(self.ReturnedSummaries) do
+        summaries[index] = cloneSummary(summary)
+    end
+
+    return summaries
+end
+
+function MazeRunTracker:beginExpedition()
+    if self.StateMachine.Current ~= 'Camp' then
+        return false, 'InvalidState'
+    end
+
+    self.StateMachine:transition('Expedition')
+    return true
+end
+
+function MazeRunTracker:beginExtraction()
+    if self.StateMachine.Current ~= 'Expedition' then
+        return false, 'InvalidState'
+    end
+
+    self.StateMachine:transition('Extraction')
+    return true
+end
+
+function MazeRunTracker:recordReturn(summary)
+    if not self:isPlayerActive(summary.UserId) then
+        return false, 'MissingActivePlayer'
+    end
+
+    self.ActivePlayersByUserId[summary.UserId] = nil
+    table.insert(self.ReturnedSummaries, cloneSummary(summary))
+
+    return true
+end
+
+function MazeRunTracker:completeSettlement(summaries)
+    if self.StateMachine.Current ~= 'Extraction' then
+        return false, 'InvalidState'
+    end
+
+    for _, summary in ipairs(summaries) do
+        if not self:isPlayerActive(summary.UserId) then
+            return false, 'MissingActivePlayer'
+        end
+    end
+
+    self.StateMachine:transition('Settlement')
+
+    for _, summary in ipairs(summaries) do
+        self:recordReturn(summary)
+    end
+
+    self.IsCompleted = true
+    return true
+end
+
+return MazeRunTracker

--- a/packages/gameplay/src/Session/init.luau
+++ b/packages/gameplay/src/Session/init.luau
@@ -1,3 +1,4 @@
 return {
+    MazeRunTracker = require(script.MazeRunTracker),
     SessionStateMachine = require(script.SessionStateMachine),
 }

--- a/packages/shared/src/Runtime/InventoryService.luau
+++ b/packages/shared/src/Runtime/InventoryService.luau
@@ -1,0 +1,67 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+
+local Inventory = Gameplay.Inventory
+
+local InventoryService = {}
+InventoryService.__index = InventoryService
+
+function InventoryService.new(capacity)
+    return setmetatable({
+        Capacity = capacity,
+        ByUserId = {},
+    }, InventoryService)
+end
+
+function InventoryService:addPlayer(player)
+    self.ByUserId[player.UserId] = Inventory.new(self.Capacity)
+end
+
+function InventoryService:removePlayer(player)
+    self.ByUserId[player.UserId] = nil
+end
+
+function InventoryService:get(player)
+    return self.ByUserId[player.UserId]
+end
+
+function InventoryService:pickup(player, itemDef)
+    local inventory = self:get(player)
+    if not inventory then
+        return false, 'MissingInventory'
+    end
+
+    return inventory:add(itemDef)
+end
+
+function InventoryService:deposit(player)
+    local inventory = self:get(player)
+    if not inventory then
+        return 0
+    end
+
+    local totalValue = inventory:getTotalValue()
+    inventory:clear()
+    return totalValue
+end
+
+function InventoryService:getSummary(player)
+    local inventory = self:get(player)
+    if not inventory then
+        return {
+            Weight = 0,
+            Count = 0,
+            Value = 0,
+        }
+    end
+
+    return {
+        Weight = inventory.Weight,
+        Count = #inventory.Order,
+        Value = inventory:getTotalValue(),
+    }
+end
+
+return InventoryService

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -1,0 +1,111 @@
+local Players = game:GetService('Players')
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local RunService = game:GetService('RunService')
+local Workspace = game:GetService('Workspace')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+
+local MonsterLogic = Gameplay.Monsters.MonsterLogic
+
+local MonsterService = {}
+MonsterService.__index = MonsterService
+
+function MonsterService.new(monsterDefinition, isExpeditionActiveCallback, canTargetPlayerCallback)
+    return setmetatable({
+        Definition = monsterDefinition,
+        IsExpeditionActive = isExpeditionActiveCallback,
+        CanTargetPlayer = canTargetPlayerCallback or function()
+            return true
+        end,
+        PatrolPoints = {},
+        PatrolIndex = 1,
+        MonsterPart = nil,
+        Connection = nil,
+    }, MonsterService)
+end
+
+function MonsterService:destroy()
+    if self.Connection then
+        self.Connection:Disconnect()
+        self.Connection = nil
+    end
+
+    if self.MonsterPart then
+        self.MonsterPart:Destroy()
+        self.MonsterPart = nil
+    end
+end
+
+function MonsterService:spawn(patrolPoints)
+    self:destroy()
+    self.PatrolPoints = patrolPoints
+    self.PatrolIndex = 1
+
+    if #patrolPoints == 0 then
+        return
+    end
+
+    local monster = Instance.new('Part')
+    monster.Name = self.Definition.Name
+    monster.Shape = Enum.PartType.Ball
+    monster.Size = Vector3.new(4, 4, 4)
+    monster.Anchored = true
+    monster.CanCollide = false
+    monster.Material = Enum.Material.Neon
+    monster.Color = Color3.fromRGB(214, 91, 91)
+    monster.Position = patrolPoints[1] + Vector3.new(0, 4, 0)
+    monster.Parent = Workspace
+
+    self.MonsterPart = monster
+
+    self.Connection = RunService.Heartbeat:Connect(function(dt)
+        self:update(dt)
+    end)
+end
+
+function MonsterService:update(dt)
+    if not self.MonsterPart or not self.IsExpeditionActive() then
+        return
+    end
+
+    local playerPositions = {}
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        if self.CanTargetPlayer(player) then
+            local character = player.Character
+            local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+            if rootPart then
+                playerPositions[player] = rootPart.Position
+            end
+        end
+    end
+
+    local currentPosition = self.MonsterPart.Position
+    local targetPlayer =
+        MonsterLogic.pickNearestTarget(currentPosition, playerPositions, self.Definition.SightRange)
+    local nextPosition
+
+    if targetPlayer then
+        nextPosition = MonsterLogic.stepToward(
+            currentPosition,
+            playerPositions[targetPlayer],
+            self.Definition.Speed,
+            dt
+        )
+    elseif #self.PatrolPoints > 0 then
+        local patrolTarget = self.PatrolPoints[self.PatrolIndex] + Vector3.new(0, 4, 0)
+        nextPosition =
+            MonsterLogic.stepToward(currentPosition, patrolTarget, self.Definition.Speed * 0.45, dt)
+
+        if (nextPosition - patrolTarget).Magnitude <= 2 then
+            self.PatrolIndex = (self.PatrolIndex % #self.PatrolPoints) + 1
+        end
+    end
+
+    if nextPosition then
+        self.MonsterPart.CFrame = CFrame.new(nextPosition)
+    end
+end
+
+return MonsterService

--- a/places/maze/default.project.json
+++ b/places/maze/default.project.json
@@ -1,0 +1,25 @@
+{
+  "name": "roblox-experience-maze",
+  "tree": {
+    "$className": "DataModel",
+    "ReplicatedStorage": {
+      "$className": "ReplicatedStorage",
+      "Packages": {
+        "$className": "Folder",
+        "Shared": {
+          "$path": "../../packages/shared/src"
+        },
+        "Gameplay": {
+          "$path": "../../packages/gameplay/src"
+        },
+        "UI": {
+          "$path": "../../packages/ui/src"
+        }
+      }
+    },
+    "ServerScriptService": {
+      "$className": "ServerScriptService",
+      "$path": "src/ServerScriptService"
+    }
+  }
+}

--- a/places/maze/src/ServerScriptService/Bootstrap.server.luau
+++ b/places/maze/src/ServerScriptService/Bootstrap.server.luau
@@ -1,0 +1,3 @@
+local MazeSessionService = require(script.Parent.Maze.MazeSessionService)
+
+MazeSessionService.new():start()

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -1,0 +1,364 @@
+local Players = game:GetService('Players')
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local Workspace = game:GetService('Workspace')
+
+local DEFAULT_WORKSPACE_SHELL_NAMES = { 'Baseplate', 'SpawnLocation' }
+local EXTRACTION_DELAY_SECONDS = 2
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Shared = Packages:WaitForChild('Shared')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+
+local SessionConfig = require(Shared:WaitForChild('Config'):WaitForChild('SessionConfig'))
+local InventoryService = require(Shared:WaitForChild('Runtime'):WaitForChild('InventoryService'))
+local MonsterService = require(Shared:WaitForChild('Runtime'):WaitForChild('MonsterService'))
+
+local MazeWorldBuilder = require(script.Parent.MazeWorldBuilder)
+
+local MazeSessionService = {}
+MazeSessionService.__index = MazeSessionService
+
+local function clearDefaultWorkspaceShell()
+    for _, instanceName in ipairs(DEFAULT_WORKSPACE_SHELL_NAMES) do
+        local instance = Workspace:FindFirstChild(instanceName)
+        if instance then
+            instance:Destroy()
+        end
+    end
+end
+
+local function bindCharacterTeleport(self, player)
+    player.CharacterAdded:Connect(function(character)
+        task.wait()
+        if not self.World or not character.Parent then
+            return
+        end
+
+        local targetCFrame = self.World.SpawnCFrame
+        if not self.RunTracker:isPlayerActive(player.UserId) then
+            targetCFrame = self.World.ReturnHoldCFrame
+        end
+
+        character:PivotTo(targetCFrame)
+    end)
+end
+
+function MazeSessionService.new()
+    local self = setmetatable({}, MazeSessionService)
+
+    self.SessionData = {
+        Seed = SessionConfig.DefaultSeed,
+        InventoryCapacity = SessionConfig.InventoryCapacity,
+    }
+    self.Status = 'Direct boot: use the expedition console to begin the maze run.'
+    self.World = nil
+    self.IsLaunched = false
+    self.RunTracker = Gameplay.Session.MazeRunTracker.new()
+    self.InventoryService = InventoryService.new(self.SessionData.InventoryCapacity)
+    self.MonsterService = MonsterService.new(Gameplay.Config.Monsters[1], function()
+        return self.RunTracker:getState() == 'Expedition'
+    end, function(player)
+        return self.RunTracker:isPlayerActive(player.UserId)
+    end)
+
+    return self
+end
+
+function MazeSessionService:_loadSessionDataFromJoin()
+    local players = Players:GetPlayers()
+    if #players == 0 then
+        return
+    end
+
+    local joinData = players[1]:GetJoinData()
+    local teleportData = joinData and joinData.TeleportData
+    local incoming = teleportData and teleportData.SessionConfig
+
+    if type(incoming) ~= 'table' then
+        return
+    end
+
+    if type(incoming.Seed) == 'number' then
+        self.SessionData.Seed = incoming.Seed
+    end
+
+    if type(incoming.InventoryCapacity) == 'number' then
+        self.SessionData.InventoryCapacity = incoming.InventoryCapacity
+    end
+
+    self.InventoryService = InventoryService.new(self.SessionData.InventoryCapacity)
+end
+
+function MazeSessionService:_addPlayerState(player)
+    local added = self.RunTracker:addPlayer({
+        UserId = player.UserId,
+        Name = player.DisplayName,
+    })
+
+    if not added then
+        return
+    end
+
+    self.InventoryService:addPlayer(player)
+end
+
+function MazeSessionService:_removePlayerState(player)
+    self.RunTracker:removePlayer(player.UserId)
+    self.InventoryService:removePlayer(player)
+end
+
+function MazeSessionService:_setStatus(status)
+    self.Status = status
+    print(string.format('[Maze] %s', status))
+end
+
+function MazeSessionService:_rebuildWorld()
+    clearDefaultWorkspaceShell()
+    self.World = MazeWorldBuilder.build(self.SessionData.Seed, SessionConfig.ProcGen)
+    self:_bindWorldInteractions()
+end
+
+function MazeSessionService:_bindWorldInteractions()
+    self.World.DeployPrompt.Triggered:Connect(function(player)
+        self:_deployCrew(player)
+    end)
+
+    self.World.ReturnPrompt.Triggered:Connect(function(player)
+        self:_returnPlayer(player)
+    end)
+
+    self.World.ExtractionPrompt.Triggered:Connect(function(player)
+        self:_startExtraction(player)
+    end)
+
+    for roomId, lootEntry in pairs(self.World.LootPrompts) do
+        lootEntry.Prompt.Triggered:Connect(function(player)
+            self:_pickupLoot(player, roomId)
+        end)
+    end
+end
+
+function MazeSessionService:_buildSummaryFor(player, returnReason, wasSettled)
+    local inventorySummary = self.InventoryService:getSummary(player)
+    self.InventoryService:deposit(player)
+
+    return {
+        UserId = player.UserId,
+        Name = player.DisplayName,
+        ReturnReason = returnReason,
+        Value = inventorySummary.Value,
+        ItemCount = inventorySummary.Count,
+        Weight = inventorySummary.Weight,
+        WasExtracted = returnReason == 'extracted' or returnReason == 'settled',
+        WasSettled = wasSettled == true,
+    }
+end
+
+function MazeSessionService:_deployCrew(player)
+    local started, reason = self.RunTracker:beginExpedition()
+    if not started then
+        if reason == 'InvalidState' then
+            self:_setStatus(
+                string.format(
+                    '%s checked the expedition console, but the maze run is already active.',
+                    player.DisplayName
+                )
+            )
+        end
+        return
+    end
+
+    self.MonsterService:spawn(self.World.PatrolPoints)
+    self:_setStatus(string.format('%s deployed the crew into the maze.', player.DisplayName))
+end
+
+function MazeSessionService:_pickupLoot(player, roomId)
+    if self.RunTracker:getState() ~= 'Expedition' then
+        self:_setStatus('Loot can only be collected during the expedition phase.')
+        return
+    end
+
+    if not self.RunTracker:isPlayerActive(player.UserId) then
+        self:_setStatus(
+            string.format(
+                '%s has already returned and cannot collect more loot.',
+                player.DisplayName
+            )
+        )
+        return
+    end
+
+    local lootEntry = self.World.LootPrompts[roomId]
+    if not lootEntry or lootEntry.Collected then
+        return
+    end
+
+    local success, reason = self.InventoryService:pickup(player, lootEntry.ItemDef)
+    if not success then
+        self:_setStatus(
+            string.format(
+                '%s could not carry %s (%s).',
+                player.DisplayName,
+                lootEntry.ItemDef.Name,
+                tostring(reason)
+            )
+        )
+        return
+    end
+
+    lootEntry.Collected = true
+    local promptPart = lootEntry.Prompt.Parent
+    if promptPart then
+        promptPart:Destroy()
+    end
+
+    local inventorySummary = self.InventoryService:getSummary(player)
+    self:_setStatus(
+        string.format(
+            '%s collected %s. Inventory value now %d.',
+            player.DisplayName,
+            lootEntry.ItemDef.Name,
+            inventorySummary.Value
+        )
+    )
+end
+
+function MazeSessionService:_returnPlayer(player)
+    local currentState = self.RunTracker:getState()
+    if currentState == 'Camp' then
+        self:_setStatus('Return is available after the expedition begins.')
+        return
+    end
+
+    if currentState == 'Settlement' then
+        self:_setStatus('Settlement is already complete.')
+        return
+    end
+
+    local recorded, reason =
+        self.RunTracker:recordReturn(self:_buildSummaryFor(player, 'early_return', false))
+    if not recorded then
+        if reason == 'MissingActivePlayer' then
+            self:_setStatus(string.format('%s already returned to camp.', player.DisplayName))
+        end
+        return
+    end
+
+    local character = player.Character
+    if character and character.Parent then
+        character:PivotTo(self.World.ReturnHoldCFrame)
+    end
+
+    local summaries = self.RunTracker:getReturnedSummaries()
+    local summary = summaries[#summaries]
+    self:_setStatus(
+        string.format('%s returned early with %d value.', player.DisplayName, summary.Value)
+    )
+end
+
+function MazeSessionService:_completeSettlement(player)
+    if self.RunTracker:getState() ~= 'Extraction' then
+        return
+    end
+
+    local summaries = {}
+    for _, currentPlayer in ipairs(Players:GetPlayers()) do
+        if self.RunTracker:isPlayerActive(currentPlayer.UserId) then
+            table.insert(summaries, self:_buildSummaryFor(currentPlayer, 'settled', true))
+        end
+    end
+
+    local completed, reason = self.RunTracker:completeSettlement(summaries)
+    if not completed then
+        self:_setStatus(string.format('Settlement failed: %s', tostring(reason)))
+        return
+    end
+
+    self.MonsterService:destroy()
+
+    for _, currentPlayer in ipairs(Players:GetPlayers()) do
+        if currentPlayer.Character and currentPlayer.Character.Parent then
+            currentPlayer.Character:PivotTo(self.World.ReturnHoldCFrame)
+        end
+    end
+
+    self:_setStatus(
+        string.format(
+            '%s completed settlement. Maze results are ready for camp handoff.',
+            player.DisplayName
+        )
+    )
+end
+
+function MazeSessionService:_startExtraction(player)
+    if self.RunTracker:getState() ~= 'Expedition' then
+        self:_setStatus('The settlement pad is only available during the expedition phase.')
+        return
+    end
+
+    if not self.RunTracker:isPlayerActive(player.UserId) then
+        self:_setStatus(string.format('%s already returned to camp.', player.DisplayName))
+        return
+    end
+
+    local started, reason = self.RunTracker:beginExtraction()
+    if not started then
+        self:_setStatus(string.format('Extraction could not start: %s', tostring(reason)))
+        return
+    end
+
+    self:_setStatus(
+        string.format('%s activated the settlement pad. Hold tight.', player.DisplayName)
+    )
+
+    task.delay(EXTRACTION_DELAY_SECONDS, function()
+        self:_completeSettlement(player)
+    end)
+end
+
+function MazeSessionService:_launchMaze()
+    if self.IsLaunched then
+        return
+    end
+
+    self.IsLaunched = true
+    Players.CharacterAutoLoads = true
+
+    self:_rebuildWorld()
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        player:LoadCharacter()
+    end
+end
+
+function MazeSessionService:start()
+    self:_loadSessionDataFromJoin()
+    Players.CharacterAutoLoads = false
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        bindCharacterTeleport(self, player)
+        self:_addPlayerState(player)
+
+        if player.Character then
+            player.Character:Destroy()
+        end
+    end
+
+    Players.PlayerAdded:Connect(function(player)
+        bindCharacterTeleport(self, player)
+        self:_addPlayerState(player)
+
+        if self.IsLaunched then
+            player:LoadCharacter()
+            self:_setStatus(string.format('%s joined the shared maze session.', player.DisplayName))
+        end
+    end)
+
+    Players.PlayerRemoving:Connect(function(player)
+        self:_removePlayerState(player)
+    end)
+
+    self:_launchMaze()
+end
+
+return MazeSessionService

--- a/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
@@ -1,0 +1,324 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local Workspace = game:GetService('Workspace')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+
+local Items = Gameplay.Config.Items
+local MazeBuilder = Gameplay.ProcGen.MazeBuilder
+
+local MazeWorldBuilder = {}
+
+local WALL_HEIGHT = 16
+local WALL_THICKNESS = 2
+local DOOR_GAP = 10
+local MARKER_HEIGHT = 1
+
+local DIRECTIONS = {
+    North = Vector3.new(0, 0, -1),
+    South = Vector3.new(0, 0, 1),
+    East = Vector3.new(1, 0, 0),
+    West = Vector3.new(-1, 0, 0),
+}
+
+local ROOM_KIND_COLORS = {
+    Camp = Color3.fromRGB(83, 126, 78),
+    Loot = Color3.fromRGB(88, 92, 112),
+    Extraction = Color3.fromRGB(145, 119, 73),
+}
+
+local function createPart(config, parent)
+    local part = Instance.new('Part')
+    part.Name = config.Name
+    part.Anchored = true
+    part.Size = config.Size
+    part.CFrame = config.CFrame
+    part.Color = config.Color
+    part.Material = config.Material or Enum.Material.SmoothPlastic
+    part.Transparency = config.Transparency or 0
+    part.CanCollide = config.CanCollide ~= false
+    part.Shape = config.Shape or Enum.PartType.Block
+    part.Parent = parent
+    return part
+end
+
+local function createPromptPart(config, parent)
+    local part = createPart({
+        Name = config.Name,
+        Size = config.Size or Vector3.new(4, 4, 4),
+        CFrame = config.CFrame,
+        Color = config.Color,
+        Material = config.Material or Enum.Material.Metal,
+        Transparency = config.Transparency or 0,
+        CanCollide = config.CanCollide,
+        Shape = config.Shape,
+    }, parent)
+
+    local prompt = Instance.new('ProximityPrompt')
+    prompt.ActionText = config.ActionText
+    prompt.ObjectText = config.ObjectText
+    prompt.HoldDuration = 0
+    prompt.MaxActivationDistance = config.MaxActivationDistance or 10
+    prompt.RequiresLineOfSight = false
+    prompt.Parent = part
+
+    return part, prompt
+end
+
+local function buildPositionIndex(layout)
+    local index = {}
+
+    for roomId, room in pairs(layout.Rooms) do
+        index[string.format('%d:%d:%d', room.Position.X, room.Position.Y, room.Position.Z)] = roomId
+    end
+
+    return index
+end
+
+local function wallHasOpening(positionIndex, room, roomSpacing, directionName)
+    local direction = DIRECTIONS[directionName]
+    local neighborPosition = room.Position + (direction * roomSpacing)
+    local key =
+        string.format('%d:%d:%d', neighborPosition.X, neighborPosition.Y, neighborPosition.Z)
+
+    return positionIndex[key] ~= nil
+end
+
+local function createNorthSouthWall(parent, room, roomSize, isNorth, hasOpening)
+    local zOffset = (roomSize.Z / 2) * (isNorth and -1 or 1)
+    local center = room.Position + Vector3.new(0, WALL_HEIGHT / 2, zOffset)
+
+    if not hasOpening then
+        createPart({
+            Name = isNorth and 'NorthWall' or 'SouthWall',
+            Size = Vector3.new(roomSize.X, WALL_HEIGHT, WALL_THICKNESS),
+            CFrame = CFrame.new(center),
+            Color = Color3.fromRGB(83, 69, 56),
+            Material = Enum.Material.WoodPlanks,
+        }, parent)
+        return
+    end
+
+    local segmentWidth = (roomSize.X - DOOR_GAP) / 2
+    local xOffset = (DOOR_GAP / 2) + (segmentWidth / 2)
+
+    for _, direction in ipairs({ -1, 1 }) do
+        createPart({
+            Name = isNorth and 'NorthWallSegment' or 'SouthWallSegment',
+            Size = Vector3.new(segmentWidth, WALL_HEIGHT, WALL_THICKNESS),
+            CFrame = CFrame.new(center + Vector3.new(xOffset * direction, 0, 0)),
+            Color = Color3.fromRGB(83, 69, 56),
+            Material = Enum.Material.WoodPlanks,
+        }, parent)
+    end
+end
+
+local function createEastWestWall(parent, room, roomSize, isEast, hasOpening)
+    local xOffset = (roomSize.X / 2) * (isEast and 1 or -1)
+    local center = room.Position + Vector3.new(xOffset, WALL_HEIGHT / 2, 0)
+
+    if not hasOpening then
+        createPart({
+            Name = isEast and 'EastWall' or 'WestWall',
+            Size = Vector3.new(WALL_THICKNESS, WALL_HEIGHT, roomSize.Z),
+            CFrame = CFrame.new(center),
+            Color = Color3.fromRGB(83, 69, 56),
+            Material = Enum.Material.WoodPlanks,
+        }, parent)
+        return
+    end
+
+    local segmentDepth = (roomSize.Z - DOOR_GAP) / 2
+    local zOffset = (DOOR_GAP / 2) + (segmentDepth / 2)
+
+    for _, direction in ipairs({ -1, 1 }) do
+        createPart({
+            Name = isEast and 'EastWallSegment' or 'WestWallSegment',
+            Size = Vector3.new(WALL_THICKNESS, WALL_HEIGHT, segmentDepth),
+            CFrame = CFrame.new(center + Vector3.new(0, 0, zOffset * direction)),
+            Color = Color3.fromRGB(83, 69, 56),
+            Material = Enum.Material.WoodPlanks,
+        }, parent)
+    end
+end
+
+local function createRoomMarker(parent, room, roomSize)
+    createPart({
+        Name = 'RoomMarker',
+        Size = Vector3.new(roomSize.X - 4, MARKER_HEIGHT, roomSize.Z - 4),
+        CFrame = CFrame.new(room.Position + Vector3.new(0, MARKER_HEIGHT / 2, 0)),
+        Color = ROOM_KIND_COLORS[room.Kind] or Color3.fromRGB(112, 112, 112),
+        Material = Enum.Material.SmoothPlastic,
+        Transparency = 0.35,
+        CanCollide = false,
+    }, parent)
+end
+
+local function buildRoom(parent, room, roomSize, positionIndex, roomSpacing)
+    local roomFolder = Instance.new('Folder')
+    roomFolder.Name = room.Id
+    roomFolder.Parent = parent
+
+    createPart({
+        Name = 'Floor',
+        Size = Vector3.new(roomSize.X, 1, roomSize.Z),
+        CFrame = CFrame.new(room.Position + Vector3.new(0, -0.5, 0)),
+        Color = Color3.fromRGB(61, 72, 81),
+        Material = Enum.Material.Slate,
+    }, roomFolder)
+
+    createPart({
+        Name = 'Ceiling',
+        Size = Vector3.new(roomSize.X, 1, roomSize.Z),
+        CFrame = CFrame.new(room.Position + Vector3.new(0, WALL_HEIGHT + 0.5, 0)),
+        Color = Color3.fromRGB(52, 44, 38),
+        Material = Enum.Material.WoodPlanks,
+    }, roomFolder)
+
+    createNorthSouthWall(
+        roomFolder,
+        room,
+        roomSize,
+        true,
+        wallHasOpening(positionIndex, room, roomSpacing, 'North')
+    )
+    createNorthSouthWall(
+        roomFolder,
+        room,
+        roomSize,
+        false,
+        wallHasOpening(positionIndex, room, roomSpacing, 'South')
+    )
+    createEastWestWall(
+        roomFolder,
+        room,
+        roomSize,
+        true,
+        wallHasOpening(positionIndex, room, roomSpacing, 'East')
+    )
+    createEastWestWall(
+        roomFolder,
+        room,
+        roomSize,
+        false,
+        wallHasOpening(positionIndex, room, roomSpacing, 'West')
+    )
+
+    createRoomMarker(roomFolder, room, roomSize)
+
+    return roomFolder
+end
+
+function MazeWorldBuilder.build(seed, config)
+    local existing = Workspace:FindFirstChild('GeneratedMazeWorld')
+    if existing then
+        existing:Destroy()
+    end
+
+    local layout = MazeBuilder.build(seed, config)
+    local roomSize = config.RoomSize or Vector3.new(28, 16, 28)
+    local roomSpacing = config.RoomSpacing or 40
+    local positionIndex = buildPositionIndex(layout)
+
+    local worldFolder = Instance.new('Folder')
+    worldFolder.Name = 'GeneratedMazeWorld'
+    worldFolder.Parent = Workspace
+
+    local campRoom = layout.Rooms[layout.CampRoomId]
+    local extractionRoom = layout.Rooms[layout.ExtractionRoomId]
+    local patrolPoints = {}
+    local lootPrompts = {}
+    local roomOrder = {}
+
+    for roomId in pairs(layout.Rooms) do
+        table.insert(roomOrder, roomId)
+    end
+    table.sort(roomOrder)
+
+    local itemIndex = 1
+    for _, roomId in ipairs(roomOrder) do
+        local room = layout.Rooms[roomId]
+        local roomFolder = buildRoom(worldFolder, room, roomSize, positionIndex, roomSpacing)
+
+        if room.Kind == 'Loot' then
+            local itemDef = Items[itemIndex]
+            itemIndex = (itemIndex % #Items) + 1
+
+            local _, prompt = createPromptPart({
+                Name = string.format('Loot_%s', roomId),
+                Size = Vector3.new(3, 3, 3),
+                CFrame = CFrame.new(room.Position + Vector3.new(0, 1.5, 0)),
+                Color = itemDef.Color,
+                Material = Enum.Material.Neon,
+                ActionText = 'Collect',
+                ObjectText = itemDef.Name,
+                CanCollide = false,
+            }, roomFolder)
+
+            lootPrompts[roomId] = {
+                ItemDef = itemDef,
+                Prompt = prompt,
+                Position = room.Position,
+                Collected = false,
+            }
+            table.insert(patrolPoints, room.Position)
+        end
+    end
+
+    local _, deployPrompt = createPromptPart({
+        Name = 'DeployConsole',
+        Size = Vector3.new(4, 4, 4),
+        CFrame = CFrame.new(campRoom.Position + Vector3.new(-6, 2, 0)),
+        Color = Color3.fromRGB(93, 196, 176),
+        Material = Enum.Material.Metal,
+        ActionText = 'Deploy',
+        ObjectText = 'Expedition Console',
+    }, worldFolder)
+
+    createPart({
+        Name = 'ReturnHoldPad',
+        Size = Vector3.new(8, 1, 8),
+        CFrame = CFrame.new(campRoom.Position + Vector3.new(0, 0.5, -10)),
+        Color = Color3.fromRGB(77, 147, 196),
+        Material = Enum.Material.Neon,
+        Transparency = 0.2,
+        CanCollide = false,
+    }, worldFolder)
+
+    local _, returnPrompt = createPromptPart({
+        Name = 'ReturnMarker',
+        Size = Vector3.new(4, 1, 4),
+        CFrame = CFrame.new(campRoom.Position + Vector3.new(6, 0.5, 0)),
+        Color = Color3.fromRGB(77, 147, 196),
+        Material = Enum.Material.Neon,
+        ActionText = 'Return',
+        ObjectText = 'Return To Camp',
+        CanCollide = false,
+    }, worldFolder)
+
+    local _, extractionPrompt = createPromptPart({
+        Name = 'ExtractionPad',
+        Size = Vector3.new(6, 1, 6),
+        CFrame = CFrame.new(extractionRoom.Position + Vector3.new(0, 0.5, 0)),
+        Color = Color3.fromRGB(214, 170, 94),
+        Material = Enum.Material.Neon,
+        ActionText = 'Extract',
+        ObjectText = 'Settlement Pad',
+        CanCollide = false,
+        MaxActivationDistance = 12,
+    }, worldFolder)
+
+    return {
+        Root = worldFolder,
+        Layout = layout,
+        SpawnCFrame = CFrame.new(campRoom.Position + Vector3.new(0, 4, 0)),
+        ReturnHoldCFrame = CFrame.new(campRoom.Position + Vector3.new(0, 4, -10)),
+        DeployPrompt = deployPrompt,
+        ReturnPrompt = returnPrompt,
+        ExtractionPrompt = extractionPrompt,
+        LootPrompts = lootPrompts,
+        PatrolPoints = patrolPoints,
+    }
+end
+
+return MazeWorldBuilder

--- a/tests/src/Shared/MazeRunTracker.spec.luau
+++ b/tests/src/Shared/MazeRunTracker.spec.luau
@@ -1,0 +1,76 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local shared = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared'))
+    local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
+    local tracker = gameplay.Session.MazeRunTracker.new()
+
+    assert(tracker:addPlayer({ UserId = 10, Name = 'Alpha' }) == true, 'First player should join')
+    assert(tracker:addPlayer({ UserId = 20, Name = 'Bravo' }) == true, 'Second player should join')
+    assert(tracker:getActiveCount() == 2, 'Both players should start active')
+
+    local expeditionStarted, expeditionReason = tracker:beginExpedition()
+    assert(expeditionStarted == true, expeditionReason or 'Expedition should start from camp')
+    assert(
+        tracker:getState() == shared.Enums.RunState.Expedition,
+        'Tracker should transition into expedition'
+    )
+
+    local earlyReturnRecorded, earlyReturnReason = tracker:recordReturn({
+        UserId = 10,
+        Name = 'Alpha',
+        ReturnReason = 'early_return',
+        Value = 18,
+        ItemCount = 1,
+        Weight = 2,
+    })
+    assert(earlyReturnRecorded == true, earlyReturnReason or 'Early return should be recorded')
+    assert(
+        tracker:isPlayerActive(10) == false,
+        'Returned players should leave the active maze roster'
+    )
+    assert(
+        tracker:getState() == shared.Enums.RunState.Expedition,
+        'Early return should not force settlement'
+    )
+
+    local extractionStarted, extractionReason = tracker:beginExtraction()
+    assert(
+        extractionStarted == true,
+        extractionReason or 'Extraction should start after expedition'
+    )
+    assert(
+        tracker:getState() == shared.Enums.RunState.Extraction,
+        'Tracker should transition into extraction'
+    )
+
+    local settlementCompleted, settlementReason = tracker:completeSettlement({
+        {
+            UserId = 20,
+            Name = 'Bravo',
+            ReturnReason = 'settled',
+            Value = 42,
+            ItemCount = 2,
+            Weight = 4,
+            WasExtracted = true,
+            WasSettled = true,
+        },
+    })
+    assert(
+        settlementCompleted == true,
+        settlementReason or 'Settlement should complete for the remaining active player'
+    )
+    assert(tracker.IsCompleted == true, 'Settlement should mark the tracker complete')
+    assert(
+        tracker:getState() == shared.Enums.RunState.Settlement,
+        'Tracker should end in settlement'
+    )
+
+    local summaries = tracker:getReturnedSummaries()
+    assert(#summaries == 2, 'Both player summaries should be retained')
+    assert(summaries[1].ReturnReason == 'early_return', 'Early return should be preserved')
+    assert(summaries[2].WasSettled == true, 'Settlement summary should keep settled flag')
+
+    local canRejoin, rejoinReason = tracker:addPlayer({ UserId = 30, Name = 'Charlie' })
+    assert(canRejoin == false, 'Completed trackers should reject new active players')
+    assert(rejoinReason == 'Completed', 'Completed trackers should expose a concrete error')
+end


### PR DESCRIPTION
### Summary

- add a dedicated `places/maze` place that can boot directly and host the procedural maze loop
- restore the minimum playable loop inside the maze place: deploy, loot pickup, per-player inventory, monster patrol, early return, extraction, and settlement
- keep camp gate wiring, teleport contract, and maze/camp UI follow-up out of this PR

### Scope

- In scope:
  - standalone `places/maze` bootstrapping
  - deterministic maze world generation and in-world prompts
  - shared runtime inventory / monster helpers reused by the maze place
  - pure logic tracking for maze lifecycle and return summaries
  - deterministic spec for early return + settlement shaping
- Out of scope:
  - camp -> maze teleport/session contract
  - wilderness maze gate wiring in `places/run`
  - camp HUD / maze HUD polish
  - returning players to the camp place itself

### Key Changes

- added `MazeRunTracker` to model expedition/extraction/settlement transitions plus per-player return summaries
- added shared runtime `InventoryService` and `MonsterService` helpers for place-level gameplay orchestration
- added `places/maze` with a thin bootstrap, `MazeWorldBuilder`, and `MazeSessionService`
- wired deterministic loot placement, active-player filtering for monster targeting, and direct-boot fallback using `SessionConfig`

### Validation

- `stylua --check .`: pass
- `selene .`: pass
- `rojo build places/maze/default.project.json -o /tmp/maze_place.rbxlx`: pass
- `rojo build tests/default.project.json -o /tmp/roblox_experience_tests.rbxlx`: pass
- Roblox Studio MCP smoke for `MazeRunTracker`: pass

### Known Unrelated Failures

- `run-in-roblox` is not installed in the current environment, so the authoritative Studio test runner could not be executed locally
- the currently opened Studio session is `test.rbxl`, not the dedicated `maze` place tree, so full in-Studio boot verification of `places/maze` is still pending

### Risks and Rollback

- 主要风险：standalone maze loop 先落地了，但 camp/teleport 接线还没做完，所以返回结果目前只在 maze 侧形成摘要
- 监控点：direct boot 出生点、多人 early return、已有玩家提前返回后剩余玩家的 extraction/settlement
- 回滚思路：revert commit `05882cc`

### Related Issues

- Related to #14
- Related to #18
- Related to #19

Refs #17
