### PR TITLE
[UI] Add the maze place status HUD

### DIFF
--- a/places/maze/default.project.json
+++ b/places/maze/default.project.json
@@ -20,6 +20,13 @@
     "ServerScriptService": {
       "$className": "ServerScriptService",
       "$path": "src/ServerScriptService"
+    },
+    "StarterPlayer": {
+      "$className": "StarterPlayer",
+      "StarterPlayerScripts": {
+        "$className": "StarterPlayerScripts",
+        "$path": "src/StarterPlayer/StarterPlayerScripts"
+      }
     }
   }
 }

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -14,6 +14,7 @@ local SharedPackage = Packages:WaitForChild('Shared')
 
 local SessionConfig = Shared.Config.SessionConfig
 local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
+local Remotes = Shared.Network.Remotes.ensure()
 local InventoryService =
     require(SharedPackage:WaitForChild('Runtime'):WaitForChild('InventoryService'))
 local MonsterService = require(SharedPackage:WaitForChild('Runtime'):WaitForChild('MonsterService'))
@@ -73,6 +74,7 @@ function MazeSessionService.new()
         RunDurationSeconds = SessionConfig.DefaultRunDurationSeconds,
         InventoryCapacity = SessionConfig.InventoryCapacity,
     }
+    self.Remotes = Remotes
     self.CampSession = CampMazeSessionContract.newCampSession({
         MazeAccessCode = 'local-debug-maze',
         MazeStatus = CampMazeSessionContract.MazeStatus.Active,
@@ -81,6 +83,7 @@ function MazeSessionService.new()
     self.World = nil
     self.IsDirectBoot = true
     self.IsLaunched = false
+    self.SnapshotThread = nil
     self.CampSessionLock = false
     self.RunTracker = Gameplay.Session.MazeRunTracker.new()
     self.InventoryService = InventoryService.new(self.SessionData.InventoryCapacity)
@@ -161,9 +164,102 @@ function MazeSessionService:_removePlayerState(player)
     self.InventoryService:removePlayer(player)
 end
 
+function MazeSessionService:_getMazeStatus()
+    if self.RunTracker.IsCompleted then
+        return CampMazeSessionContract.MazeStatus.Completed
+    end
+
+    return CampMazeSessionContract.MazeStatus.Active
+end
+
+function MazeSessionService:_buildRoster()
+    local roster = {}
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        table.insert(roster, {
+            Name = player.DisplayName,
+            UserId = player.UserId,
+            InMaze = self.RunTracker:isPlayerActive(player.UserId),
+        })
+    end
+
+    table.sort(roster, function(left, right)
+        return left.Name < right.Name
+    end)
+
+    return roster
+end
+
+function MazeSessionService:_getPlayerArea(player)
+    if not self.IsLaunched or not self.World then
+        return 'Maze Staging'
+    end
+
+    local character = player.Character
+    local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+    if not rootPart then
+        return 'Maze Staging'
+    end
+
+    local room = self.World.FindRoomByPosition(rootPart.Position)
+    if not room then
+        return 'Maze Staging'
+    end
+
+    return string.format('%s Room', room.Kind)
+end
+
+function MazeSessionService:_getObjectiveFor()
+    local state = self.RunTracker:getState()
+
+    if state == 'Camp' then
+        return 'Use the expedition console to deploy, or use the return marker to leave early later.'
+    end
+
+    if state == 'Expedition' then
+        return 'Collect loot, avoid the monster, and reach the settlement pad.'
+    end
+
+    if state == 'Extraction' then
+        return 'Settlement is underway. Hold position until the camp return begins.'
+    end
+
+    return 'Settlement is complete. Review the return summaries or head back to camp.'
+end
+
+function MazeSessionService:_broadcastSnapshot()
+    if not self.IsLaunched then
+        return
+    end
+
+    local roster = self:_buildRoster()
+    local returnedSummaries = self.RunTracker:getReturnedSummaries()
+    local mazeStatus = self:_getMazeStatus()
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        self.Remotes.RunSnapshot:FireClient(player, {
+            IsLaunched = true,
+            Status = self.Status,
+            Area = self:_getPlayerArea(player),
+            Objective = self:_getObjectiveFor(),
+            State = self.RunTracker:getState(),
+            Inventory = self.InventoryService:getSummary(player),
+            Roster = roster,
+            SessionId = self.CampSession.SessionId,
+            MazeAccessCode = self.CampSession.MazeAccessCode,
+            MazeStatus = mazeStatus,
+            ReturnedPlayerSummaries = returnedSummaries,
+            IsDirectBoot = self.IsDirectBoot,
+        })
+
+        self.Remotes.PrivateState:FireClient(player, nil)
+    end
+end
+
 function MazeSessionService:_setStatus(status)
     self.Status = status
     print(string.format('[Maze] %s', status))
+    self:_broadcastSnapshot()
 end
 
 function MazeSessionService:_rebuildWorld()
@@ -449,6 +545,25 @@ function MazeSessionService:_launchMaze()
     for _, player in ipairs(Players:GetPlayers()) do
         player:LoadCharacter()
     end
+
+    self:_startSnapshotLoop()
+    self:_broadcastSnapshot()
+end
+
+function MazeSessionService:_startSnapshotLoop()
+    if self.SnapshotThread then
+        return
+    end
+
+    self.SnapshotThread = task.spawn(function()
+        while true do
+            task.wait(1)
+
+            if self.IsLaunched then
+                self:_broadcastSnapshot()
+            end
+        end
+    end)
 end
 
 function MazeSessionService:start()
@@ -472,11 +587,15 @@ function MazeSessionService:start()
         if self.IsLaunched then
             player:LoadCharacter()
             self:_setStatus(string.format('%s joined the shared maze session.', player.DisplayName))
+            return
         end
+
+        self:_broadcastSnapshot()
     end)
 
     Players.PlayerRemoving:Connect(function(player)
         self:_removePlayerState(player)
+        self:_broadcastSnapshot()
     end)
 
     self:_launchMaze()

--- a/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
@@ -318,6 +318,20 @@ function MazeWorldBuilder.build(seed, config)
         ExtractionPrompt = extractionPrompt,
         LootPrompts = lootPrompts,
         PatrolPoints = patrolPoints,
+        FindRoomByPosition = function(position)
+            local nearestRoom = nil
+            local nearestDistance = math.huge
+
+            for _, room in pairs(layout.Rooms) do
+                local distance = (room.Position - position).Magnitude
+                if distance < nearestDistance then
+                    nearestRoom = room
+                    nearestDistance = distance
+                end
+            end
+
+            return nearestRoom
+        end,
     }
 end
 

--- a/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
+++ b/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
@@ -1,0 +1,137 @@
+local Players = game:GetService('Players')
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+local localPlayer = Players.LocalPlayer
+local playerGui = localPlayer:WaitForChild('PlayerGui')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Shared = require(Packages:WaitForChild('Shared'))
+local UI = require(Packages:WaitForChild('UI'))
+
+local Remotes = Shared.Network.Remotes.ensure()
+local Theme = UI.Hud.Theme
+
+local screenGui = Instance.new('ScreenGui')
+screenGui.Name = 'MazeHud'
+screenGui.IgnoreGuiInset = true
+screenGui.ResetOnSpawn = false
+screenGui.Parent = playerGui
+
+local function makeTextLabel(parent, size, color, textSize, bold)
+    local label = Instance.new('TextLabel')
+    label.Size = size
+    label.BackgroundTransparency = 1
+    label.Font = bold and Enum.Font.GothamBold or Theme.Font
+    label.TextColor3 = color
+    label.TextSize = textSize
+    label.TextWrapped = true
+    label.TextXAlignment = Enum.TextXAlignment.Left
+    label.TextYAlignment = Enum.TextYAlignment.Top
+    label.Parent = parent
+    return label
+end
+
+local panel = Instance.new('Frame')
+panel.Name = 'MazePanel'
+panel.AnchorPoint = Vector2.new(0, 0)
+panel.Position = UDim2.fromScale(0.03, 0.05)
+panel.Size = UDim2.fromOffset(420, 430)
+panel.BackgroundColor3 = Theme.Background
+panel.BorderSizePixel = 0
+panel.Parent = screenGui
+
+local panelCorner = Instance.new('UICorner')
+panelCorner.CornerRadius = UDim.new(0, 16)
+panelCorner.Parent = panel
+
+local panelPadding = Instance.new('UIPadding')
+panelPadding.PaddingTop = UDim.new(0, 18)
+panelPadding.PaddingLeft = UDim.new(0, 18)
+panelPadding.PaddingRight = UDim.new(0, 18)
+panelPadding.PaddingBottom = UDim.new(0, 18)
+panelPadding.Parent = panel
+
+local list = Instance.new('UIListLayout')
+list.Padding = UDim.new(0, 10)
+list.Parent = panel
+
+local title = makeTextLabel(panel, UDim2.new(1, 0, 0, 36), Theme.Text, 28, true)
+title.Text = 'Maze Status'
+
+local statusLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 78), Theme.SubtleText, 18, false)
+statusLabel.Text = 'Waiting for maze snapshot...'
+
+local objectiveLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 66), Theme.Accent, 18, false)
+objectiveLabel.Text = 'Objective: --'
+
+local promptLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 66), Theme.Text, 16, false)
+promptLabel.Text =
+    'In-world prompts:\n- Expedition Console\n- Loot pickups\n- Return To Camp\n- Settlement Pad'
+
+local inventoryLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 44), Theme.Warning, 16, false)
+inventoryLabel.Text = 'Inventory: --'
+
+local rosterLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 94), Theme.SubtleText, 16, false)
+rosterLabel.Text = ''
+
+local returnedLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 104), Theme.SubtleText, 16, false)
+returnedLabel.Text = ''
+
+Remotes.PrivateState.OnClientEvent:Connect(function()
+    -- The first maze HUD does not surface per-player private state yet.
+end)
+
+Remotes.RunSnapshot.OnClientEvent:Connect(function(snapshot)
+    if snapshot.IsLaunched ~= true then
+        return
+    end
+
+    statusLabel.Text = string.format(
+        '%s\nArea: %s | Phase: %s | Maze: %s%s',
+        snapshot.Status or 'Maze ready.',
+        snapshot.Area or 'Unknown',
+        snapshot.State or 'Camp',
+        snapshot.MazeStatus or 'active',
+        snapshot.IsDirectBoot and ' | Direct Boot' or ''
+    )
+
+    objectiveLabel.Text = string.format('Objective: %s', snapshot.Objective or '--')
+
+    local inventory = snapshot.Inventory or {}
+    inventoryLabel.Text = string.format(
+        'Inventory: %d items | %d weight | %d value',
+        inventory.Count or 0,
+        inventory.Weight or 0,
+        inventory.Value or 0
+    )
+
+    local rosterLines = { 'Crew:' }
+    for _, rosterEntry in ipairs(snapshot.Roster or {}) do
+        local youMarker = rosterEntry.UserId == localPlayer.UserId and ' (You)' or ''
+        local stateMarker = rosterEntry.InMaze == false and ' - Returned' or ' - Active'
+        table.insert(
+            rosterLines,
+            string.format('- %s%s%s', rosterEntry.Name, youMarker, stateMarker)
+        )
+    end
+    rosterLabel.Text = table.concat(rosterLines, '\n')
+
+    local returnedLines = { 'Returned summaries:' }
+    local returned = snapshot.ReturnedPlayerSummaries or {}
+    if #returned == 0 then
+        table.insert(returnedLines, '- No one has returned yet.')
+    else
+        for _, entry in ipairs(returned) do
+            table.insert(
+                returnedLines,
+                string.format(
+                    '- %s: %d value (%s)',
+                    entry.Name,
+                    entry.Value or 0,
+                    entry.ReturnReason or 'unknown'
+                )
+            )
+        end
+    end
+    returnedLabel.Text = table.concat(returnedLines, '\n')
+end)


### PR DESCRIPTION
### Summary

- add a minimal in-maze HUD so players can read the current phase, room, inventory, crew roster, and return summaries while inside the dedicated maze place
- teach `MazeSessionService` to broadcast live `RunSnapshot` payloads inside the maze place instead of leaving the maze client blind
- finish the remaining UI side of `#19` on top of the existing stacked camp HUD and deterministic test work from `#17/#18`

### Scope

- In scope:
  - `places/maze` StarterPlayer wiring for a dedicated maze HUD client
  - maze-side snapshot broadcasting and status shaping needed by that HUD
  - minimal room lookup support so the HUD can show which maze room the player is in
- Out of scope:
  - camp HUD changes already handled in the base branch `#23`
  - teleport contract and deterministic specs already handled in the lower stacked PRs `#22/#23`
  - broader UI polish or a full design pass for camp/maze presentation

### Key Changes

- updated `places/maze/default.project.json` so the maze place now includes `StarterPlayerScripts`
- added `MazeClient.client.luau` with a minimal HUD for phase, objective, inventory, crew activity, and returned summaries
- updated `MazeSessionService` to send `RunSnapshot` / `PrivateState` events from inside the maze place and keep them refreshed on status changes and a lightweight snapshot loop
- extended `MazeWorldBuilder` with nearest-room lookup so the HUD can show a readable room label

### Validation

- `stylua --check .`: pass
- `selene .`: pass
- `rojo build places/maze/default.project.json -o /tmp/maze_place_issue19.rbxlx`: pass
- `rojo build tests/default.project.json -o /tmp/roblox_experience_tests_issue19.rbxlx`: pass

### Known Unrelated Failures

- `run-in-roblox` is still not installed locally, so the authoritative Studio runner could not be executed
- full visual verification of the maze HUD still requires opening the dedicated maze place in Studio and walking through deploy / loot / return / settlement manually
- this PR is intentionally stacked on `#23`; the full `#19` acceptance depends on the lower stack for camp HUD and deterministic test coverage

### Risks and Rollback

- 主要风险：maze-side snapshot cadence now depends on the same remote names as camp, so stale or malformed payloads would surface directly in the new HUD
- 监控点：HUD 在 direct boot 与 camp-entered 两种模式下都能更新、early return 后 roster/returned summaries 同步正确、settlement 后 phase/status 及时收敛
- 回滚思路：revert commit `0fc2c54`

### Related Issues

- Related to #14
- Related to #17
- Related to #18

Refs #19
