### PR TITLE
refactor(contract): isolate place handoff boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,14 @@ data contract explicit first.
   relevant `default.project.json` file in the same change.
 - Keep cross-place reuse in `packages/**`; do not copy logic between
   `places/lobby` and `places/run`.
+- Treat place delivery as four lines: `lobby`, `run`, `maze`, and `contract`.
+  The `contract` line owns cross-place handoffs, shared remote definitions, and
+  deterministic tests.
+- Keep cross-place teleports inside place-local portal adapter modules. Do not
+  inline new teleport payload shaping or `TeleportService` orchestration in the
+  main service flow when a portal adapter can own it.
+- Use place-scoped remotes for place-local HUD/runtime state. Do not reuse a
+  run-only or maze-only state channel in another place.
 - Do not commit placeholder production behavior silently. If a change depends on
   real place ids, call out `SessionConfig.PlaceIds` requirements in the PR or
   task note.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,23 @@ The current Rojo project files point at `packages/**`, including:
 If a document or comment disagrees with those project files, trust the project
 files first.
 
+## Parallel Place Workflow
+
+Use these long-lived delivery lines for multi-place work:
+
+- `lobby`
+- `run`
+- `maze`
+- `contract`
+
+The `contract` line owns cross-place teleport payloads, shared remote names,
+session handoff records, and the deterministic tests that lock those contracts.
+Place lines should stay focused on their own `places/<name>/**` content plus
+their local portal adapter.
+
+For the full ownership and worktree layout, see
+`references/place-parallel-development.md`.
+
 ## Local Validation
 
 These checks are the default local baseline:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ Roblox game skeleton for a multi-place experience:
 - `packages/ui`: lightweight UI helpers for the first vertical slice
 - `DevPackages`: Wally-generated third-party dependencies, kept separate from repo-owned source
 
+## Place Delivery Lines
+
+Parallel work on the experience is split into four long-lived lines:
+
+- `lobby`
+- `run`
+- `maze`
+- `contract`
+
+Use one worktree per line so place content stays isolated and cross-place
+handoff changes stay on the `contract` line. See
+`references/place-parallel-development.md` for ownership, worktree commands,
+merge order, and validation rules.
+
 ## Local Setup And Startup
 
 ### One-Click Windows Start

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,6 +12,19 @@
 - `packages/ui`: 首个垂直切片使用的轻量 UI 辅助
 - `DevPackages`: 由 Wally 生成的第三方依赖，与仓库自有源码分离
 
+## Place 开发线
+
+多 place 并行开发固定使用 4 条长期线：
+
+- `lobby`
+- `run`
+- `maze`
+- `contract`
+
+建议每条线使用一个独立 worktree，这样关卡内容和跨 place handoff 契约可以分开演进。
+具体 ownership、worktree 命令、合并顺序和验证规则见
+`references/place-parallel-development.md`。
+
 ## 本地启动与开发
 
 ### Windows 一键启动

--- a/packages/shared/src/Network/Remotes.luau
+++ b/packages/shared/src/Network/Remotes.luau
@@ -1,14 +1,40 @@
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
-local REMOTE_NAMES = {
+local Remotes = {}
+
+Remotes.Scope = table.freeze({
+    Lobby = 'Lobby',
+    Run = 'Run',
+    Maze = 'Maze',
+})
+
+local REMOTE_NAMES_BY_SCOPE = table.freeze({
+    [Remotes.Scope.Lobby] = {
+        'LobbyAction',
+        'LobbyState',
+    },
+    [Remotes.Scope.Run] = {
+        'RunAction',
+        'RunState',
+        'RunPrivateState',
+    },
+    [Remotes.Scope.Maze] = {
+        'MazeAction',
+        'MazeState',
+        'MazePrivateState',
+    },
+})
+
+local ALL_REMOTE_NAMES = {
     'LobbyAction',
     'LobbyState',
-    'PrivateState',
     'RunAction',
-    'RunSnapshot',
+    'RunState',
+    'RunPrivateState',
+    'MazeAction',
+    'MazeState',
+    'MazePrivateState',
 }
-
-local Remotes = {}
 
 local function ensureContainer()
     local container = ReplicatedStorage:FindFirstChild('Remotes')
@@ -38,7 +64,23 @@ function Remotes.ensure()
     local container = ensureContainer()
     local resolved = {}
 
-    for _, name in ipairs(REMOTE_NAMES) do
+    for _, name in ipairs(ALL_REMOTE_NAMES) do
+        resolved[name] = ensureRemote(container, name)
+    end
+
+    return resolved
+end
+
+function Remotes.ensureScope(scope)
+    local remoteNames = REMOTE_NAMES_BY_SCOPE[scope]
+    if remoteNames == nil then
+        error(string.format('Unknown remote scope %q', tostring(scope)), 0)
+    end
+
+    local container = ensureContainer()
+    local resolved = {}
+
+    for _, name in ipairs(remoteNames) do
         resolved[name] = ensureRemote(container, name)
     end
 

--- a/packages/shared/src/Session/CampMazeSessionContract.luau
+++ b/packages/shared/src/Session/CampMazeSessionContract.luau
@@ -225,7 +225,7 @@ function CampMazeSessionContract.applyReturn(session, summary, mazeCompleted)
     return nextSession
 end
 
-function CampMazeSessionContract.buildLobbyToCampTeleportData(params)
+function CampMazeSessionContract.buildLobbyToRunTeleportData(params)
     return {
         SessionConfig = cloneTable(params.SessionConfig),
         CampSession = CampMazeSessionContract.newCampSession({
@@ -243,7 +243,11 @@ function CampMazeSessionContract.buildLobbyToCampTeleportData(params)
     }
 end
 
-function CampMazeSessionContract.buildCampToMazeTeleportData(params)
+function CampMazeSessionContract.buildLobbyToCampTeleportData(params)
+    return CampMazeSessionContract.buildLobbyToRunTeleportData(params)
+end
+
+function CampMazeSessionContract.buildRunToMazeTeleportData(params)
     return {
         SessionConfig = cloneTable(params.SessionConfig),
         CampSession = CampMazeSessionContract.normalizeCampSession(params.CampSession),
@@ -257,7 +261,11 @@ function CampMazeSessionContract.buildCampToMazeTeleportData(params)
     }
 end
 
-function CampMazeSessionContract.buildMazeToCampTeleportData(params)
+function CampMazeSessionContract.buildCampToMazeTeleportData(params)
+    return CampMazeSessionContract.buildRunToMazeTeleportData(params)
+end
+
+function CampMazeSessionContract.buildMazeToRunTeleportData(params)
     return {
         SessionConfig = cloneTable(params.SessionConfig),
         CampSession = CampMazeSessionContract.normalizeCampSession(params.CampSession),
@@ -266,6 +274,10 @@ function CampMazeSessionContract.buildMazeToCampTeleportData(params)
             Summaries = cloneArray(params.Summaries),
         },
     }
+end
+
+function CampMazeSessionContract.buildMazeToCampTeleportData(params)
+    return CampMazeSessionContract.buildMazeToRunTeleportData(params)
 end
 
 function CampMazeSessionContract.findReturnSummary(teleportData, userId)

--- a/places/lobby/src/ServerScriptService/Lobby/LobbyRunPortal.luau
+++ b/places/lobby/src/ServerScriptService/Lobby/LobbyRunPortal.luau
@@ -1,0 +1,70 @@
+local HttpService = game:GetService('HttpService')
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local TeleportService = game:GetService('TeleportService')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Shared = require(Packages:WaitForChild('Shared'))
+
+local SessionConfig = Shared.Config.SessionConfig
+local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
+local TeleportDiagnostics = Shared.Util.TeleportDiagnostics
+
+local LobbyRunPortal = {}
+
+function LobbyRunPortal.launch(params)
+    local runTeleportSnapshot = TeleportDiagnostics.captureSnapshot({
+        TargetKey = 'Run',
+        TargetPlaceId = SessionConfig.PlaceIds.Run,
+    })
+
+    local reserved, reserveResult = pcall(function()
+        return TeleportService:ReserveServer(SessionConfig.PlaceIds.Run)
+    end)
+    if not reserved then
+        return {
+            Ok = false,
+            Reason = TeleportDiagnostics.formatFailure(
+                'ReserveServer',
+                reserveResult,
+                runTeleportSnapshot
+            ),
+        }
+    end
+
+    local campAccessCode = reserveResult
+    local sessionId = HttpService:GenerateGUID(false)
+    local teleportData = CampMazeSessionContract.buildLobbyToRunTeleportData({
+        SessionId = sessionId,
+        CampAccessCode = campAccessCode,
+        SessionConfig = params.SessionConfig,
+    })
+
+    local success, message = pcall(function()
+        TeleportService:TeleportToPrivateServer(
+            SessionConfig.PlaceIds.Run,
+            campAccessCode,
+            params.Players,
+            nil,
+            teleportData
+        )
+    end)
+    if not success then
+        return {
+            Ok = false,
+            Reason = TeleportDiagnostics.formatFailure(
+                'TeleportToPrivateServer',
+                message,
+                runTeleportSnapshot
+            ),
+        }
+    end
+
+    return {
+        Ok = true,
+        Status = 'Teleporting crew to run instance...',
+        SessionId = sessionId,
+        CampAccessCode = campAccessCode,
+    }
+end
+
+return LobbyRunPortal

--- a/places/lobby/src/ServerScriptService/Lobby/LobbyService.luau
+++ b/places/lobby/src/ServerScriptService/Lobby/LobbyService.luau
@@ -1,15 +1,13 @@
 local Players = game:GetService('Players')
-local HttpService = game:GetService('HttpService')
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
-local TeleportService = game:GetService('TeleportService')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Shared = require(Packages:WaitForChild('Shared'))
 
 local SessionConfig = Shared.Config.SessionConfig
-local Remotes = Shared.Network.Remotes.ensure()
-local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
-local TeleportDiagnostics = Shared.Util.TeleportDiagnostics
+local Remotes = Shared.Network.Remotes.ensureScope(Shared.Network.Remotes.Scope.Lobby)
+
+local LobbyRunPortal = require(script.Parent.LobbyRunPortal)
 
 local LobbyService = {}
 LobbyService.__index = LobbyService
@@ -90,25 +88,8 @@ function LobbyService:_teleportToRun()
 
     self.Seed = Random.new():NextInteger(100000, 999999)
 
-    local runTeleportSnapshot = TeleportDiagnostics.captureSnapshot({
-        TargetKey = 'Run',
-        TargetPlaceId = SessionConfig.PlaceIds.Run,
-    })
-    local reserved, reserveResult = pcall(function()
-        return TeleportService:ReserveServer(SessionConfig.PlaceIds.Run)
-    end)
-    if not reserved then
-        self.Status =
-            TeleportDiagnostics.formatFailure('ReserveServer', reserveResult, runTeleportSnapshot)
-        self:_broadcast()
-        return
-    end
-
-    local campAccessCode = reserveResult
-    local sessionId = HttpService:GenerateGUID(false)
-    local teleportData = CampMazeSessionContract.buildLobbyToCampTeleportData({
-        SessionId = sessionId,
-        CampAccessCode = campAccessCode,
+    local result = LobbyRunPortal.launch({
+        Players = players,
         SessionConfig = {
             Seed = self.Seed,
             Quota = SessionConfig.DefaultQuota,
@@ -116,28 +97,14 @@ function LobbyService:_teleportToRun()
             InventoryCapacity = SessionConfig.InventoryCapacity,
         },
     })
-
-    self.Status = 'Teleporting crew to run instance...'
-    self:_broadcast()
-
-    local success, message = pcall(function()
-        TeleportService:TeleportToPrivateServer(
-            SessionConfig.PlaceIds.Run,
-            campAccessCode,
-            players,
-            nil,
-            teleportData
-        )
-    end)
-
-    if not success then
-        self.Status = TeleportDiagnostics.formatFailure(
-            'TeleportToPrivateServer',
-            message,
-            runTeleportSnapshot
-        )
+    if not result.Ok then
+        self.Status = result.Reason
         self:_broadcast()
+        return
     end
+
+    self.Status = result.Status
+    self:_broadcast()
 end
 
 function LobbyService:start()

--- a/places/lobby/src/StarterPlayer/StarterPlayerScripts/LobbyClient.client.luau
+++ b/places/lobby/src/StarterPlayer/StarterPlayerScripts/LobbyClient.client.luau
@@ -9,7 +9,7 @@ local Shared = require(Packages:WaitForChild('Shared'))
 local UI = require(Packages:WaitForChild('UI'))
 
 local Theme = UI.Hud.Theme
-local Remotes = Shared.Network.Remotes.ensure()
+local Remotes = Shared.Network.Remotes.ensureScope(Shared.Network.Remotes.Scope.Lobby)
 
 Shared.Client.FirstPersonController.start(localPlayer)
 

--- a/places/maze/src/ServerScriptService/Maze/MazeRunPortal.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeRunPortal.luau
@@ -1,0 +1,59 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local TeleportService = game:GetService('TeleportService')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Shared = require(Packages:WaitForChild('Shared'))
+
+local SessionConfig = Shared.Config.SessionConfig
+local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
+local TeleportDiagnostics = Shared.Util.TeleportDiagnostics
+
+local MazeRunPortal = {}
+
+function MazeRunPortal.returnPlayers(params)
+    local currentSession = CampMazeSessionContract.normalizeCampSession(params.CampSession)
+    local nextCampSession = currentSession
+    for _, summary in ipairs(params.Summaries) do
+        nextCampSession =
+            CampMazeSessionContract.applyReturn(nextCampSession, summary, params.MazeCompleted)
+    end
+
+    local teleportData = CampMazeSessionContract.buildMazeToRunTeleportData({
+        SessionConfig = params.SessionConfig,
+        CampSession = nextCampSession,
+        Summaries = params.Summaries,
+        MazeCompleted = params.MazeCompleted,
+    })
+
+    local runTeleportSnapshot = TeleportDiagnostics.captureSnapshot({
+        TargetKey = 'Run',
+        TargetPlaceId = SessionConfig.PlaceIds.Run,
+    })
+
+    local success, message = pcall(function()
+        TeleportService:TeleportToPrivateServer(
+            SessionConfig.PlaceIds.Run,
+            nextCampSession.CampAccessCode,
+            params.Players,
+            nil,
+            teleportData
+        )
+    end)
+    if not success then
+        return {
+            Ok = false,
+            Reason = TeleportDiagnostics.formatFailure(
+                'TeleportToPrivateServer',
+                message,
+                runTeleportSnapshot
+            ),
+        }
+    end
+
+    return {
+        Ok = true,
+        NextCampSession = nextCampSession,
+    }
+end
+
+return MazeRunPortal

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -1,7 +1,6 @@
 local Players = game:GetService('Players')
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 local RunService = game:GetService('RunService')
-local TeleportService = game:GetService('TeleportService')
 local Workspace = game:GetService('Workspace')
 
 local DEFAULT_WORKSPACE_SHELL_NAMES = { 'Baseplate', 'SpawnLocation' }
@@ -19,7 +18,7 @@ local SharedPackage = Packages:WaitForChild('Shared')
 
 local SessionConfig = Shared.Config.SessionConfig
 local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
-local Remotes = Shared.Network.Remotes.ensure()
+local Remotes = Shared.Network.Remotes.ensureScope(Shared.Network.Remotes.Scope.Maze)
 local InventoryService =
     require(SharedPackage:WaitForChild('Runtime'):WaitForChild('InventoryService'))
 local MonsterService = require(SharedPackage:WaitForChild('Runtime'):WaitForChild('MonsterService'))
@@ -27,6 +26,7 @@ local ControlStateService = Shared.Runtime.ControlStateService
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
 local PlayerStateService = Shared.Runtime.PlayerStateService
 
+local MazeRunPortal = require(script.Parent.MazeRunPortal)
 local MazeWorldBuilder = require(script.Parent.MazeWorldBuilder)
 
 local DEBUG_DAMAGE_BY_ACTION = {
@@ -338,7 +338,7 @@ function MazeSessionService:_broadcastSnapshot()
     local mazeStatus = self:_getMazeStatus()
 
     for _, player in ipairs(Players:GetPlayers()) do
-        self.Remotes.RunSnapshot:FireClient(player, {
+        self.Remotes.MazeState:FireClient(player, {
             IsLaunched = true,
             Status = self.Status,
             Area = self:_getPlayerArea(player),
@@ -356,7 +356,7 @@ function MazeSessionService:_broadcastSnapshot()
             IsDirectBoot = self.IsDirectBoot,
         })
 
-        self.Remotes.PrivateState:FireClient(player, nil)
+        self.Remotes.MazePrivateState:FireClient(player, nil)
     end
 end
 
@@ -444,34 +444,19 @@ function MazeSessionService:_teleportToCamp(players, summaries, mazeCompleted)
 
         -- Teleports yield, so keep the camp-side handoff serialized per maze server.
         local mergedSummaries = mergeSummaries(self.RunTracker:getReturnedSummaries(), summaries)
-        local nextCampSession = self.CampSession
-        for _, summary in ipairs(mergedSummaries) do
-            nextCampSession =
-                CampMazeSessionContract.applyReturn(nextCampSession, summary, mazeCompleted)
-        end
-        local teleportData = CampMazeSessionContract.buildMazeToCampTeleportData({
+        local result = MazeRunPortal.returnPlayers({
+            Players = players,
             SessionConfig = self.SessionData,
-            CampSession = nextCampSession,
+            CampSession = self.CampSession,
             Summaries = mergedSummaries,
             MazeCompleted = mazeCompleted,
         })
-
-        local success, message = pcall(function()
-            TeleportService:TeleportToPrivateServer(
-                SessionConfig.PlaceIds.Run,
-                nextCampSession.CampAccessCode,
-                players,
-                nil,
-                teleportData
-            )
-        end)
-
-        if not success then
-            self:_setStatus(string.format('Camp return failed: %s', tostring(message)))
+        if not result.Ok then
+            self:_setStatus(string.format('Camp return failed: %s', tostring(result.Reason)))
             return false
         end
 
-        self.CampSession = nextCampSession
+        self.CampSession = result.NextCampSession
         return true
     end)
 end
@@ -849,7 +834,7 @@ function MazeSessionService:start()
         self:_broadcastSnapshot()
     end)
 
-    self.Remotes.RunAction.OnServerEvent:Connect(function(player, payload)
+    self.Remotes.MazeAction.OnServerEvent:Connect(function(player, payload)
         if type(payload) ~= 'table' then
             return
         end

--- a/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
+++ b/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
@@ -10,7 +10,7 @@ local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Shared = require(Packages:WaitForChild('Shared'))
 local UI = require(Packages:WaitForChild('UI'))
 
-local Remotes = Shared.Network.Remotes.ensure()
+local Remotes = Shared.Network.Remotes.ensureScope(Shared.Network.Remotes.Scope.Maze)
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
 local Theme = UI.Hud.Theme
 
@@ -102,28 +102,28 @@ actionInputConnection = UserInputService.InputBegan:Connect(function(input, game
     end
 
     if input.KeyCode == Enum.KeyCode.LeftShift then
-        Remotes.RunAction:FireServer({
+        Remotes.MazeAction:FireServer({
             Type = 'RequestSprintStart',
         })
         return
     end
 
     if RunService:IsStudio() and input.KeyCode == Enum.KeyCode.H then
-        Remotes.RunAction:FireServer({
+        Remotes.MazeAction:FireServer({
             Type = 'RequestDebugLightDamage',
         })
         return
     end
 
     if RunService:IsStudio() and input.KeyCode == Enum.KeyCode.J then
-        Remotes.RunAction:FireServer({
+        Remotes.MazeAction:FireServer({
             Type = 'RequestDebugHeavyDamage',
         })
         return
     end
 
     if input.KeyCode == Enum.KeyCode.X then
-        Remotes.RunAction:FireServer({
+        Remotes.MazeAction:FireServer({
             Type = 'RequestUnequipItem',
         })
         return
@@ -144,7 +144,7 @@ actionInputConnection = UserInputService.InputBegan:Connect(function(input, game
         return
     end
 
-    Remotes.RunAction:FireServer({
+    Remotes.MazeAction:FireServer({
         Type = 'RequestEquipItem',
         ItemInstanceId = itemEntry.InstanceId,
     })
@@ -159,7 +159,7 @@ sprintInputEndedConnection = UserInputService.InputEnded:Connect(function(input,
         return
     end
 
-    Remotes.RunAction:FireServer({
+    Remotes.MazeAction:FireServer({
         Type = 'RequestSprintStop',
     })
 end)
@@ -176,11 +176,11 @@ script.Destroying:Connect(function()
     end
 end)
 
-Remotes.PrivateState.OnClientEvent:Connect(function()
+Remotes.MazePrivateState.OnClientEvent:Connect(function()
     -- The first maze HUD does not surface per-player private state yet.
 end)
 
-Remotes.RunSnapshot.OnClientEvent:Connect(function(snapshot)
+Remotes.MazeState.OnClientEvent:Connect(function(snapshot)
     if snapshot.IsLaunched ~= true then
         return
     end

--- a/places/run/src/ServerScriptService/Run/RunMazePortal.luau
+++ b/places/run/src/ServerScriptService/Run/RunMazePortal.luau
@@ -1,0 +1,92 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local TeleportService = game:GetService('TeleportService')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Shared = require(Packages:WaitForChild('Shared'))
+
+local SessionConfig = Shared.Config.SessionConfig
+local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
+local MazeEntryAvailability = Shared.Session.MazeEntryAvailability
+local TeleportDiagnostics = Shared.Util.TeleportDiagnostics
+
+local RunMazePortal = {}
+
+RunMazePortal.FailureCode = table.freeze({
+    ReserveServerFailed = 'ReserveServerFailed',
+    TeleportToPrivateServerFailed = 'TeleportToPrivateServerFailed',
+})
+
+function RunMazePortal.enter(params)
+    local currentSession = CampMazeSessionContract.normalizeCampSession(params.CampSession)
+    local mazeTeleportSnapshot = TeleportDiagnostics.captureSnapshot({
+        TargetKey = 'Maze',
+        TargetPlaceId = SessionConfig.PlaceIds.Maze,
+    })
+
+    local mazeAccessCode = currentSession.MazeAccessCode
+    if mazeAccessCode == nil then
+        local reserved, reserveResult = pcall(function()
+            return TeleportService:ReserveServer(SessionConfig.PlaceIds.Maze)
+        end)
+
+        if not reserved then
+            return {
+                Ok = false,
+                FailureCode = RunMazePortal.FailureCode.ReserveServerFailed,
+                Reason = TeleportDiagnostics.formatFailure(
+                    'ReserveServer',
+                    reserveResult,
+                    mazeTeleportSnapshot
+                ),
+                ReasonCode = RunMazePortal.FailureCode.ReserveServerFailed,
+                CurrentSession = currentSession,
+            }
+        end
+
+        mazeAccessCode = reserveResult
+    end
+
+    local nextSession =
+        CampMazeSessionContract.markPlayerEntered(currentSession, params.EnteringPlayer)
+    nextSession.MazeAccessCode = mazeAccessCode
+    nextSession.GateOpen = params.GateOpen == true
+
+    local teleportData = CampMazeSessionContract.buildRunToMazeTeleportData({
+        SessionConfig = params.SessionConfig,
+        CampSession = nextSession,
+        EnteringPlayer = params.EnteringPlayer,
+        EntryReason = params.EntryReason or 'maze_gate',
+    })
+
+    local success, message = pcall(function()
+        TeleportService:TeleportToPrivateServer(
+            SessionConfig.PlaceIds.Maze,
+            mazeAccessCode,
+            { params.Player },
+            nil,
+            teleportData
+        )
+    end)
+    if not success then
+        return {
+            Ok = false,
+            FailureCode = RunMazePortal.FailureCode.TeleportToPrivateServerFailed,
+            Reason = TeleportDiagnostics.formatFailure(
+                'TeleportToPrivateServer',
+                message,
+                mazeTeleportSnapshot
+            ),
+            ReasonCode = RunMazePortal.FailureCode.TeleportToPrivateServerFailed,
+            CurrentSession = currentSession,
+        }
+    end
+
+    return {
+        Ok = true,
+        NextSession = nextSession,
+        Reason = 'Maze teleport target is ready.',
+        ReasonCode = MazeEntryAvailability.ReasonCode.TeleportReady,
+    }
+end
+
+return RunMazePortal

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -1,22 +1,21 @@
 local Players = game:GetService('Players')
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 local RunService = game:GetService('RunService')
-local TeleportService = game:GetService('TeleportService')
 local Workspace = game:GetService('Workspace')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Shared = require(Packages:WaitForChild('Shared'))
 
 local SessionConfig = Shared.Config.SessionConfig
-local Remotes = Shared.Network.Remotes.ensure()
+local Remotes = Shared.Network.Remotes.ensureScope(Shared.Network.Remotes.Scope.Run)
 local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
 local MazeEntryAvailability = Shared.Session.MazeEntryAvailability
 local ControlStateService = Shared.Runtime.ControlStateService
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
 local PlayerStateService = Shared.Runtime.PlayerStateService
-local TeleportDiagnostics = Shared.Util.TeleportDiagnostics
 
 local LocalDebugMazeWorldBuilder = require(script.Parent.LocalDebugMazeWorldBuilder)
+local RunMazePortal = require(script.Parent.RunMazePortal)
 local RunWorldBuilder = require(script.Parent.RunWorldBuilder)
 
 local RunSessionService = {}
@@ -29,15 +28,6 @@ local MAZE_ENTRY_DISTANCE_BUFFER = 2
 local LOCAL_DEBUG_ROOM_DETECTION_RADIUS = 56
 local LOCAL_DEBUG_MAZE_RETURN_REASON = 'local_debug_return'
 local SNAPSHOT_INTERVAL_SECONDS = 0.25
-
-local TELEPORT_FAILURE_CODE = {
-    ReserveServerFailed = 'ReserveServerFailed',
-    TeleportToPrivateServerFailed = 'TeleportToPrivateServerFailed',
-}
-
-local function formatTeleportFailureReason(step, message, snapshot)
-    return TeleportDiagnostics.formatFailure(step, message, snapshot)
-end
 
 local function bindCharacterTeleport(self, player)
     player.CharacterAdded:Connect(function(character)
@@ -440,7 +430,7 @@ function RunSessionService:_broadcastSnapshot()
     local mazeEntryAvailability = self:_resolveMazeEntryAvailability()
 
     for _, player in ipairs(Players:GetPlayers()) do
-        self.Remotes.RunSnapshot:FireClient(player, {
+        self.Remotes.RunState:FireClient(player, {
             IsLaunched = self.IsLaunched,
             Status = self.Status,
             Area = self:_getPlayerArea(player),
@@ -459,7 +449,7 @@ function RunSessionService:_broadcastSnapshot()
             PlayerState = self.PlayerStateService:getSummary(player),
         })
 
-        self.Remotes.PrivateState:FireClient(player, nil)
+        self.Remotes.RunPrivateState:FireClient(player, nil)
     end
 end
 
@@ -583,86 +573,32 @@ function RunSessionService:_enterMaze(player)
             return
         end
 
-        -- Teleports yield, so keep the camp session mutation serialized per server.
-        local previousSession = CampMazeSessionContract.normalizeCampSession(self.CampSession)
-        local mazeAccessCode = previousSession.MazeAccessCode
-        local mazeTeleportSnapshot = TeleportDiagnostics.captureSnapshot({
-            TargetKey = 'Maze',
-            TargetPlaceId = SessionConfig.PlaceIds.Maze,
-        })
-        if mazeAccessCode == nil then
-            local reserved, reserveResult = pcall(function()
-                return TeleportService:ReserveServer(SessionConfig.PlaceIds.Maze)
-            end)
-
-            if not reserved then
-                local reason = formatTeleportFailureReason(
-                    'ReserveServer',
-                    reserveResult,
-                    mazeTeleportSnapshot
-                )
-                self.MazeEntryMode = MazeEntryAvailability.Mode.Blocked
-                self.MazeEntryReasonCode = TELEPORT_FAILURE_CODE.ReserveServerFailed
-                self.MazeEntryReason = reason
-                self:_setStatus(
-                    string.format('%s could not enter the maze: %s', player.DisplayName, reason)
-                )
-                return
-            end
-
-            mazeAccessCode = reserveResult
-        end
-
-        previousSession.MazeAccessCode = mazeAccessCode
-        previousSession.GateOpen = self.GateOpen
-
-        local nextSession = CampMazeSessionContract.markPlayerEntered(previousSession, {
-            UserId = player.UserId,
-            Name = player.DisplayName,
-        })
-        nextSession.MazeAccessCode = mazeAccessCode
-        nextSession.GateOpen = self.GateOpen
-
-        local teleportData = CampMazeSessionContract.buildCampToMazeTeleportData({
+        local result = RunMazePortal.enter({
+            Player = player,
+            CampSession = self.CampSession,
+            GateOpen = self.GateOpen,
             SessionConfig = self.SessionData,
-            CampSession = nextSession,
             EnteringPlayer = {
                 UserId = player.UserId,
                 Name = player.DisplayName,
             },
             EntryReason = 'maze_gate',
         })
-
-        local success, message = pcall(function()
-            TeleportService:TeleportToPrivateServer(
-                SessionConfig.PlaceIds.Maze,
-                mazeAccessCode,
-                { player },
-                nil,
-                teleportData
-            )
-        end)
-
-        if not success then
-            self.CampSession = previousSession
-            local reason = formatTeleportFailureReason(
-                'TeleportToPrivateServer',
-                message,
-                mazeTeleportSnapshot
-            )
+        if not result.Ok then
+            self.CampSession = result.CurrentSession or self.CampSession
             self.MazeEntryMode = MazeEntryAvailability.Mode.Blocked
-            self.MazeEntryReasonCode = TELEPORT_FAILURE_CODE.TeleportToPrivateServerFailed
-            self.MazeEntryReason = reason
+            self.MazeEntryReasonCode = result.ReasonCode or result.FailureCode
+            self.MazeEntryReason = result.Reason
             self:_setStatus(
-                string.format('%s could not enter the maze: %s', player.DisplayName, reason)
+                string.format('%s could not enter the maze: %s', player.DisplayName, result.Reason)
             )
             return
         end
 
         self.MazeEntryMode = MazeEntryAvailability.Mode.Teleport
-        self.MazeEntryReasonCode = MazeEntryAvailability.ReasonCode.TeleportReady
-        self.MazeEntryReason = 'Maze teleport target is ready.'
-        self.CampSession = nextSession
+        self.MazeEntryReasonCode = result.ReasonCode
+        self.MazeEntryReason = result.Reason
+        self.CampSession = result.NextSession
         self:_setStatus(string.format('%s is entering the shared maze run.', player.DisplayName))
     end)
 end

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -10,7 +10,7 @@ local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Shared = require(Packages:WaitForChild('Shared'))
 local UI = require(Packages:WaitForChild('UI'))
 
-local Remotes = Shared.Network.Remotes.ensure()
+local Remotes = Shared.Network.Remotes.ensureScope(Shared.Network.Remotes.Scope.Run)
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
 local Theme = UI.Hud.Theme
 
@@ -322,11 +322,11 @@ singlePlayerButton.MouseButton1Click:Connect(function()
     })
 end)
 
-Remotes.PrivateState.OnClientEvent:Connect(function()
+Remotes.RunPrivateState.OnClientEvent:Connect(function()
     -- Private role data is intentionally unused in the camp staging run.
 end)
 
-Remotes.RunSnapshot.OnClientEvent:Connect(function(snapshot)
+Remotes.RunState.OnClientEvent:Connect(function(snapshot)
     local hasLaunched = snapshot.IsLaunched == true
     isRunLaunched = hasLaunched
     if not hasLaunched then

--- a/references/place-parallel-development.md
+++ b/references/place-parallel-development.md
@@ -1,0 +1,71 @@
+# Place Parallel Development
+
+This repository uses four long-lived delivery lines for the multi-place
+experience:
+
+- `lobby`
+- `run`
+- `maze`
+- `contract`
+
+## Ownership
+
+- `lobby` owns `places/lobby/**` and the local adapter that launches into run.
+- `run` owns `places/run/**` and the local adapter that enters maze or accepts
+  maze returns.
+- `maze` owns `places/maze/**` and the local adapter that returns players to run.
+- `contract` owns cross-place handoff definitions under:
+  - `packages/shared/src/Session/**`
+  - `packages/shared/src/Network/**`
+  - `packages/shared/src/Config/SessionConfig.luau`
+  - `tests/src/Shared/**`
+
+## Hard Boundaries
+
+- Place branches do not change teleport payload shape, return summary shape, or
+  shared remote names.
+- Shared handoff changes land in `contract` first, then each place rebases onto
+  that baseline.
+- Each place uses place-scoped remotes:
+  - lobby: `LobbyAction`, `LobbyState`
+  - run: `RunAction`, `RunState`, `RunPrivateState`
+  - maze: `MazeAction`, `MazeState`, `MazePrivateState`
+- Cross-place teleports must go through place-local portal adapters instead of
+  being inlined directly inside service orchestration code.
+
+## Recommended Worktree Layout
+
+Create sibling worktrees next to the main repository:
+
+```bash
+git worktree add ../roblox_experience-lobby lobby
+git worktree add ../roblox_experience-run run
+git worktree add ../roblox_experience-maze maze
+git worktree add -b contract ../roblox_experience-contract origin/main
+```
+
+The main repository worktree can stay on an unrelated feature branch. Use the
+dedicated worktree for the line you are changing.
+
+## Merge Order
+
+1. Land the shared `contract` baseline.
+2. Rebase `lobby`, `run`, and `maze` onto that baseline.
+3. Land place-local PRs independently.
+4. For any later handoff change, repeat the same order: contract first, then
+   place adapters and consumers.
+
+## Validation
+
+For contract changes:
+
+1. `stylua --check .`
+2. `selene .`
+3. `rojo build tests/default.project.json -o <output.rbxlx>`
+4. `run-in-roblox --place <output.rbxlx> --script tests/run-in-roblox.lua`
+
+For place-local changes, also build the relevant place project:
+
+- `rojo build places/lobby/default.project.json -o <output.rbxlx>`
+- `rojo build places/run/default.project.json -o <output.rbxlx>`
+- `rojo build places/maze/default.project.json -o <output.rbxlx>`

--- a/tests/src/Shared/CampMazeSessionContract.spec.luau
+++ b/tests/src/Shared/CampMazeSessionContract.spec.luau
@@ -25,7 +25,19 @@ return function()
     )
     assert(#entered.PlayersInMaze == 1, 'Entering should track the player inside the maze')
 
-    local campToMaze = contract.buildCampToMazeTeleportData({
+    local lobbyToRun = contract.buildLobbyToRunTeleportData({
+        SessionId = 'camp-session-1',
+        CampAccessCode = 'camp-access-code',
+        SessionConfig = {
+            Seed = 12345,
+        },
+    })
+    assert(
+        lobbyToRun.Entry.Kind == 'LobbyLaunch',
+        'Lobby -> run teleport payload should mark the handoff entry kind'
+    )
+
+    local campToMaze = contract.buildRunToMazeTeleportData({
         SessionConfig = {
             Seed = 12345,
             Quota = 120,
@@ -139,7 +151,7 @@ return function()
         'Completed maze sessions should not retain active maze players'
     )
 
-    local mazeToCamp = contract.buildMazeToCampTeleportData({
+    local mazeToCamp = contract.buildMazeToRunTeleportData({
         SessionConfig = {
             Seed = 12345,
             Quota = 120,

--- a/tests/src/Shared/Remotes.spec.luau
+++ b/tests/src/Shared/Remotes.spec.luau
@@ -15,9 +15,12 @@ return function()
     local expectedNames = {
         'LobbyAction',
         'LobbyState',
-        'PrivateState',
         'RunAction',
-        'RunSnapshot',
+        'RunState',
+        'RunPrivateState',
+        'MazeAction',
+        'MazeState',
+        'MazePrivateState',
     }
 
     for _, name in ipairs(expectedNames) do
@@ -32,11 +35,19 @@ return function()
 
     local repeatedEnsure = shared.Network.Remotes.ensure()
     assert(
-        repeatedEnsure.RunSnapshot == remotes.RunSnapshot,
+        repeatedEnsure.RunState == remotes.RunState,
         'ensure should be idempotent for existing remotes'
     )
     assert(
         #container:GetChildren() == #expectedNames,
         'ensure should not duplicate remotes on repeated calls'
+    )
+
+    local mazeScoped = shared.Network.Remotes.ensureScope(shared.Network.Remotes.Scope.Maze)
+    assert(mazeScoped.MazeAction == remotes.MazeAction, 'Maze scope should reuse MazeAction')
+    assert(mazeScoped.MazeState == remotes.MazeState, 'Maze scope should reuse MazeState')
+    assert(
+        mazeScoped.MazePrivateState == remotes.MazePrivateState,
+        'Maze scope should reuse MazePrivateState'
     )
 end


### PR DESCRIPTION
## What changed
- split shared remotes into place-scoped channels for lobby, run, and maze
- extract cross-place teleport orchestration into local portal adapters for each place
- document the 4-line workflow (`lobby` / `run` / `maze` / `contract`) and worktree strategy
- extend shared tests to lock the new remote map and handoff builders

## Why
- reduce cross-place handoff drift by keeping teleport payloads and remote names on the `contract` line
- stop `run` and `maze` from sharing one state channel with incompatible UI/runtime concerns
- make each place branch consume a stable contract baseline before local level work starts

## Validation
- `stylua --check .`
- `selene .`
- `rojo build places/lobby/default.project.json -o /tmp/roblox_experience-lobby.rbxlx`
- `rojo build places/run/default.project.json -o /tmp/roblox_experience-run.rbxlx`
- `rojo build places/maze/default.project.json -o /tmp/roblox_experience-maze.rbxlx`
- `rojo build tests/default.project.json -o /tmp/roblox_experience-tests-contract.rbxlx`
- `run-in-roblox --place /tmp/roblox_experience-tests-contract.rbxlx --script tests/run-in-roblox.lua`
