### PR TITLE
[Maze][Affordance] 为怪物与物资系统定义房间 affordance 参数接口

### DIFF
--- a/packages/shared/src/Runtime/MazeFormalWorldComposer.luau
+++ b/packages/shared/src/Runtime/MazeFormalWorldComposer.luau
@@ -9,6 +9,7 @@ local MazeModuleAssetContract = require(script.Parent.MazeModuleAssetContract)
 local MazeWorldShellBuilder = require(script.Parent.MazeWorldShellBuilder)
 
 local MazeFormalWorldComposer = {}
+local LOOT_SOCKET_HEIGHT = 1.5
 
 local function validateModuleAssetsIfConfigured(options)
     if options == nil then
@@ -29,6 +30,110 @@ local function validateModuleAssetsIfConfigured(options)
     return nil
 end
 
+local function buildThreatTags(roomKind)
+    return {
+        string.format('RoomKind:%s', roomKind),
+    }
+end
+
+local function cloneSortedNumbers(values)
+    local cloned = table.clone(values or {})
+    table.sort(cloned)
+    return cloned
+end
+
+local function buildSortedNeighborRoomIds(room)
+    local neighborRoomIds = {}
+    for _, neighborRoomId in pairs(room.Neighbors or {}) do
+        table.insert(neighborRoomIds, neighborRoomId)
+    end
+    table.sort(neighborRoomIds)
+    return neighborRoomIds
+end
+
+local function buildRoomAffordance(shell, roomId)
+    local room = shell.RoomById[roomId]
+    local roomCenter = shell.RoomCenters[roomId]
+
+    local affordance = {
+        RoomId = roomId,
+        RoomKind = room.Kind,
+        RoomCenter = roomCenter,
+        SpawnSockets = {
+            {
+                Id = string.format('%s_Spawn_1', roomId),
+                Kind = 'RoomCenter',
+                Position = roomCenter + Vector3.new(0, LOOT_SOCKET_HEIGHT, 0),
+            },
+        },
+        PatrolAnchors = {},
+        SightBreakers = {},
+        DoorControlPoints = {},
+        ThreatTags = buildThreatTags(room.Kind),
+        TraversalMask = {
+            NeighborRoomIds = buildSortedNeighborRoomIds(room),
+            DoorwayIds = {},
+            ExitDirections = cloneSortedNumbers(room.ExitDirections),
+        },
+    }
+
+    if room.Kind == 'Loot' then
+        table.insert(affordance.PatrolAnchors, roomCenter)
+    end
+
+    return affordance
+end
+
+local function appendDoorwayAffordances(roomAffordances, doorwayId, doorway)
+    local roomIds = {
+        doorway.RoomA,
+        doorway.RoomB,
+    }
+    local neighborRoomIds = {
+        [doorway.RoomA] = doorway.RoomB,
+        [doorway.RoomB] = doorway.RoomA,
+    }
+
+    for _, roomId in ipairs(roomIds) do
+        local affordance = roomAffordances[roomId]
+        if affordance then
+            table.insert(affordance.TraversalMask.DoorwayIds, doorwayId)
+
+            if doorway.Prompt then
+                table.insert(affordance.DoorControlPoints, {
+                    DoorwayId = doorwayId,
+                    NeighborRoomId = neighborRoomIds[roomId],
+                    Position = doorway.Prompt.Parent.Position,
+                })
+            end
+        end
+    end
+end
+
+local function finalizeAffordances(roomAffordances)
+    for _, affordance in pairs(roomAffordances) do
+        table.sort(affordance.TraversalMask.DoorwayIds)
+        table.sort(affordance.DoorControlPoints, function(left, right)
+            return left.DoorwayId < right.DoorwayId
+        end)
+    end
+end
+
+local function collectPatrolPointsFromAffordances(roomIds, roomAffordances)
+    local patrolPoints = {}
+
+    for _, roomId in ipairs(roomIds) do
+        local affordance = roomAffordances[roomId]
+        if affordance then
+            for _, patrolAnchor in ipairs(affordance.PatrolAnchors) do
+                table.insert(patrolPoints, patrolAnchor)
+            end
+        end
+    end
+
+    return patrolPoints
+end
+
 function MazeFormalWorldComposer.build(seed, config, options)
     local resolvedOptions = options or {}
     validateModuleAssetsIfConfigured(resolvedOptions)
@@ -43,13 +148,15 @@ function MazeFormalWorldComposer.build(seed, config, options)
         DetectionBuffer = resolvedOptions.DetectionBuffer,
     })
 
-    local patrolPoints = {}
+    local roomAffordances = {}
     local lootNodes = {}
     local itemIndex = 1
 
     for _, roomId in ipairs(shell.RoomIds) do
+        local affordance = buildRoomAffordance(shell, roomId)
         local room = shell.RoomById[roomId]
-        local roomCenter = shell.RoomCenters[roomId]
+        local lootPosition = affordance.SpawnSockets[1].Position
+        roomAffordances[roomId] = affordance
 
         if room.Kind == 'Loot' then
             local itemDef = Items[itemIndex]
@@ -58,7 +165,7 @@ function MazeFormalWorldComposer.build(seed, config, options)
             local _, prompt = MazeInteractionPartFactory.createPromptPart({
                 Name = string.format('Loot_%s', roomId),
                 Size = Vector3.new(3, 3, 3),
-                CFrame = CFrame.new(roomCenter + Vector3.new(0, 1.5, 0)),
+                CFrame = CFrame.new(lootPosition),
                 Color = itemDef.Color,
                 Material = Enum.Material.Neon,
                 ActionText = 'Collect',
@@ -69,10 +176,9 @@ function MazeFormalWorldComposer.build(seed, config, options)
             lootNodes[roomId] = {
                 ItemDef = itemDef,
                 Prompt = prompt,
-                Position = roomCenter,
+                Position = lootPosition,
                 Collected = false,
             }
-            table.insert(patrolPoints, roomCenter)
         end
     end
 
@@ -107,8 +213,21 @@ function MazeFormalWorldComposer.build(seed, config, options)
         },
     }
 
+    local doorwayIds = {}
+    for doorwayId in pairs(shell.Doorways or {}) do
+        table.insert(doorwayIds, doorwayId)
+    end
+    table.sort(doorwayIds)
+
+    for _, doorwayId in ipairs(doorwayIds) do
+        appendDoorwayAffordances(roomAffordances, doorwayId, shell.Doorways[doorwayId])
+    end
+
+    finalizeAffordances(roomAffordances)
+
     shell.LootNodes = lootNodes
-    shell.PatrolPoints = patrolPoints
+    shell.RoomAffordances = roomAffordances
+    shell.PatrolPoints = collectPatrolPointsFromAffordances(shell.RoomIds, roomAffordances)
     shell.ReturnHoldPad = returnHoldPad
     shell.ExtractionNodes = extractionNodes
 

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -119,6 +119,27 @@ local function buildMazeMonsterRuntimeProfile(monsterAuthorProfile)
     return runtimeProfileOrReason
 end
 
+local function collectPatrolPointsFromWorld(world)
+    local patrolPoints = {}
+
+    if world and world.RoomAffordances then
+        for _, roomId in ipairs(world.RoomIds or {}) do
+            local affordance = world.RoomAffordances[roomId]
+            if affordance then
+                for _, patrolAnchor in ipairs(affordance.PatrolAnchors or {}) do
+                    table.insert(patrolPoints, patrolAnchor)
+                end
+            end
+        end
+    end
+
+    if #patrolPoints > 0 then
+        return patrolPoints
+    end
+
+    return world and world.PatrolPoints or {}
+end
+
 function MazeSessionService.new()
     local self = setmetatable({}, MazeSessionService)
 
@@ -492,7 +513,7 @@ function MazeSessionService:_beginFormalExpedition()
         return
     end
 
-    self.MonsterService:spawn(self.World.PatrolPoints)
+    self.MonsterService:spawn(collectPatrolPointsFromWorld(self.World))
     self:_setStatus('Maze session is live. Explore, loot, and find an extraction point.')
 end
 

--- a/tests/src/Shared/MazeFormalWorldComposer.spec.luau
+++ b/tests/src/Shared/MazeFormalWorldComposer.spec.luau
@@ -26,6 +26,7 @@ return function()
         world.ReturnHoldPad ~= nil,
         'Formal world should create a return hold pad for post-run staging'
     )
+    assert(next(world.RoomAffordances or {}) ~= nil, 'Formal world should expose room affordances')
     assert(next(world.LootNodes or {}) ~= nil, 'Formal world should create loot nodes')
     assert(next(world.ExtractionNodes or {}) ~= nil, 'Formal world should create extraction nodes')
     assert(
@@ -52,6 +53,113 @@ return function()
     end
 
     assert(extractionCount >= 1, 'Formal world should include at least one extraction node')
+
+    local patrolPointCount = 0
+    local expectedPatrolPointCount = 0
+    local controlPointCount = 0
+    local lootAffordanceCount = 0
+
+    for _, patrolPoint in ipairs(world.PatrolPoints or {}) do
+        patrolPointCount += 1
+        assert(typeof(patrolPoint) == 'Vector3', 'Patrol points should remain vector positions')
+    end
+
+    for _, roomId in ipairs(world.RoomIds) do
+        local affordance = world.RoomAffordances[roomId]
+        local room = world.RoomById[roomId]
+
+        assert(affordance ~= nil, string.format('Room %s should have an affordance entry', roomId))
+        assert(affordance.RoomId == roomId, 'Affordance should preserve the room id')
+        assert(
+            affordance.RoomKind == room.Kind,
+            'Affordance should expose the same room kind as the world shell'
+        )
+        assert(
+            affordance.RoomCenter == world.RoomCenters[roomId],
+            'Affordance should expose the room center'
+        )
+        assert(
+            #(affordance.SpawnSockets or {}) >= 1,
+            'Each room should expose a primary spawn socket'
+        )
+        assert(
+            #(affordance.SightBreakers or {}) == 0,
+            'Sight breakers should be an explicit empty list until authored sources exist'
+        )
+        assert(
+            #(affordance.ThreatTags or {}) >= 1,
+            'Each affordance should expose at least one threat tag'
+        )
+        assert(
+            affordance.ThreatTags[1] == string.format('RoomKind:%s', room.Kind),
+            'Threat tags should currently derive from room kind only'
+        )
+        assert(
+            type(affordance.TraversalMask) == 'table',
+            'Each affordance should expose a traversal mask table'
+        )
+        assert(
+            #(affordance.TraversalMask.NeighborRoomIds or {}) == room.DoorCount,
+            'Traversal mask should expose one neighboring room id per connected doorway'
+        )
+        assert(
+            #(affordance.TraversalMask.DoorwayIds or {}) == room.DoorCount,
+            'Traversal mask should expose one doorway id per connected doorway'
+        )
+        assert(
+            #(affordance.TraversalMask.ExitDirections or {}) == #(room.ExitDirections or {}),
+            'Traversal mask should preserve external exit directions'
+        )
+
+        for _, doorwayId in ipairs(affordance.TraversalMask.DoorwayIds or {}) do
+            assert(world.Doorways[doorwayId] ~= nil, 'Traversal mask doorway ids should be valid')
+        end
+
+        for _, controlPoint in ipairs(affordance.DoorControlPoints or {}) do
+            controlPointCount += 1
+            local doorway = world.Doorways[controlPoint.DoorwayId]
+            assert(doorway ~= nil, 'Door control points should reference a valid doorway')
+            assert(
+                doorway.Prompt ~= nil,
+                'Door control points should only expose interactable doorways'
+            )
+            assert(
+                controlPoint.Position == doorway.Prompt.Parent.Position,
+                'Door control points should expose the prompt position'
+            )
+        end
+
+        if room.Kind == 'Loot' then
+            lootAffordanceCount += 1
+            expectedPatrolPointCount += 1
+            assert(
+                #(affordance.PatrolAnchors or {}) == 1,
+                'Loot rooms should provide one patrol anchor in the minimal affordance pass'
+            )
+
+            local lootNode = world.LootNodes[roomId]
+            assert(lootNode ~= nil, 'Loot rooms should still expose loot runtime nodes')
+            assert(
+                lootNode.Position == affordance.SpawnSockets[1].Position,
+                'Loot node positions should derive from the room spawn socket'
+            )
+        else
+            assert(
+                #(affordance.PatrolAnchors or {}) == 0,
+                'Non-loot rooms should not gain patrol anchors in the minimal affordance pass'
+            )
+        end
+    end
+
+    assert(lootAffordanceCount >= 1, 'Formal world should expose at least one loot affordance')
+    assert(
+        patrolPointCount == expectedPatrolPointCount,
+        'Legacy patrol points should remain a flattened view of loot-room patrol anchors'
+    )
+    assert(
+        controlPointCount >= 1,
+        'Formal world affordances should expose at least one interactable door control point'
+    )
 
     local ok, err = pcall(function()
         composer.build(12345, shared.Config.SessionConfig.ProcGen, {


### PR DESCRIPTION
## Summary
- add `World.RoomAffordances` to the formal maze world so rooms expose a shared affordance surface instead of only coarse `PatrolPoints`
- derive loot placement, patrol anchors, door control points, threat tags, and traversal metadata from the current maze world output without introducing new prefab authoring formats
- migrate the maze monster startup path to collect patrol anchors from room affordances while keeping legacy runtime fields available for compatibility

## Why This Lives In maze
- `#103` is a maze-owned world/runtime issue: it changes how the formal maze world exposes room capability data to maze-side consumers
- this PR does not change teleport payloads, remotes, replicated snapshot shape, `SessionConfig.PlaceIds`, or any shared handoff semantics under `packages/shared/src/Session/**` or `packages/shared/src/Network/**`
- although the implementation touches shared runtime code, the changed meaning stays inside the maze expedition runtime, so this remains a `maze` lane change instead of `contract-first`

## Scope
- add `MazeRoomAffordance`-shaped room entries under `World.RoomAffordances` in `MazeFormalWorldComposer`
- derive `SpawnSockets`, `PatrolAnchors`, `SightBreakers`, `DoorControlPoints`, `ThreatTags`, and `TraversalMask` from existing room / doorway runtime data
- move the maze monster spawn path in `MazeSessionService` to read patrol anchors from room affordances instead of directly consuming `World.PatrolPoints`
- extend deterministic composer coverage to lock the affordance shape, loot spawn derivation, patrol anchor flattening, and door control point grouping

## Validation
- `stylua --check packages/shared/src/Runtime/MazeFormalWorldComposer.luau places/maze/src/ServerScriptService/Maze/MazeSessionService.luau tests/src/Shared/MazeFormalWorldComposer.spec.luau`
- `selene .`
- `rojo build places/maze/default.project.json -o .\\tmp\\maze.rbxlx`
- `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`
- `run-in-roblox --place .\\tmp\\roblox_experience-tests.rbxlx --script tests/run-in-roblox.lua`

## Risks / Follow-Up
- `SightBreakers` and `ThreatTags` are intentionally minimal in this pass: they provide stable shape now, but they do not yet carry authored prefab semantics or new gameplay meaning
- legacy `World.PatrolPoints` is still preserved as a flattened compatibility view, but new consumers should prefer `World.RoomAffordances`
- manual Studio verification for maze spawn / loot / door interaction is still recommended before using these affordances as the basis for `#39`

Closes #103