### PR TITLE
[Camp] Support toggling Camp Status with C shortcut

### DIFF
--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -16,6 +16,8 @@ local Theme = UI.Hud.Theme
 local disconnectFirstPersonLock
 local ensureFirstPersonLock
 local canRequestMazeEntry = false
+local isRunLaunched = false
+local isCampPanelVisible = true
 local actionInputConnection
 local sprintInputEndedConnection
 local isMenuMouseUnlockBound = false
@@ -243,7 +245,7 @@ objectiveLabel.Text = 'Objective: --'
 
 local guideLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 60), Theme.Text, 16, false)
 guideLabel.Text =
-    'In-world prompts:\n- Shop Terminal (Soon)\n- Loadout Bench (Soon)\n- Camp Gate / Shared Maze Gate\nKeyboard: Hold LeftShift to sprint'
+    'In-world prompts:\n- Shop Terminal (Soon)\n- Loadout Bench (Soon)\n- Camp Gate / Shared Maze Gate\nKeyboard: Hold LeftShift to sprint, tap C to toggle Camp Status'
 
 local playerStateLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 86), Theme.Warning, 16, false)
 playerStateLabel.Text = 'Health: --\nStamina: --\nState: --\nControls: --'
@@ -253,6 +255,10 @@ rosterLabel.Text = ''
 
 local mazeLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 96), Theme.SubtleText, 16, false)
 mazeLabel.Text = ''
+
+local function syncCampPanelVisibility()
+    panel.Visible = isRunLaunched and isCampPanelVisible
+end
 
 releaseFirstPersonLockForMenu()
 bindMenuMouseUnlock()
@@ -266,7 +272,7 @@ actionInputConnection = UserInputService.InputBegan:Connect(function(input, game
     end
 
     if input.KeyCode == Enum.KeyCode.LeftShift then
-        if panel.Visible then
+        if isRunLaunched then
             Remotes.RunAction:FireServer({
                 Type = 'RequestSprintStart',
             })
@@ -274,7 +280,15 @@ actionInputConnection = UserInputService.InputBegan:Connect(function(input, game
         return
     end
 
-    if input.KeyCode ~= Enum.KeyCode.E or not canRequestMazeEntry then
+    if input.KeyCode == Enum.KeyCode.C then
+        if isRunLaunched then
+            isCampPanelVisible = not isCampPanelVisible
+            syncCampPanelVisibility()
+        end
+        return
+    end
+
+    if input.KeyCode ~= Enum.KeyCode.E or not isRunLaunched or not canRequestMazeEntry then
         return
     end
 
@@ -288,7 +302,7 @@ sprintInputEndedConnection = UserInputService.InputEnded:Connect(function(input,
         return
     end
 
-    if input.KeyCode ~= Enum.KeyCode.LeftShift or not panel.Visible then
+    if input.KeyCode ~= Enum.KeyCode.LeftShift or not isRunLaunched then
         return
     end
 
@@ -313,9 +327,13 @@ end)
 
 Remotes.RunSnapshot.OnClientEvent:Connect(function(snapshot)
     local hasLaunched = snapshot.IsLaunched == true
+    isRunLaunched = hasLaunched
+    if not hasLaunched then
+        isCampPanelVisible = true
+    end
 
     menuBackdrop.Visible = not hasLaunched
-    panel.Visible = hasLaunched
+    syncCampPanelVisibility()
 
     if not hasLaunched then
         releaseFirstPersonLockForMenu()


### PR DESCRIPTION
## Summary

- add a local HUD visibility toggle for the run-place `Camp Status` panel on `C`
- keep sprint and maze-entry inputs active while the panel is hidden by tracking run launch state separately from panel visibility
- update the panel help text so players can discover the new shortcut in-game

## Roblox Integration Checklist

- [x] The change updates the active runtime source under `packages/**`, or I explained why another source path had to change.
- [x] If Studio tree structure changed, I updated the relevant `default.project.json` in the same PR.
- [x] If I changed Remote names, replicated schema, or visibility behavior, I updated all linked producers/consumers/tests in the same PR.
- [x] If I changed non-trivial shared/gameplay behavior, I added or updated deterministic coverage under `tests/src/Shared`, or I explained why no test change was needed.
- [x] If I touched `SessionConfig.PlaceIds` or any other real-environment configuration, I documented the required rollout or environment follow-up.
- [x] If this PR includes `.rbxl`, generated output, or other non-source artifacts, I explained why they are required.

Notes:
- This PR only changes `/places/run` client HUD/input handling; it does not touch shared/gameplay contracts, Rojo tree wiring, remotes, config, or generated artifacts.
- No deterministic shared test was added because the change is a local client HUD shortcut rather than shared/gameplay logic.

## Validation

- [x] `stylua --check .`
- [x] `selene .`
- [x] Additional verification steps are listed below if this PR needs more than static checks.

Additional verification:
- Manual Studio verification still recommended: launch run, press `C` to hide/show `Camp Status`, confirm `LeftShift` sprint and `E` maze entry still work while the panel is hidden.
- I attempted a local `rojo build places/run/default.project.json -o <tmp>` check, but it did not return a usable result in this shell session; no Rojo project wiring changed in this PR.

## Notes

- Manual test notes: not run in Studio in this session.
- Risks / follow-ups: low risk because the change is isolated to local run-place HUD visibility, but keyboard-path regression should be spot-checked in Studio before merge.

Closes #67