### PR TITLE
[Teleport][Run] Switch maze handoff to TeleportAsync reserved-server flow

### DIFF
--- a/places/run/src/ServerScriptService/Run/RunMazePortal.luau
+++ b/places/run/src/ServerScriptService/Run/RunMazePortal.luau
@@ -13,8 +13,15 @@ local RunMazePortal = {}
 
 RunMazePortal.FailureCode = table.freeze({
     ReserveServerFailed = 'ReserveServerFailed',
-    TeleportToPrivateServerFailed = 'TeleportToPrivateServerFailed',
+    TeleportAsyncFailed = 'TeleportAsyncFailed',
 })
+
+local function buildReservedServerTeleportOptions(accessCode, teleportData)
+    local teleportOptions = Instance.new('TeleportOptions')
+    teleportOptions.ReservedServerAccessCode = accessCode
+    teleportOptions:SetTeleportData(teleportData)
+    return teleportOptions
+end
 
 function RunMazePortal.enter(params)
     local currentSession = CampMazeSessionContract.normalizeCampSession(params.CampSession)
@@ -58,25 +65,24 @@ function RunMazePortal.enter(params)
         EntryReason = params.EntryReason or 'maze_gate',
     })
 
+    local teleportOptions = buildReservedServerTeleportOptions(mazeAccessCode, teleportData)
     local success, message = pcall(function()
-        TeleportService:TeleportToPrivateServer(
+        TeleportService:TeleportAsync(
             SessionConfig.PlaceIds.Maze,
-            mazeAccessCode,
             { params.Player },
-            nil,
-            teleportData
+            teleportOptions
         )
     end)
     if not success then
         return {
             Ok = false,
-            FailureCode = RunMazePortal.FailureCode.TeleportToPrivateServerFailed,
+            FailureCode = RunMazePortal.FailureCode.TeleportAsyncFailed,
             Reason = TeleportDiagnostics.formatFailure(
-                'TeleportToPrivateServer',
+                'TeleportAsync',
                 message,
                 mazeTeleportSnapshot
             ),
-            ReasonCode = RunMazePortal.FailureCode.TeleportToPrivateServerFailed,
+            ReasonCode = RunMazePortal.FailureCode.TeleportAsyncFailed,
             CurrentSession = currentSession,
         }
     end


### PR DESCRIPTION
## TL;DR
This draft PR replaces the `run -> maze` handoff path in `RunSessionService` so it reserves the maze server with `ReserveServerAsync`, then dispatches players with `TeleportAsync + TeleportOptions` while preserving the existing `CampSession` / `MazeAccessCode` / `TeleportData` contract.

## Scope
- remove the old `RunMazePortal.enter(...)` handoff path from `run`
- reserve or reuse a maze access code directly in `RunSessionService`
- dispatch the player with `TeleportAsync` and `ReservedServerAccessCode`
- add ordered `[RunMazeDiag]` diagnostics for begin, reserve, payload-ready, dispatch, and failure
- keep failure text routed through `TeleportDiagnostics` so the HUD/status still includes place/context metadata

## Why
Issue #75 is blocking the live `liminal/run -> maze` path with a `ReserveServer failed: HTTP 403` style error. This PR isolates the transport-layer change without mixing in maze-side diagnostics or other gameplay work.

## Out Of Scope
- no maze-side build/seed/direct-boot validation changes
- no `lobby -> run` or `maze -> run` teleport refactor
- no claim that the platform-side 403 is fully resolved until live publish verification passes

## Validation
- `stylua --check .`
- `selene .`
- manual live verification still required on published `liminal` + `maze`

## Follow-up Verification
- publish `run/liminal` and `maze`
- trigger one live `run -> maze`
- confirm we no longer fail at the old reserved-server handoff point
- if it still fails, append the `[RunMazeDiag]` sequence back to #75

Refs #75
