### PR TITLE
fix(session): set live place defaults and Studio fallback

### DIFF
--- a/packages/shared/src/Config/SessionConfig.luau
+++ b/packages/shared/src/Config/SessionConfig.luau
@@ -2,8 +2,10 @@ local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local DEFAULT_PLACE_IDS = {
     Lobby = 0,
-    Maze = 0,
-    Run = 0,
+    -- Production defaults for this universe. Can be overridden via attributes
+    -- on `game` or `ReplicatedStorage` (SessionPlaceId*).
+    Maze = 114148445477110,
+    Run = 86424182464617,
 }
 local DEFAULT_DEBUG_LOCAL_MAZE_HANDOFF = false
 

--- a/packages/shared/src/Session/MazeEntryAvailability.luau
+++ b/packages/shared/src/Session/MazeEntryAvailability.luau
@@ -9,6 +9,7 @@ MazeEntryAvailability.Mode = {
 MazeEntryAvailability.ReasonCode = {
     TeleportReady = 'TeleportReady',
     LocalDebugFallbackEnabled = 'LocalDebugFallbackEnabled',
+    StudioLocalFileAutoFallback = 'StudioLocalFileAutoFallback',
     MazePlaceIdMissing = 'MazePlaceIdMissing',
     StudioLocalFileTeleportBlocked = 'StudioLocalFileTeleportBlocked',
 }
@@ -21,19 +22,23 @@ function MazeEntryAvailability.evaluate(params)
     local gameId = type(params.GameId) == 'number' and params.GameId or 0
     local debugLocalMazeHandoff = params.DebugLocalMazeHandoff == true
 
-    if isStudio and (placeId <= 0 or gameId <= 0) then
-        if debugLocalMazeHandoff then
-            return {
-                Mode = MazeEntryAvailability.Mode.LocalDebugFallback,
-                ReasonCode = MazeEntryAvailability.ReasonCode.LocalDebugFallbackEnabled,
-                Reason = 'Studio local debug fallback is enabled. Maze entry stays in the current place for MVP testing.',
-            }
-        end
-
+    -- In Studio we sometimes want to iterate on the maze flow without relying on
+    -- cross-place teleports (which can fail when place IDs are misconfigured,
+    -- unpublished, or in a different universe). This flag forces the in-place
+    -- fallback even when the current place has real PlaceId/GameId.
+    if isStudio and debugLocalMazeHandoff then
         return {
-            Mode = MazeEntryAvailability.Mode.Blocked,
-            ReasonCode = MazeEntryAvailability.ReasonCode.StudioLocalFileTeleportBlocked,
-            Reason = 'Maze teleport requires a published run place session (placeId and gameId must be non-zero).',
+            Mode = MazeEntryAvailability.Mode.LocalDebugFallback,
+            ReasonCode = MazeEntryAvailability.ReasonCode.LocalDebugFallbackEnabled,
+            Reason = 'Studio local debug fallback is enabled. Maze entry stays in the current place for MVP testing.',
+        }
+    end
+
+    if isStudio and (placeId <= 0 or gameId <= 0) then
+        return {
+            Mode = MazeEntryAvailability.Mode.LocalDebugFallback,
+            ReasonCode = MazeEntryAvailability.ReasonCode.StudioLocalFileAutoFallback,
+            Reason = 'Studio local-file sessions automatically use the in-place maze fallback because teleport targets are unpublished.',
         }
     end
 

--- a/tests/src/Shared/MazeEntryAvailability.spec.luau
+++ b/tests/src/Shared/MazeEntryAvailability.spec.luau
@@ -45,7 +45,45 @@ return function()
         'Local debug fallback should expose the expected reason code'
     )
 
-    local blockedStudioLocalFile = availability.evaluate({
+    local studioPublishedFallback = availability.evaluate({
+        PlaceIds = {
+            Lobby = 1,
+            Run = 2,
+            Maze = 3,
+        },
+        PlaceId = 2,
+        GameId = 99,
+        IsStudio = true,
+        DebugLocalMazeHandoff = true,
+    })
+
+    assert(
+        studioPublishedFallback.Mode == availability.Mode.LocalDebugFallback,
+        'Studio should allow local debug fallback even when PlaceId/GameId are set'
+    )
+    assert(
+        studioPublishedFallback.ReasonCode == availability.ReasonCode.LocalDebugFallbackEnabled,
+        'Studio local debug fallback should expose the expected reason code'
+    )
+
+    local studioPublishedFallbackWithoutMazePlaceId = availability.evaluate({
+        PlaceIds = {
+            Lobby = 1,
+            Run = 2,
+            Maze = 0,
+        },
+        PlaceId = 2,
+        GameId = 99,
+        IsStudio = true,
+        DebugLocalMazeHandoff = true,
+    })
+
+    assert(
+        studioPublishedFallbackWithoutMazePlaceId.Mode == availability.Mode.LocalDebugFallback,
+        'Studio debug fallback should not require a maze place id'
+    )
+
+    local autoFallbackStudioLocalFile = availability.evaluate({
         PlaceIds = {
             Lobby = 1,
             Run = 2,
@@ -58,12 +96,13 @@ return function()
     })
 
     assert(
-        blockedStudioLocalFile.Mode == availability.Mode.Blocked,
-        'Studio local-file mode should block teleport when debug flag is disabled'
+        autoFallbackStudioLocalFile.Mode == availability.Mode.LocalDebugFallback,
+        'Studio local-file mode should auto-fallback when teleport targets are unpublished'
     )
     assert(
-        blockedStudioLocalFile.ReasonCode == availability.ReasonCode.StudioLocalFileTeleportBlocked,
-        'Studio local-file block should expose the expected reason code'
+        autoFallbackStudioLocalFile.ReasonCode
+            == availability.ReasonCode.StudioLocalFileAutoFallback,
+        'Studio local-file auto-fallback should expose the expected reason code'
     )
 
     local blockedMissingPlaceId = availability.evaluate({

--- a/tests/src/Shared/SessionConfig.spec.luau
+++ b/tests/src/Shared/SessionConfig.spec.luau
@@ -6,6 +6,8 @@ return function()
     assert(type(config.PlaceIds.Lobby) == 'number', 'Lobby place id should always be numeric')
     assert(type(config.PlaceIds.Maze) == 'number', 'Maze place id should always be numeric')
     assert(type(config.PlaceIds.Run) == 'number', 'Run place id should always be numeric')
+    assert(config.PlaceIds.Maze > 0, 'Maze place id default should point at the live maze place')
+    assert(config.PlaceIds.Run > 0, 'Run place id default should point at the live run place')
     assert(
         type(config.DebugLocalMazeHandoff) == 'boolean',
         'DebugLocalMazeHandoff should always be boolean'


### PR DESCRIPTION
## What
- set production default place ids for run and maze in SessionConfig
- auto-fallback to in-place maze flow for Studio local-file sessions
- expand shared specs to cover published Studio fallback and live place-id defaults

## Why
- the current dirty worktree was based on an older branch, so this PR only extracts the safe session/config changes that are still forward-moving against main
- this keeps place configuration and Studio fallback behavior isolated from the run->maze teleport modernization PR

## Validation
- `stylua --check packages/shared/src/Config/SessionConfig.luau packages/shared/src/Session/MazeEntryAvailability.luau tests/src/Shared/MazeEntryAvailability.spec.luau tests/src/Shared/SessionConfig.spec.luau`
- `rojo build tests/default.project.json -o /tmp/roblox_experience_pr3/tests.rbxlx`
- `run-in-roblox --place /tmp/roblox_experience_pr3/tests.rbxlx --script tests/run-in-roblox.lua`