### PR TITLE
[Run] Delay first-person lock until camp launch

### DIFF
--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -10,16 +10,20 @@ local UI = require(Packages:WaitForChild('UI'))
 
 local Remotes = Shared.Network.Remotes.ensure()
 local Theme = UI.Hud.Theme
-local firstPersonLockStarted = false
 
-local function ensureFirstPersonLock()
-    if firstPersonLockStarted then
-        return
-    end
-
-    Shared.Client.FirstPersonController.start(localPlayer)
-    firstPersonLockStarted = true
+local disconnectFirstPersonLock
+local ensureFirstPersonLock
+ensureFirstPersonLock = function()
+    disconnectFirstPersonLock = Shared.Client.FirstPersonController.start(localPlayer)
+    ensureFirstPersonLock = function() end
 end
+
+script.Destroying:Connect(function()
+    if disconnectFirstPersonLock ~= nil then
+        disconnectFirstPersonLock()
+        disconnectFirstPersonLock = nil
+    end
+end)
 
 local screenGui = Instance.new('ScreenGui')
 screenGui.Name = 'RunHud'


### PR DESCRIPTION
### Summary

- delay `FirstPersonController` activation in run client until the camp has actually launched (`snapshot.IsLaunched == true`)
- keep the first-person-only gameplay behavior after launch, while making the start menu phase cursor-friendly

### Scope

- In scope:
  - run client first-person activation timing
- Out of scope:
  - camera policy changes in lobby/maze
  - any teleport/session flow changes

### Key Changes

- `places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau`
  - replace eager `FirstPersonController.start(localPlayer)` call with lazy `ensureFirstPersonLock()`
  - invoke `ensureFirstPersonLock()` only after run is launched

### Validation

- `stylua --check .`: pass
- `selene .`: pass

### Risks and Rollback

- Main risk: none beyond timing changes in run menu stage.
- Monitoring: verify menu cursor is usable before launch and camera still locks first-person after launch.
- Rollback: revert commit `69ef299`
