### PR TITLE
merge: sync main into maze after skill system

### DIFF
--- a/.claude/skills/cross-vibe-pr-review/SKILL.md
+++ b/.claude/skills/cross-vibe-pr-review/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: cross-vibe-pr-review
+description: Review a pull request in this Roblox repo with a cross-vibe mindset. Use when a PR may touch contract plus place-local consumers, or when the merge target and sync story need to be explained clearly.
+context: fork
+agent: Plan
+disable-model-invocation: true
+argument-hint: "[pr-number-or-url]"
+allowed-tools: Read, Grep, Glob, Bash(gh *), Bash(git *), Bash(rg *)
+---
+
+Review PR $ARGUMENTS with findings first.
+
+Read references only as needed:
+
+- `references/review-checklist.md` for the full review checklist and merge-story rules
+- `references/pr-95-case.md` for the onboarding example based on issue `#34` and PR `#95`
+
+## Gather context
+
+Collect:
+
+- `gh pr view`
+- `gh pr diff --name-only`
+- `gh pr diff` when needed
+- `git fetch origin` if branch freshness matters
+
+Read the touched vibe's `VIBE.md` first and `NOW.md` second.
+
+## Review focus
+
+Look for:
+
+- contract drift between producers, consumers, and tests
+- teleport or join lifecycle regressions
+- replicated snapshot mismatches
+- run versus maze ownership mistakes
+- missing validation for shared gameplay changes
+- incorrect statements about landing on multiple long-lived branches at once
+
+## Output
+
+Return:
+
+1. Findings
+2. Open Questions / Assumptions
+3. Summary
+
+Follow the detailed output and merge-story rules in `references/review-checklist.md`.
+
+If there are no blocking findings, say exactly `No blocking findings.`

--- a/.claude/skills/cross-vibe-pr-review/references/pr-95-case.md
+++ b/.claude/skills/cross-vibe-pr-review/references/pr-95-case.md
@@ -1,0 +1,12 @@
+# PR 95 Case
+
+PR `#95` is the baseline cross-vibe review example.
+
+Why:
+
+- it changes `contract`
+- it changes `run`
+- it changes `maze`
+- it still lands on one target branch: `main`
+
+Use it to teach that cross-vibe review does not mean multi-target merge.

--- a/.claude/skills/cross-vibe-pr-review/references/review-checklist.md
+++ b/.claude/skills/cross-vibe-pr-review/references/review-checklist.md
@@ -1,0 +1,28 @@
+# Review Checklist
+
+## Setup
+
+1. Read PR metadata.
+2. Read changed files.
+3. Read diff when needed.
+4. Fetch base branch if freshness matters.
+5. Map files to vibe domains.
+
+## Review Questions
+
+- Did contract meaning change?
+- Were producers, consumers, and tests updated together?
+- Did the PR change teleport or join lifecycle behavior?
+- Did validation match the touched area?
+- Does the write-up correctly say the PR lands on `main` first?
+
+## Output Rules
+
+- Findings first
+- Severity ordered
+- Separate code issues from merge-process notes
+- Say `No blocking findings.` when appropriate
+
+## Plan Mode Note
+
+Use the planning agent first to align the review surface.

--- a/.claude/skills/roblox-vibe-issue-to-draft-pr/SKILL.md
+++ b/.claude/skills/roblox-vibe-issue-to-draft-pr/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: roblox-vibe-issue-to-draft-pr
+description: Implement a GitHub issue in this Roblox repo using the vibe workflow and stop at a draft PR to main. Use for issue-driven implementation that should end in validated code, a pushed branch, and a draft PR.
+disable-model-invocation: true
+argument-hint: "[issue-number-or-url]"
+---
+
+Implement issue $ARGUMENTS in this repository and stop at a draft PR.
+
+Read references only as needed:
+
+- `references/execution-checklist.md` for the full execution order
+- `references/issue-34-case.md` for the onboarding example based on issue `#34` and PR `#95`
+
+## Start here
+
+Read:
+
+- `AGENTS.md`
+- `references/place-parallel-development.md`
+- the owning `VIBE.md` first and `NOW.md` second
+
+Route the issue before coding. If it changes cross-place handoff semantics, make the contract change explicit and update the matching tests.
+
+## Branching rules
+
+- Use a feature branch off `main` when one integration PR is the right delivery vehicle.
+- Land the draft PR on `main`.
+- Do not silently sync `main` back into `run`, `maze`, `lobby`, or `contract`.
+
+## Validation
+
+Run the checks that match the touched area:
+
+1. `stylua --check` on touched files
+2. `selene .`
+3. `rojo build` for affected place projects
+4. test project build plus `run-in-roblox` when shared or gameplay logic changes
+
+## Draft PR requirements
+
+Use the PR structure in `references/execution-checklist.md`.
+
+End the PR body with `Closes #<issue-number>`.
+
+Do not merge.

--- a/.claude/skills/roblox-vibe-issue-to-draft-pr/references/execution-checklist.md
+++ b/.claude/skills/roblox-vibe-issue-to-draft-pr/references/execution-checklist.md
@@ -1,0 +1,21 @@
+# Execution Checklist
+
+1. Read `AGENTS.md`.
+2. Read `references/place-parallel-development.md`.
+3. Route the issue before coding.
+4. Read the owner `VIBE.md` and `NOW.md`.
+5. Branch from `main`.
+6. Implement the smallest end-to-end slice.
+7. Update contract producers, consumers, and tests together when shared meaning changes.
+8. Run validation.
+9. Push.
+10. Open a draft PR to `main`.
+
+## PR Body Sections
+
+- `Summary`
+- `Why This Lives In <vibe or cross-vibe>`
+- `Scope`
+- `Validation`
+- `Risks / Follow-Up`
+- final line: `Closes #<issue-number>`

--- a/.claude/skills/roblox-vibe-issue-to-draft-pr/references/issue-34-case.md
+++ b/.claude/skills/roblox-vibe-issue-to-draft-pr/references/issue-34-case.md
@@ -1,0 +1,12 @@
+# Issue 34 To PR 95 Case
+
+- Issue: `#34`
+- PR: `#95`
+- Base: `main`
+
+This case is useful because it demonstrates:
+
+1. routing a seemingly local feature into a cross-vibe implementation
+2. updating `contract`, `run`, and `maze` in one integrated branch
+3. validating shared tests and place builds
+4. landing the draft PR on `main`

--- a/.claude/skills/vibe-issue-router/SKILL.md
+++ b/.claude/skills/vibe-issue-router/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: vibe-issue-router
+description: Route a GitHub issue in this Roblox repo to the correct vibe, worktree, and delivery mode. Use when triaging a new issue or deciding whether work is place-local, cross-vibe, or contract-first.
+context: fork
+agent: Plan
+disable-model-invocation: true
+argument-hint: "[issue-number-or-url]"
+allowed-tools: Read, Grep, Glob, Bash(gh *), Bash(git *), Bash(rg *)
+---
+
+Route issue $ARGUMENTS for this repository.
+
+Read references only as needed:
+
+- `references/routing-playbook.md` for the full decision tree and output format
+- `references/issue-34-case.md` for the onboarding example based on issue `#34`
+
+## Required context
+
+Read:
+
+- `AGENTS.md`
+- `references/place-parallel-development.md`
+- the relevant local `VIBE.md` first and `NOW.md` second
+
+Use `gh issue view` when $ARGUMENTS is an issue number or URL.
+
+## Classification
+
+Choose one of:
+
+1. `place-local`
+2. `cross-vibe integration`
+3. `contract-first`
+
+Mark the issue `contract-first` if it changes teleport payloads, remote meaning, snapshot shape, place ids, or the shared handoff surface under:
+
+- `packages/shared/src/Session/**`
+- `packages/shared/src/Network/**`
+- `packages/shared/src/Config/SessionConfig.luau`
+
+## Deliverable
+
+Return the routing brief defined in `references/routing-playbook.md`.
+
+If routing is ambiguous, stop after the brief and say what needs confirmation.

--- a/.claude/skills/vibe-issue-router/references/issue-34-case.md
+++ b/.claude/skills/vibe-issue-router/references/issue-34-case.md
@@ -1,0 +1,18 @@
+# Issue 34 Case
+
+Issue `#34` looked maze-local at first because pickup happens in the maze.
+
+It became cross-vibe once the intent was clarified:
+
+- backpack should exist in both `run` and `maze`
+- inventory should survive `run -> maze -> run`
+
+Recommended routing:
+
+- `Owner vibe`: `contract`
+- `Affected vibes`: `contract`, `run`, `maze`
+- `Base branch`: `main`
+- `Landing branch`: `main`
+- `Delivery mode`: `cross-vibe integration`
+
+Use this case to teach that the interaction surface is not always the true owner.

--- a/.claude/skills/vibe-issue-router/references/routing-playbook.md
+++ b/.claude/skills/vibe-issue-router/references/routing-playbook.md
@@ -1,0 +1,30 @@
+# Routing Playbook
+
+## Decision Tree
+
+1. Read the issue body and acceptance criteria.
+2. Identify the player-facing owner domain.
+3. Check whether the change alters any shared seam:
+   - teleport payloads
+   - remote meaning
+   - replicated snapshot shape
+   - `SessionConfig.PlaceIds`
+   - `packages/shared/src/Session/**`
+   - `packages/shared/src/Network/**`
+4. Classify the issue as `place-local`, `cross-vibe integration`, or `contract-first`.
+
+## Output Template
+
+- `Issue`
+- `Owner vibe`
+- `Affected vibes`
+- `Recommended worktree`
+- `Base branch`
+- `Landing branch`
+- `Delivery mode`
+- `Why this is not <other vibe>`
+- `Review surface`
+
+## Plan Mode Note
+
+Use the planning agent first. Return a routing brief, not code.

--- a/.codex/skills/cross-vibe-pr-review/SKILL.md
+++ b/.codex/skills/cross-vibe-pr-review/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: cross-vibe-pr-review
+description: Review a pull request in this Roblox repo with a cross-vibe mindset. Use when a PR may touch `contract`, `lobby`, `run`, or `maze` together, when the merge target or branch sync story is unclear, or when review needs to separate code correctness from cross-place handoff and integration risks.
+---
+
+# Cross Vibe PR Review
+
+Review with findings first. Prefer a planning pass first when the environment supports a dedicated plan mode or planning subagent.
+
+Read references only as needed:
+
+- Read `references/review-checklist.md` when you need the full cross-vibe review checklist and merge-story rules.
+- Read `references/pr-95-case.md` when the user wants a concrete onboarding example based on issue `#34` and PR `#95`.
+
+## Resolve Scope
+
+Start by collecting:
+
+- PR metadata (`gh pr view`)
+- changed files (`gh pr diff --name-only`)
+- full diff when needed (`gh pr diff`)
+- current base branch freshness (`git fetch origin`)
+
+## Map The Vibes
+
+Map changed files to vibe surfaces:
+
+- `packages/shared/src/Session/**`, `packages/shared/src/Network/**`, `packages/shared/src/Config/SessionConfig.luau`, and matching tests are `contract`
+- `places/lobby/**` is `lobby`
+- `places/run/**` is `run`
+- `places/maze/**` is `maze`
+
+Read the touched vibe's `VIBE.md` first and `NOW.md` second before judging whether the change is in the right owner zone.
+
+## Review Priorities
+
+Look for concrete failures, not style nits:
+
+- contract drift between producers, consumers, and tests
+- teleport or join lifecycle regressions
+- replicated snapshot mismatches between server and client
+- run/maze ownership confusion
+- missing `rojo build` or `run-in-roblox` coverage for shared gameplay changes
+- incorrect merge story, especially when the PR is described as updating multiple long-lived branches at once
+
+## Output Format
+
+Always produce:
+
+1. `Findings`
+2. `Open Questions / Assumptions`
+3. `Summary`
+
+Follow the detailed output and review rules in `references/review-checklist.md`.
+
+## Merge Readiness Language
+
+- `Approve-ready`: no blocking code findings remain
+- `Merge-ready`: code is approve-ready and no process blockers remain
+- `Blocked`: code issue or merge gate still needs action

--- a/.codex/skills/cross-vibe-pr-review/agents/openai.yaml
+++ b/.codex/skills/cross-vibe-pr-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Cross-Vibe PR Review"
+  short_description: "Review PRs for contract/place seam risks and merge readiness."
+  default_prompt: "Use $cross-vibe-pr-review to review PR #95 for cross-vibe risks and merge readiness."

--- a/.codex/skills/cross-vibe-pr-review/references/pr-95-case.md
+++ b/.codex/skills/cross-vibe-pr-review/references/pr-95-case.md
@@ -1,0 +1,41 @@
+# PR 95 Case
+
+## What Was Reviewed
+
+- PR: `#95`
+- Base: `main`
+- Purpose: deliver issue `#34` as a cross-vibe integration PR
+
+## Why This Case Matters
+
+PR `#95` is the baseline example for review because it combines:
+
+- shared contract changes
+- `run` consumer changes
+- `maze` consumer changes
+- updated shared tests
+
+That means reviewers have to check both:
+
+- code correctness
+- merge-story correctness
+
+## Expected Review Conclusion
+
+The correct explanation is:
+
+- the PR lands on `main`
+- it affects the `contract`, `run`, and `maze` code domains
+- after merge, `main` is synced back into the long-lived vibe branches
+
+The incorrect explanation is:
+
+- "this PR merges into `main`, `contract`, `run`, and `maze` together"
+
+## Teaching Value
+
+Use this case to show teammates how cross-vibe review differs from place-local review:
+
+- the code diff spans several vibes
+- the branch target still stays singular
+- review must cover both handoff semantics and place-local consumers

--- a/.codex/skills/cross-vibe-pr-review/references/review-checklist.md
+++ b/.codex/skills/cross-vibe-pr-review/references/review-checklist.md
@@ -1,0 +1,36 @@
+# Review Checklist
+
+## Review Setup
+
+1. Read PR metadata with `gh pr view`.
+2. Read the changed file list with `gh pr diff --name-only`.
+3. Read full diff when needed.
+4. Fetch the base branch when freshness matters.
+5. Map touched files to vibe domains.
+
+## Code Review Questions
+
+- Did the PR change shared meaning under `contract`?
+- If yes, were all producers, consumers, and tests updated together?
+- Did the PR alter teleport or join lifecycle behavior?
+- Did any new snapshot field get added on the server without a matching client read, or vice versa?
+- Is the issue truly cross-vibe, or did the PR sprawl into unrelated owner zones?
+- Did validation match the touched area?
+
+## Merge Story Questions
+
+- Does the PR target `main`?
+- Is anyone describing it as if it merges into several long-lived branches at once?
+- Does the write-up explain that `main` becomes the new integration baseline and other long-lived vibe branches are synced later?
+
+## Output Rules
+
+- Put findings first.
+- Order by severity.
+- Use file references when possible.
+- If there are no blocking findings, say exactly `No blocking findings.`
+- Separate code correctness from merge-process notes.
+
+## Plan Mode Note
+
+When plan mode is available, use it to collect context and decide the review surface before forming findings.

--- a/.codex/skills/roblox-vibe-issue-to-draft-pr/SKILL.md
+++ b/.codex/skills/roblox-vibe-issue-to-draft-pr/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: roblox-vibe-issue-to-draft-pr
+description: Implement a GitHub issue in this Roblox repo using the vibe workflow and finish with a draft PR to `main`. Use for issue-driven development tasks that may touch shared contract files plus place-local consumers, and when the work should end in validated code, a pushed branch, and a draft PR.
+---
+
+# Roblox Vibe Issue To Draft PR
+
+Implement one issue cleanly, validate it, and stop at a draft PR. Do not merge.
+
+Read references only as needed:
+
+- Read `references/execution-checklist.md` when you need the full end-to-end execution order.
+- Read `references/issue-34-case.md` when the user wants a concrete baseline for a cross-vibe issue-to-draft-PR flow.
+
+## Start With Routing
+
+Before editing code:
+
+- read `AGENTS.md`
+- read `references/place-parallel-development.md`
+- read the owning `VIBE.md` first and `NOW.md` second
+- run the issue through the repo's routing logic
+
+If the issue changes cross-place handoff semantics, stage the shared contract before or alongside the place consumers and explain that choice in the PR body.
+
+## Base Branch Rules
+
+- Use a feature branch off `main` when the issue needs one integrated PR.
+- Use a `contract`-first sequence only when the user asks to split delivery or when reviewability would materially improve.
+- Land the draft PR on `main`.
+- Do not silently update the long-lived `run`, `maze`, `lobby`, or `contract` branches as part of this skill. Those branches are synced from `main` after merge.
+
+## Implementation Rules
+
+- Keep changes inside the owner zone and direct dependency zone whenever possible.
+- Update producers, consumers, and deterministic tests in the same change whenever contract or shared state shape changes.
+- Keep bootstrap scripts thin.
+- Treat server state as authoritative and clients as intent senders.
+- Prefer the smallest end-to-end slice that satisfies the issue acceptance criteria.
+
+## Validation Rules
+
+Run the checks that match the touched area:
+
+1. `stylua --check` on touched files
+2. `selene .`
+3. `rojo build` for every affected place project
+4. `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx` when shared or gameplay logic changes
+5. `run-in-roblox --place .\\tmp\\roblox_experience-tests.rbxlx --script tests/run-in-roblox.lua` when shared or gameplay logic changes
+
+Call out validation gaps honestly if a runtime or multi-place flow could not be exercised.
+
+## Draft PR Rules
+
+Create a draft PR that includes:
+
+Use the structure in `references/execution-checklist.md`.
+
+End the PR body with `Closes #<issue-number>`.
+
+## Stop Conditions
+
+- Stop after the draft PR is created.
+- Do not merge, squash, or sync long-lived vibe branches unless the user explicitly asks.

--- a/.codex/skills/roblox-vibe-issue-to-draft-pr/agents/openai.yaml
+++ b/.codex/skills/roblox-vibe-issue-to-draft-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vibe Issue To Draft PR"
+  short_description: "Implement a repo issue and open a draft PR to main."
+  default_prompt: "Use $roblox-vibe-issue-to-draft-pr to implement issue #34 and open a draft PR."

--- a/.codex/skills/roblox-vibe-issue-to-draft-pr/references/execution-checklist.md
+++ b/.codex/skills/roblox-vibe-issue-to-draft-pr/references/execution-checklist.md
@@ -1,0 +1,38 @@
+# Execution Checklist
+
+## Order Of Work
+
+1. Read the repo guardrails in `AGENTS.md`.
+2. Read `references/place-parallel-development.md`.
+3. Route the issue before coding.
+4. Read the owning `VIBE.md` first and `NOW.md` second.
+5. Create a feature branch.
+6. Implement the smallest end-to-end slice that satisfies the issue.
+7. Update shared contract producers, consumers, and tests together when shared meaning changes.
+8. Run validation.
+9. Push the branch.
+10. Open a draft PR to `main`.
+
+## Validation Matrix
+
+- Always:
+  - `stylua --check` on touched files
+  - `selene .`
+- For affected places:
+  - `rojo build places/<place>/default.project.json -o .\\tmp\\<place>.rbxlx`
+- For shared or gameplay logic:
+  - `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`
+  - `run-in-roblox --place .\\tmp\\roblox_experience-tests.rbxlx --script tests/run-in-roblox.lua`
+
+## Draft PR Body Template
+
+- `Summary`
+- `Why This Lives In <vibe or cross-vibe>`
+- `Scope`
+- `Validation`
+- `Risks / Follow-Up`
+- final line: `Closes #<issue-number>`
+
+## Merge Story Rule
+
+The draft PR lands on `main`. The long-lived vibe branches are synced from `main` after merge; they are not co-target branches of the PR.

--- a/.codex/skills/roblox-vibe-issue-to-draft-pr/references/issue-34-case.md
+++ b/.codex/skills/roblox-vibe-issue-to-draft-pr/references/issue-34-case.md
@@ -1,0 +1,46 @@
+# Issue 34 To PR 95 Case
+
+## Issue
+
+- Issue: `#34`
+- Title: `[Items] Glow orb pilot for held light and visibility`
+
+## Final Delivery
+
+- PR: `#95`
+- Base: `main`
+- Head: `feat/issue-34-glow-orb-handoff`
+
+## Why This Was A Good Baseline
+
+It exercised the full vibe workflow:
+
+1. route the issue correctly
+2. detect that it is not just maze-local
+3. update the shared handoff contract
+4. wire both `run` and `maze` consumers
+5. validate with shared tests and place builds
+6. open a draft PR to `main`
+
+## The Core Insight
+
+The feature was not "just a glow orb."
+
+It forced a decision about whether inventory is:
+
+- local to one place, or
+- a player-centric cross-place state
+
+Once the second interpretation was chosen, the implementation had to include:
+
+- contract handoff changes
+- `run` inventory snapshot and equip support
+- `maze` return behavior that preserves inventory
+
+## Teaching Value
+
+Use this case when onboarding teammates on:
+
+- how to detect a cross-vibe issue
+- why `main` is the integration landing branch
+- how one feature can touch `contract`, `run`, and `maze` without changing the routing model

--- a/.codex/skills/vibe-issue-router/SKILL.md
+++ b/.codex/skills/vibe-issue-router/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: vibe-issue-router
+description: Route a GitHub issue or feature request in this Roblox repo to the correct vibe (`lobby`, `run`, `maze`, or `contract`) and recommend the worktree, base branch, landing branch, and review surface. Use when triaging a new issue, explaining code ownership, deciding whether a request is place-local or cross-place, or checking whether work should start contract-first.
+---
+
+# Vibe Issue Router
+
+Route an issue before code is written. Prefer a planning pass first when the environment supports a dedicated plan mode or planning subagent.
+
+Read references only as needed:
+
+- Read `references/routing-playbook.md` when you need the full decision tree or the exact output format.
+- Read `references/issue-34-case.md` when the user wants an onboarding example or a concrete cross-vibe case.
+
+## Load The Right Context
+
+Read these files before making a routing call:
+
+- `AGENTS.md`
+- `references/place-parallel-development.md`
+- the relevant local `VIBE.md` first and `NOW.md` second for any vibe that looks involved
+
+Use `gh issue view <id>` when the user gives an issue number or URL.
+
+## Classify The Work
+
+Classify the issue into one of three buckets:
+
+1. `place-local`
+   - One vibe owns the change.
+   - No cross-place contract meaning changes.
+   - Start in the matching long-lived worktree or branch.
+
+2. `cross-vibe integration`
+   - More than one vibe consumes the feature.
+   - The issue still belongs in one integration PR.
+   - Start from `main` and explain which vibes are touched.
+
+3. `contract-first`
+   - The issue changes teleport payloads, remote meaning, snapshot shape, place ids, or shared handoff semantics.
+   - Start with the `contract` owner zone under `packages/shared/src/Session/**`, `packages/shared/src/Network/**`, `packages/shared/src/Config/SessionConfig.luau`, and the matching tests.
+   - Call out downstream consumer vibes explicitly.
+
+## Routing Rules
+
+- Choose `lobby` when the issue is about rooming, roster, ready state, or lobby-to-run launch.
+- Choose `run` when the issue is about camp orchestration, camp-only UI, run snapshots, or the run-to-maze seam from the run side.
+- Choose `maze` when the issue is about expedition runtime, loot, extraction, maze world flow, or maze-side UI.
+- Choose `contract` when multiple sides need to agree on a new shared meaning before place code can safely evolve.
+- Choose `main` as the landing branch for integration PRs.
+- Do not describe a PR as "merging into `main`, `contract`, `run`, and `maze` at once." Explain that the PR lands on `main`, then `main` is synced back into the long-lived vibe branches.
+
+## Output Contract
+
+Produce the routing brief defined in `references/routing-playbook.md`.
+
+## Special Cases
+
+- If the issue is really a player-centric ability that must survive `run -> maze -> run`, bias toward `contract-first` or `cross-vibe integration`, not a maze-only call.
+- If the issue only changes place-local composition while reading shared state, keep the owner local and note shared files as dependency zone only.
+- If the routing is ambiguous, stop after the routing brief and ask for confirmation instead of coding.

--- a/.codex/skills/vibe-issue-router/agents/openai.yaml
+++ b/.codex/skills/vibe-issue-router/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vibe Issue Router"
+  short_description: "Route repo issues to the right vibe and worktree."
+  default_prompt: "Use $vibe-issue-router to route issue #34 and explain the owning vibe, branch, and contract impact."

--- a/.codex/skills/vibe-issue-router/references/issue-34-case.md
+++ b/.codex/skills/vibe-issue-router/references/issue-34-case.md
@@ -1,0 +1,41 @@
+# Issue 34 Case
+
+## The Prompt
+
+Issue `#34` started as a glow orb pilot for held light and visibility.
+
+At first glance it looked `maze`-local because:
+
+- pickup happens in the maze
+- equip and hand-held feedback already existed more fully in `maze`
+
+## Why It Was Not Maze-Only
+
+The requirement became cross-vibe once the product intent was clarified:
+
+- backpack should exist in both `run` and `maze`
+- the player should keep the same inventory across `run -> maze -> run`
+- the held item state should survive cross-place handoff
+
+That means the issue was no longer just "maze pickup UX." It became a player-centric capability spanning:
+
+- `contract`
+- `run`
+- `maze`
+
+## Recommended Routing
+
+- `Owner vibe`: `contract`
+- `Affected vibes`: `contract`, `run`, `maze`
+- `Recommended worktree`: feature work off `main` for one integrated PR
+- `Base branch`: `main`
+- `Landing branch`: `main`
+- `Delivery mode`: `cross-vibe integration` with contract-first reasoning
+
+## Why This Case Matters
+
+This is the canonical example for teaching teammates that:
+
+- the place where interaction happens is not always the true owner
+- player-centric state often crosses vibe boundaries
+- `main` is the integration branch even when the work touches multiple long-lived vibe domains

--- a/.codex/skills/vibe-issue-router/references/routing-playbook.md
+++ b/.codex/skills/vibe-issue-router/references/routing-playbook.md
@@ -1,0 +1,47 @@
+# Routing Playbook
+
+## Decision Tree
+
+1. Read the issue body and acceptance criteria.
+2. Identify the player-facing owner domain.
+3. Check whether the change alters any of these shared seams:
+   - teleport payloads
+   - remote meaning
+   - replicated snapshot shape
+   - `SessionConfig.PlaceIds`
+   - any file under `packages/shared/src/Session/**`
+   - any file under `packages/shared/src/Network/**`
+4. Classify the issue:
+   - `place-local`: one vibe owns it and shared meaning does not change
+   - `cross-vibe integration`: more than one vibe consumes it, but one integrated PR is the right delivery
+   - `contract-first`: multiple sides must agree on a new shared meaning first
+
+## Owner Heuristics
+
+- `lobby`: rooming, roster, ready state, launch into run
+- `run`: camp orchestration, camp UI, run snapshot behavior, run-owned gate logic
+- `maze`: expedition runtime, loot, extraction, maze UI, maze world behavior
+- `contract`: teleport/session/remotes/config seams shared across places
+
+## Branch And Worktree Rules
+
+- Use the matching long-lived worktree for place-local work.
+- Use a feature branch off `main` when one integration PR is the cleanest delivery vehicle.
+- Use `contract` first only when reviewability or dependency order demands it.
+- Explain that PRs land on `main`; they do not merge into `main`, `contract`, `run`, and `maze` at once.
+
+## Output Template
+
+- `Issue`
+- `Owner vibe`
+- `Affected vibes`
+- `Recommended worktree`
+- `Base branch`
+- `Landing branch`
+- `Delivery mode`
+- `Why this is not <other vibe>`
+- `Review surface`
+
+## Plan Mode Note
+
+When a planning agent or plan mode is available, use it first for routing. The output should be a decision brief, not code.


### PR DESCRIPTION
## Summary
- sync the latest \\main\\ into \\maze\\
- bring the project-local Codex and Claude skill definitions into the long-lived maze branch
- keep the maze line aligned with the new onboarding and review workflow docs now living on main

## Notes
- source baseline: skill-system merge on \\main\\
- no maze runtime behavior changes beyond the shared docs/skill files