### PR TITLE
[Monster][Shared] 建立共享 authoring schema、校验器与 maze runtime compile 边界

### DIFF
--- a/packages/gameplay/src/Config/Monsters.luau
+++ b/packages/gameplay/src/Config/Monsters.luau
@@ -1,8 +1,45 @@
+local MonsterBehaviorCatalog = require(script.Parent.Parent.Monsters.MonsterBehaviorCatalog)
+local MonsterEffectCatalog = require(script.Parent.Parent.Monsters.MonsterEffectCatalog)
+
 return {
     {
         Id = 'scrap-wisp',
         Name = 'Scrap Wisp',
-        Speed = 12,
-        SightRange = 60,
+        Lore = 'A knot of scavenged metal and spite that circles abandoned loot trails.',
+        Atmosphere = 'Dread',
+        TriggerIntent = {
+            Summary = 'Roams active maze lanes once the expedition starts and closes on nearby explorers.',
+            Space = 'Maze expedition rooms',
+        },
+        CounterplayIntent = {
+            Summary = 'Break line of sight around corners and use distance to reset its route.',
+            Tool = 'No dedicated suppression tool in v1',
+        },
+        NumericProfile = {
+            Speed = 12,
+            SightRange = 60,
+            PatrolSpeedMultiplier = 0.45,
+            SpawnOffset = Vector3.new(0, 4, 0),
+        },
+        BehaviorIntents = {
+            {
+                Id = MonsterBehaviorCatalog.Behavior.Patrol,
+            },
+            {
+                Id = MonsterBehaviorCatalog.Behavior.SenseNearestTarget,
+            },
+            {
+                Id = MonsterBehaviorCatalog.Behavior.Chase,
+            },
+            {
+                Id = MonsterBehaviorCatalog.Behavior.LoseTarget,
+            },
+        },
+        EffectIntents = {
+            {
+                Id = MonsterEffectCatalog.Effect.SprintSuppressed,
+                DurationSeconds = 2.5,
+            },
+        },
     },
 }

--- a/packages/gameplay/src/Monsters/MonsterAuthorProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterAuthorProfile.luau
@@ -1,0 +1,114 @@
+local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
+local MonsterEffectCatalog = require(script.Parent.MonsterEffectCatalog)
+
+local MonsterAuthorProfile = {}
+
+local function isNonEmptyString(value)
+    return type(value) == 'string' and value ~= ''
+end
+
+local function validateSummaryTable(summaryTable, missingReason)
+    if type(summaryTable) ~= 'table' then
+        return false, missingReason
+    end
+
+    if not isNonEmptyString(summaryTable.Summary) then
+        return false, missingReason
+    end
+
+    return true
+end
+
+function MonsterAuthorProfile.validate(profile)
+    if type(profile) ~= 'table' then
+        return false, 'MalformedMonsterAuthorProfile'
+    end
+
+    if not isNonEmptyString(profile.Id) then
+        return false, 'MissingId'
+    end
+
+    if not isNonEmptyString(profile.Name) then
+        return false, 'MissingName'
+    end
+
+    if not isNonEmptyString(profile.Lore) then
+        return false, 'MissingLore'
+    end
+
+    if not isNonEmptyString(profile.Atmosphere) then
+        return false, 'MissingAtmosphere'
+    end
+
+    local triggerOk, triggerReason =
+        validateSummaryTable(profile.TriggerIntent, 'MissingTriggerIntentSummary')
+    if not triggerOk then
+        return false, triggerReason
+    end
+
+    local counterplayOk, counterplayReason =
+        validateSummaryTable(profile.CounterplayIntent, 'MissingCounterplayIntentSummary')
+    if not counterplayOk then
+        return false, counterplayReason
+    end
+
+    local numericProfile = profile.NumericProfile
+    if type(numericProfile) ~= 'table' then
+        return false, 'MissingNumericProfile'
+    end
+
+    if type(numericProfile.Speed) ~= 'number' or numericProfile.Speed <= 0 then
+        return false, 'InvalidSpeed'
+    end
+
+    if type(numericProfile.SightRange) ~= 'number' or numericProfile.SightRange <= 0 then
+        return false, 'InvalidSightRange'
+    end
+
+    if
+        type(numericProfile.PatrolSpeedMultiplier) ~= 'number'
+        or numericProfile.PatrolSpeedMultiplier <= 0
+    then
+        return false, 'InvalidPatrolSpeedMultiplier'
+    end
+
+    if numericProfile.SpawnOffset ~= nil and typeof(numericProfile.SpawnOffset) ~= 'Vector3' then
+        return false, 'InvalidSpawnOffset'
+    end
+
+    if type(profile.BehaviorIntents) ~= 'table' or #profile.BehaviorIntents == 0 then
+        return false, 'MissingBehaviorIntents'
+    end
+
+    for _, behaviorIntent in ipairs(profile.BehaviorIntents) do
+        if type(behaviorIntent) ~= 'table' then
+            return false, 'MalformedBehaviorIntent'
+        end
+
+        if type(behaviorIntent.Id) ~= 'string' or behaviorIntent.Id == '' then
+            return false, 'MissingBehaviorIntentId'
+        end
+
+        if not MonsterBehaviorCatalog.Known[behaviorIntent.Id] then
+            return false, 'UnknownBehaviorIntent'
+        end
+    end
+
+    local effectIntents = profile.EffectIntents
+    if effectIntents ~= nil then
+        if type(effectIntents) ~= 'table' then
+            return false, 'MalformedEffectIntents'
+        end
+
+        for _, effectIntent in ipairs(effectIntents) do
+            local validEffect, effectReason = MonsterEffectCatalog.validateIntent(effectIntent)
+            if not validEffect then
+                return false, effectReason
+            end
+        end
+    end
+
+    return true
+end
+
+return MonsterAuthorProfile

--- a/packages/gameplay/src/Monsters/MonsterBehaviorCatalog.luau
+++ b/packages/gameplay/src/Monsters/MonsterBehaviorCatalog.luau
@@ -1,0 +1,25 @@
+local BEHAVIOR = table.freeze({
+    Patrol = 'Patrol',
+    SenseNearestTarget = 'SenseNearestTarget',
+    Chase = 'Chase',
+    LoseTarget = 'LoseTarget',
+    Attack = 'Attack',
+    Suppressed = 'Suppressed',
+})
+
+local knownBehaviorIds = {}
+for _, behaviorId in pairs(BEHAVIOR) do
+    knownBehaviorIds[behaviorId] = true
+end
+
+local MonsterBehaviorCatalog = table.freeze({
+    Behavior = BEHAVIOR,
+    Known = table.freeze(knownBehaviorIds),
+    MazeExecutable = table.freeze({
+        [BEHAVIOR.Patrol] = true,
+        [BEHAVIOR.SenseNearestTarget] = true,
+        [BEHAVIOR.Chase] = true,
+    }),
+})
+
+return MonsterBehaviorCatalog

--- a/packages/gameplay/src/Monsters/MonsterCompiler.luau
+++ b/packages/gameplay/src/Monsters/MonsterCompiler.luau
@@ -1,0 +1,76 @@
+local MonsterAuthorProfile = require(script.Parent.MonsterAuthorProfile)
+local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
+local MonsterEffectCatalog = require(script.Parent.MonsterEffectCatalog)
+local MonsterRuntimeProfile = require(script.Parent.MonsterRuntimeProfile)
+
+local DEFAULT_SPAWN_OFFSET = Vector3.new(0, 4, 0)
+
+local MonsterCompiler = {}
+
+local function cloneRuntimeEffect(effectIntent)
+    local runtimeEffect = {
+        Id = effectIntent.Id,
+    }
+
+    if type(effectIntent.DurationSeconds) == 'number' then
+        runtimeEffect.DurationSeconds = effectIntent.DurationSeconds
+    end
+
+    return table.freeze(runtimeEffect)
+end
+
+function MonsterCompiler.compileMonsterForMaze(authorProfile)
+    local validAuthorProfile, authorReason = MonsterAuthorProfile.validate(authorProfile)
+    if not validAuthorProfile then
+        return false, authorReason
+    end
+
+    local behaviors = {}
+    local skippedBehaviorIds = {}
+    for _, behaviorIntent in ipairs(authorProfile.BehaviorIntents) do
+        if behaviorIntent.Enabled ~= false then
+            if MonsterBehaviorCatalog.MazeExecutable[behaviorIntent.Id] then
+                behaviors[behaviorIntent.Id] = true
+            else
+                table.insert(skippedBehaviorIds, behaviorIntent.Id)
+            end
+        end
+    end
+
+    local runtimeEffects = {}
+    local skippedEffectIds = {}
+    for _, effectIntent in ipairs(authorProfile.EffectIntents or {}) do
+        if effectIntent.Enabled ~= false then
+            if MonsterEffectCatalog.MazeExecutable[effectIntent.Id] then
+                table.insert(runtimeEffects, cloneRuntimeEffect(effectIntent))
+            else
+                table.insert(skippedEffectIds, effectIntent.Id)
+            end
+        end
+    end
+
+    local runtimeProfile = table.freeze({
+        Id = authorProfile.Id,
+        Name = authorProfile.Name,
+        Speed = authorProfile.NumericProfile.Speed,
+        SightRange = authorProfile.NumericProfile.SightRange,
+        PatrolSpeedMultiplier = authorProfile.NumericProfile.PatrolSpeedMultiplier,
+        SpawnOffset = authorProfile.NumericProfile.SpawnOffset or DEFAULT_SPAWN_OFFSET,
+        Behaviors = table.freeze(behaviors),
+        Effects = table.freeze(runtimeEffects),
+    })
+
+    local validRuntimeProfile, runtimeReason = MonsterRuntimeProfile.validate(runtimeProfile)
+    if not validRuntimeProfile then
+        return false, runtimeReason
+    end
+
+    local compileReport = table.freeze({
+        SkippedBehaviorIds = table.freeze(skippedBehaviorIds),
+        SkippedEffectIds = table.freeze(skippedEffectIds),
+    })
+
+    return true, runtimeProfile, compileReport
+end
+
+return MonsterCompiler

--- a/packages/gameplay/src/Monsters/MonsterEffectCatalog.luau
+++ b/packages/gameplay/src/Monsters/MonsterEffectCatalog.luau
@@ -1,0 +1,57 @@
+local CATEGORY = table.freeze({
+    Damage = 'Damage',
+    PlayerStatus = 'PlayerStatus',
+    MonsterStatus = 'MonsterStatus',
+})
+
+local EFFECT = table.freeze({
+    DamageLight = 'DamageLight',
+    DamageHeavy = 'DamageHeavy',
+    SprintSuppressed = 'SprintSuppressed',
+    MonsterStunned = 'MonsterStunned',
+})
+
+local knownEffectIds = {}
+for _, effectId in pairs(EFFECT) do
+    knownEffectIds[effectId] = true
+end
+
+local DURATION_EFFECTS = table.freeze({
+    [EFFECT.SprintSuppressed] = true,
+    [EFFECT.MonsterStunned] = true,
+})
+
+local MonsterEffectCatalog = {
+    Category = CATEGORY,
+    Effect = EFFECT,
+    Known = table.freeze(knownEffectIds),
+    MazeExecutable = table.freeze({
+        [EFFECT.DamageLight] = true,
+        [EFFECT.DamageHeavy] = true,
+    }),
+}
+
+function MonsterEffectCatalog.validateIntent(effectIntent)
+    if type(effectIntent) ~= 'table' then
+        return false, 'MalformedEffectIntent'
+    end
+
+    if type(effectIntent.Id) ~= 'string' or effectIntent.Id == '' then
+        return false, 'MissingEffectIntentId'
+    end
+
+    if not MonsterEffectCatalog.Known[effectIntent.Id] then
+        return false, 'UnknownEffectIntent'
+    end
+
+    if DURATION_EFFECTS[effectIntent.Id] then
+        local durationSeconds = effectIntent.DurationSeconds
+        if type(durationSeconds) ~= 'number' or durationSeconds <= 0 then
+            return false, 'InvalidEffectPayload'
+        end
+    end
+
+    return true
+end
+
+return table.freeze(MonsterEffectCatalog)

--- a/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
@@ -1,0 +1,47 @@
+local MonsterRuntimeProfile = {}
+
+local function isNonEmptyString(value)
+    return type(value) == 'string' and value ~= ''
+end
+
+function MonsterRuntimeProfile.validate(profile)
+    if type(profile) ~= 'table' then
+        return false, 'MalformedMonsterRuntimeProfile'
+    end
+
+    if not isNonEmptyString(profile.Id) then
+        return false, 'MissingRuntimeId'
+    end
+
+    if not isNonEmptyString(profile.Name) then
+        return false, 'MissingRuntimeName'
+    end
+
+    if type(profile.Speed) ~= 'number' or profile.Speed <= 0 then
+        return false, 'InvalidRuntimeSpeed'
+    end
+
+    if type(profile.SightRange) ~= 'number' or profile.SightRange <= 0 then
+        return false, 'InvalidRuntimeSightRange'
+    end
+
+    if type(profile.PatrolSpeedMultiplier) ~= 'number' or profile.PatrolSpeedMultiplier <= 0 then
+        return false, 'InvalidRuntimePatrolSpeedMultiplier'
+    end
+
+    if typeof(profile.SpawnOffset) ~= 'Vector3' then
+        return false, 'InvalidRuntimeSpawnOffset'
+    end
+
+    if type(profile.Behaviors) ~= 'table' then
+        return false, 'MissingRuntimeBehaviors'
+    end
+
+    if type(profile.Effects) ~= 'table' then
+        return false, 'MissingRuntimeEffects'
+    end
+
+    return true
+end
+
+return MonsterRuntimeProfile

--- a/packages/gameplay/src/Monsters/init.luau
+++ b/packages/gameplay/src/Monsters/init.luau
@@ -1,3 +1,11 @@
+local MonsterCompiler = require(script.MonsterCompiler)
+
 return {
+    MonsterAuthorProfile = require(script.MonsterAuthorProfile),
+    MonsterBehaviorCatalog = require(script.MonsterBehaviorCatalog),
+    MonsterCompiler = MonsterCompiler,
+    MonsterEffectCatalog = require(script.MonsterEffectCatalog),
     MonsterLogic = require(script.MonsterLogic),
+    MonsterRuntimeProfile = require(script.MonsterRuntimeProfile),
+    compileMonsterForMaze = MonsterCompiler.compileMonsterForMaze,
 }

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -6,19 +6,26 @@ local Workspace = game:GetService('Workspace')
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
 
+local MonsterBehaviorCatalog = Gameplay.Monsters.MonsterBehaviorCatalog
 local MonsterLogic = Gameplay.Monsters.MonsterLogic
+local MonsterRuntimeProfile = Gameplay.Monsters.MonsterRuntimeProfile
 
 local MonsterService = {}
 MonsterService.__index = MonsterService
 
 function MonsterService.new(
-    monsterDefinition,
+    monsterRuntimeProfile,
     isExpeditionActiveCallback,
     canTargetPlayerCallback,
     canTraverseCallback
 )
+    local validRuntimeProfile, runtimeReason = MonsterRuntimeProfile.validate(monsterRuntimeProfile)
+    if not validRuntimeProfile then
+        error(string.format('Monster runtime profile invalid: %s', tostring(runtimeReason)), 0)
+    end
+
     return setmetatable({
-        Definition = monsterDefinition,
+        Definition = monsterRuntimeProfile,
         IsExpeditionActive = isExpeditionActiveCallback,
         CanTargetPlayer = canTargetPlayerCallback or function()
             return true
@@ -62,7 +69,7 @@ function MonsterService:spawn(patrolPoints)
     monster.CanCollide = false
     monster.Material = Enum.Material.Neon
     monster.Color = Color3.fromRGB(214, 91, 91)
-    monster.Position = patrolPoints[1] + Vector3.new(0, 4, 0)
+    monster.Position = patrolPoints[1] + self.Definition.SpawnOffset
     monster.Parent = Workspace
 
     self.MonsterPart = monster
@@ -90,21 +97,34 @@ function MonsterService:update(dt)
     end
 
     local currentPosition = self.MonsterPart.Position
-    local targetPlayer =
-        MonsterLogic.pickNearestTarget(currentPosition, playerPositions, self.Definition.SightRange)
+    local targetPlayer = nil
+    if self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.SenseNearestTarget] then
+        targetPlayer = MonsterLogic.pickNearestTarget(
+            currentPosition,
+            playerPositions,
+            self.Definition.SightRange
+        )
+    end
     local nextPosition
 
-    if targetPlayer then
+    if targetPlayer and self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.Chase] then
         nextPosition = MonsterLogic.stepToward(
             currentPosition,
             playerPositions[targetPlayer],
             self.Definition.Speed,
             dt
         )
-    elseif #self.PatrolPoints > 0 then
-        local patrolTarget = self.PatrolPoints[self.PatrolIndex] + Vector3.new(0, 4, 0)
-        nextPosition =
-            MonsterLogic.stepToward(currentPosition, patrolTarget, self.Definition.Speed * 0.45, dt)
+    elseif
+        self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.Patrol]
+        and #self.PatrolPoints > 0
+    then
+        local patrolTarget = self.PatrolPoints[self.PatrolIndex] + self.Definition.SpawnOffset
+        nextPosition = MonsterLogic.stepToward(
+            currentPosition,
+            patrolTarget,
+            self.Definition.Speed * self.Definition.PatrolSpeedMultiplier,
+            dt
+        )
 
         if (nextPosition - patrolTarget).Magnitude <= 2 then
             self.PatrolIndex = (self.PatrolIndex % #self.PatrolPoints) + 1

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -102,6 +102,23 @@ local function runWithCampSessionLock(self, callback)
     return table.unpack(results, 2, results.n)
 end
 
+local function buildMazeMonsterRuntimeProfile(monsterAuthorProfile)
+    local compiledOk, runtimeProfileOrReason =
+        Gameplay.Monsters.compileMonsterForMaze(monsterAuthorProfile)
+    if not compiledOk then
+        error(
+            string.format(
+                'Failed to compile maze monster %s: %s',
+                tostring(monsterAuthorProfile and monsterAuthorProfile.Id),
+                tostring(runtimeProfileOrReason)
+            ),
+            0
+        )
+    end
+
+    return runtimeProfileOrReason
+end
+
 function MazeSessionService.new()
     local self = setmetatable({}, MazeSessionService)
 
@@ -126,17 +143,22 @@ function MazeSessionService.new()
     self.InventoryService = InventoryService.new(self.SessionData.InventoryCapacity)
     self.ControlStateService = ControlStateService.new()
     self.PlayerStateService = PlayerStateService.new()
-    self.MonsterService = MonsterService.new(Gameplay.Config.Monsters[1], function()
-        return self.RunTracker:getState() == 'Expedition'
-    end, function(player)
-        return self.RunTracker:isPlayerActive(player.UserId)
-    end, function(fromPosition, toPosition)
-        if not self.World or not self.World.CanTraverseBetweenPositions then
-            return true
-        end
+    self.MonsterService = MonsterService.new(
+        buildMazeMonsterRuntimeProfile(Gameplay.Config.Monsters[1]),
+        function()
+            return self.RunTracker:getState() == 'Expedition'
+        end,
+        function(player)
+            return self.RunTracker:isPlayerActive(player.UserId)
+        end,
+        function(fromPosition, toPosition)
+            if not self.World or not self.World.CanTraverseBetweenPositions then
+                return true
+            end
 
-        return self.World.CanTraverseBetweenPositions(fromPosition, toPosition)
-    end)
+            return self.World.CanTraverseBetweenPositions(fromPosition, toPosition)
+        end
+    )
     self.CorpsesByUserId = {}
 
     return self

--- a/tests/src/Shared/MonsterCompiler.spec.luau
+++ b/tests/src/Shared/MonsterCompiler.spec.luau
@@ -1,0 +1,116 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
+
+    local compiler = gameplay.Monsters.compileMonsterForMaze
+    local behaviorCatalog = gameplay.Monsters.MonsterBehaviorCatalog
+    local effectCatalog = gameplay.Monsters.MonsterEffectCatalog
+    local authorProfileModule = gameplay.Monsters.MonsterAuthorProfile
+    local runtimeProfileModule = gameplay.Monsters.MonsterRuntimeProfile
+
+    local scrapWisp = gameplay.Config.Monsters[1]
+
+    local validAuthorProfile, authorReason = authorProfileModule.validate(scrapWisp)
+    assert(
+        validAuthorProfile == true,
+        string.format('Expected valid author profile, got %s', authorReason)
+    )
+
+    local compileOk, runtimeProfile, compileReport = compiler(scrapWisp)
+    assert(compileOk == true, string.format('Expected compiler success, got %s', runtimeProfile))
+
+    local validRuntimeProfile, runtimeReason = runtimeProfileModule.validate(runtimeProfile)
+    assert(
+        validRuntimeProfile == true,
+        string.format('Expected valid runtime profile, got %s', runtimeReason)
+    )
+
+    assert(runtimeProfile.Id == 'scrap-wisp', 'Compiled runtime should preserve the monster id')
+    assert(runtimeProfile.Name == 'Scrap Wisp', 'Compiled runtime should preserve the monster name')
+    assert(runtimeProfile.Speed == 12, 'Compiled runtime should expose the configured speed')
+    assert(
+        runtimeProfile.SightRange == 60,
+        'Compiled runtime should expose the configured sight range'
+    )
+    assert(
+        runtimeProfile.PatrolSpeedMultiplier == 0.45,
+        'Compiled runtime should expose the configured patrol speed multiplier'
+    )
+    assert(
+        runtimeProfile.Behaviors[behaviorCatalog.Behavior.Patrol] == true,
+        'Patrol should stay enabled in the maze runtime profile'
+    )
+    assert(
+        runtimeProfile.Behaviors[behaviorCatalog.Behavior.SenseNearestTarget] == true,
+        'Nearest-target sensing should stay enabled in the maze runtime profile'
+    )
+    assert(
+        runtimeProfile.Behaviors[behaviorCatalog.Behavior.Chase] == true,
+        'Chase should stay enabled in the maze runtime profile'
+    )
+    assert(
+        runtimeProfile.Behaviors[behaviorCatalog.Behavior.LoseTarget] == nil,
+        'Known but not-yet-enabled behaviors should be excluded from the runtime profile'
+    )
+    assert(
+        runtimeProfile.Lore == nil,
+        'Authoring-only fields should not leak into the runtime profile'
+    )
+    assert(
+        #runtimeProfile.Effects == 0,
+        'Known but not-yet-enabled effects should be excluded from the runtime profile'
+    )
+    assert(
+        #compileReport.SkippedBehaviorIds == 1
+            and compileReport.SkippedBehaviorIds[1] == behaviorCatalog.Behavior.LoseTarget,
+        'Compiler should report maze-skipped behavior intents'
+    )
+    assert(
+        #compileReport.SkippedEffectIds == 1
+            and compileReport.SkippedEffectIds[1] == effectCatalog.Effect.SprintSuppressed,
+        'Compiler should report maze-skipped effect intents'
+    )
+
+    local missingNameProfile = table.clone(scrapWisp)
+    missingNameProfile.Name = nil
+
+    local missingNameOk, missingNameReason = authorProfileModule.validate(missingNameProfile)
+    assert(missingNameOk == false, 'Missing names should fail author profile validation')
+    assert(missingNameReason == 'MissingName', 'Missing names should expose the expected reason')
+
+    local unknownBehaviorProfile = table.clone(scrapWisp)
+    unknownBehaviorProfile.BehaviorIntents = {
+        {
+            Id = 'UnknownBehavior',
+        },
+    }
+
+    local unknownBehaviorOk, unknownBehaviorReason =
+        authorProfileModule.validate(unknownBehaviorProfile)
+    assert(unknownBehaviorOk == false, 'Unknown behavior intents should fail validation')
+    assert(
+        unknownBehaviorReason == 'UnknownBehaviorIntent',
+        'Unknown behavior intents should expose the expected reason'
+    )
+
+    local invalidEffectProfile = table.clone(scrapWisp)
+    invalidEffectProfile.EffectIntents = {
+        {
+            Id = effectCatalog.Effect.SprintSuppressed,
+        },
+    }
+
+    local invalidEffectOk, invalidEffectReason = authorProfileModule.validate(invalidEffectProfile)
+    assert(invalidEffectOk == false, 'Invalid effect payloads should fail validation')
+    assert(
+        invalidEffectReason == 'InvalidEffectPayload',
+        'Invalid effect payloads should expose the expected reason'
+    )
+
+    local compileFailureOk, compileFailureReason = compiler(invalidEffectProfile)
+    assert(compileFailureOk == false, 'Compiler should reject invalid authoring profiles')
+    assert(
+        compileFailureReason == 'InvalidEffectPayload',
+        'Compiler should surface the authoring validation failure reason'
+    )
+end


### PR DESCRIPTION
## Summary

- 建立共享的怪物 authoring schema、validator、behavior catalog、effect catalog，以及 `compileMonsterForMaze(...)`。
- 将现有 `scrap-wisp` 从直接 runtime 配置迁移到 authoring profile，并在 maze 侧先 compile 再交给 runtime。
- 保持 `MonsterService` 只消费 `MonsterRuntimeProfile`，不承担 authoring -> runtime 转换职责。
- Follow-up: 编译后的 effect 目前只做校验与过滤，不在本 PR 内执行；本地 Studio 的 maze spawn / patrol / chase 手动验证将在进入 `#39` 前补齐。

## Why This Lives In maze

- 这是一个 `maze-first` 的共享底座 PR：首个真实 consumer 是 maze runtime，编译目标也明确是 `compileMonsterForMaze(...)`。
- 这次改动没有改变 teleport payload、remote meaning、replicated snapshot shape、`SessionConfig.PlaceIds` 或跨 place session handoff 语义。
- 因此它属于 `maze` owner lane，而不是 `contract-first` 交付。

## Roblox Integration Checklist

- [x] The change updates the active runtime source under `packages/**`, or I explained why another source path had to change.
- [ ] If Studio tree structure changed, I updated the relevant `default.project.json` in the same PR.
- [ ] If I changed Remote names, replicated schema, or visibility behavior, I updated all linked producers/consumers/tests in the same PR.
- [x] If I changed non-trivial shared/gameplay behavior, I added or updated deterministic coverage under `tests/src/Shared`, or I explained why no test change was needed.
- [ ] If I touched `SessionConfig.PlaceIds` or any other real-environment configuration, I documented the required rollout or environment follow-up.
- [ ] If this PR includes `.rbxl`, generated output, or other non-source artifacts, I explained why they are required.

Checklist notes:
- This PR changes shared/gameplay monster foundation plus maze-side consumption only.
- It does not change Studio tree structure, remotes, replicated schema, `SessionConfig.PlaceIds`, or runtime artifact policy.

## Validation

- [x] `stylua --check packages/gameplay/src/Config/Monsters.luau packages/gameplay/src/Monsters/init.luau packages/gameplay/src/Monsters/MonsterAuthorProfile.luau packages/gameplay/src/Monsters/MonsterBehaviorCatalog.luau packages/gameplay/src/Monsters/MonsterCompiler.luau packages/gameplay/src/Monsters/MonsterEffectCatalog.luau packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau packages/shared/src/Runtime/MonsterService.luau places/maze/src/ServerScriptService/Maze/MazeSessionService.luau tests/src/Shared/MonsterCompiler.spec.luau`
- [x] `selene .`
- [x] Additional verification steps are listed below if this PR needs more than static checks.

Additional verification:
- `rojo build places/maze/default.project.json -o .\\tmp\\maze.rbxlx`
- `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`
- `run-in-roblox --place .\\tmp\\roblox_experience-tests.rbxlx --script tests/run-in-roblox.lua`

## Notes

- Manual test notes: 本地 Studio 的 maze spawn / patrol / chase 手动验证尚未执行；这次先完成 shared schema/compiler 和 deterministic coverage 的闭环。
- Risks / follow-ups: `LoseTarget`、`SprintSuppressed` 等 authoring intent 目前会被保留在 authoring 层并由 maze compiler 跳过；后续如果新增更多 compile target 或开始执行 effect，再评估是否抽象 compiler helper。
- Related to #101

Closes #102