### PR TITLE
Refactor monster runtime into modular enemy components

### DIFF
--- a/packages/shared/src/Runtime/MonsterRuntime/AttackComponent.luau
+++ b/packages/shared/src/Runtime/MonsterRuntime/AttackComponent.luau
@@ -1,0 +1,43 @@
+local AttackComponent = {}
+AttackComponent.__index = AttackComponent
+
+function AttackComponent.new(options)
+    local runtimeOptions = options or {}
+
+    return setmetatable({
+        Clock = runtimeOptions.Clock or os.clock,
+        AttackRange = runtimeOptions.AttackRange or 0,
+        CooldownSeconds = runtimeOptions.CooldownSeconds or 0.8,
+        LastAttackAt = -math.huge,
+    }, AttackComponent)
+end
+
+function AttackComponent:tryQueueAttack(currentPosition, blackboard)
+    local target = blackboard.CurrentTarget
+    if target == nil then
+        return false
+    end
+
+    local targetPosition = blackboard.TargetPositions[target]
+    if targetPosition == nil then
+        return false
+    end
+
+    local now = self.Clock()
+    if (now - self.LastAttackAt) < self.CooldownSeconds then
+        return false
+    end
+
+    if self.AttackRange <= 0 then
+        return false
+    end
+
+    if (targetPosition - currentPosition).Magnitude > self.AttackRange then
+        return false
+    end
+
+    self.LastAttackAt = now
+    return true
+end
+
+return AttackComponent

--- a/packages/shared/src/Runtime/MonsterRuntime/EnemyBlackboard.luau
+++ b/packages/shared/src/Runtime/MonsterRuntime/EnemyBlackboard.luau
@@ -1,0 +1,41 @@
+local EnemyBlackboard = {}
+EnemyBlackboard.__index = EnemyBlackboard
+
+function EnemyBlackboard.new(options)
+    local runtimeOptions = options or {}
+
+    return setmetatable({
+        CurrentTarget = nil,
+        PreviousTarget = nil,
+        TargetPositions = {},
+        Awareness = 0,
+        PerceptionState = 'Idle',
+        LastSeenPosition = nil,
+        LastSeenAt = nil,
+        MemoryDurationSeconds = runtimeOptions.MemoryDurationSeconds or 3,
+    }, EnemyBlackboard)
+end
+
+function EnemyBlackboard:setTarget(nextTarget, targetPosition, now)
+    if self.CurrentTarget ~= nextTarget then
+        self.PreviousTarget = self.CurrentTarget
+    end
+
+    self.CurrentTarget = nextTarget
+    self.Awareness = if nextTarget ~= nil then 1 else 0
+
+    if nextTarget ~= nil and targetPosition ~= nil then
+        self.LastSeenPosition = targetPosition
+        self.LastSeenAt = now
+    end
+end
+
+function EnemyBlackboard:canUseLastSeen(now)
+    if self.LastSeenPosition == nil or self.LastSeenAt == nil then
+        return false
+    end
+
+    return (now - self.LastSeenAt) <= self.MemoryDurationSeconds
+end
+
+return EnemyBlackboard

--- a/packages/shared/src/Runtime/MonsterRuntime/EnemyRuntime.luau
+++ b/packages/shared/src/Runtime/MonsterRuntime/EnemyRuntime.luau
@@ -1,0 +1,81 @@
+local EnemyBlackboard = require(script.Parent.EnemyBlackboard)
+local EnemyStateMachine = require(script.Parent.EnemyStateMachine)
+local PerceptionComponent = require(script.Parent.PerceptionComponent)
+local MovementComponent = require(script.Parent.MovementComponent)
+local AttackComponent = require(script.Parent.AttackComponent)
+local HealthComponent = require(script.Parent.HealthComponent)
+
+local EnemyRuntime = {}
+EnemyRuntime.__index = EnemyRuntime
+
+function EnemyRuntime.new(options)
+    local runtimeOptions = options or {}
+
+    local blackboard = EnemyBlackboard.new({
+        MemoryDurationSeconds = runtimeOptions.MemoryDurationSeconds,
+    })
+
+    return setmetatable({
+        Blackboard = blackboard,
+        StateMachine = EnemyStateMachine.new(),
+        Perception = PerceptionComponent.new(runtimeOptions.Perception),
+        Movement = MovementComponent.new(runtimeOptions.Movement),
+        Attack = AttackComponent.new(runtimeOptions.Attack),
+        Health = HealthComponent.new(runtimeOptions.Health),
+        Context = {
+            PatrolPoints = {},
+            PatrolIndex = 1,
+        },
+        Clock = runtimeOptions.Clock or os.clock,
+    }, EnemyRuntime)
+end
+
+function EnemyRuntime:reset(patrolPoints, initialPatrolIndex)
+    self.Context.PatrolPoints = patrolPoints or {}
+    self.Context.PatrolIndex = initialPatrolIndex or 1
+    self.Blackboard.CurrentTarget = nil
+    self.Blackboard.PreviousTarget = nil
+    self.Blackboard.TargetPositions = {}
+    self.Blackboard.Awareness = 0
+    self.Blackboard.PerceptionState = EnemyStateMachine.State.Idle
+    self.Blackboard.LastSeenPosition = nil
+    self.Blackboard.LastSeenAt = nil
+    self.StateMachine.Current = EnemyStateMachine.State.Idle
+    self.StateMachine.Previous = nil
+end
+
+function EnemyRuntime:update(dt)
+    if not self.Health:isAlive() then
+        return {
+            NextPosition = nil,
+            AnimationName = 'Idle',
+            AnimationSpeed = 1,
+            ShouldPlayChaseLoop = false,
+            TargetChanged = false,
+            StateChanged = false,
+            AttackQueued = false,
+            PerceptionState = self.Blackboard.PerceptionState,
+        }
+    end
+
+    local targetChanged = self.Perception:update(self.Blackboard)
+    local stateChanged, state = self.StateMachine:update(self.Blackboard, self.Clock())
+
+    local movementDecision = self.Movement:update(self.Context, self.Blackboard, state, dt)
+
+    local currentPosition = self.Movement.GetCurrentPosition()
+    local attackQueued = self.Attack:tryQueueAttack(currentPosition, self.Blackboard)
+
+    return {
+        NextPosition = movementDecision.NextPosition,
+        AnimationName = movementDecision.AnimationName,
+        AnimationSpeed = movementDecision.AnimationSpeed,
+        ShouldPlayChaseLoop = movementDecision.ShouldPlayChaseLoop,
+        TargetChanged = targetChanged,
+        StateChanged = stateChanged,
+        AttackQueued = attackQueued,
+        PerceptionState = state,
+    }
+end
+
+return EnemyRuntime

--- a/packages/shared/src/Runtime/MonsterRuntime/EnemyStateMachine.luau
+++ b/packages/shared/src/Runtime/MonsterRuntime/EnemyStateMachine.luau
@@ -1,0 +1,37 @@
+local EnemyStateMachine = {}
+EnemyStateMachine.__index = EnemyStateMachine
+
+EnemyStateMachine.State = table.freeze({
+    Idle = 'Idle',
+    Suspect = 'Suspect',
+    Alert = 'Alert',
+    Search = 'Search',
+})
+
+function EnemyStateMachine.new()
+    return setmetatable({
+        Current = EnemyStateMachine.State.Idle,
+        Previous = nil,
+    }, EnemyStateMachine)
+end
+
+function EnemyStateMachine:update(blackboard, now)
+    local nextState = EnemyStateMachine.State.Idle
+
+    if blackboard.CurrentTarget ~= nil then
+        nextState = EnemyStateMachine.State.Alert
+    elseif blackboard:canUseLastSeen(now) then
+        nextState = EnemyStateMachine.State.Search
+    end
+
+    local changed = nextState ~= self.Current
+    if changed then
+        self.Previous = self.Current
+        self.Current = nextState
+    end
+
+    blackboard.PerceptionState = nextState
+    return changed, nextState
+end
+
+return EnemyStateMachine

--- a/packages/shared/src/Runtime/MonsterRuntime/HealthComponent.luau
+++ b/packages/shared/src/Runtime/MonsterRuntime/HealthComponent.luau
@@ -1,0 +1,24 @@
+local HealthComponent = {}
+HealthComponent.__index = HealthComponent
+
+function HealthComponent.new(options)
+    local runtimeOptions = options or {}
+    local maxHealth = runtimeOptions.MaxHealth or 1
+
+    return setmetatable({
+        MaxHealth = maxHealth,
+        CurrentHealth = maxHealth,
+    }, HealthComponent)
+end
+
+function HealthComponent:isAlive()
+    return self.CurrentHealth > 0
+end
+
+function HealthComponent:applyDamage(amount)
+    local damage = math.max(0, amount or 0)
+    self.CurrentHealth = math.max(0, self.CurrentHealth - damage)
+    return self.CurrentHealth
+end
+
+return HealthComponent

--- a/packages/shared/src/Runtime/MonsterRuntime/MovementComponent.luau
+++ b/packages/shared/src/Runtime/MonsterRuntime/MovementComponent.luau
@@ -14,6 +14,7 @@ function MovementComponent.new(options)
         PatrolSpeedMultiplier = runtimeOptions.PatrolSpeedMultiplier,
         EnableChase = runtimeOptions.EnableChase,
         EnablePatrol = runtimeOptions.EnablePatrol,
+        ArrivalThreshold = runtimeOptions.ArrivalThreshold or 2,
     }, MovementComponent)
 end
 

--- a/packages/shared/src/Runtime/MonsterRuntime/MovementComponent.luau
+++ b/packages/shared/src/Runtime/MonsterRuntime/MovementComponent.luau
@@ -52,7 +52,7 @@ function MovementComponent:update(context, blackboard, state, dt)
         )
         animationName = 'Walk'
 
-        if (nextPosition - patrolTarget).Magnitude <= 2 then
+        if (nextPosition - patrolTarget).Magnitude <= self.ArrivalThreshold then
             context.PatrolIndex = (context.PatrolIndex % #context.PatrolPoints) + 1
         end
     end

--- a/packages/shared/src/Runtime/MonsterRuntime/MovementComponent.luau
+++ b/packages/shared/src/Runtime/MonsterRuntime/MovementComponent.luau
@@ -1,0 +1,67 @@
+local EnemyStateMachine = require(script.Parent.EnemyStateMachine)
+
+local MovementComponent = {}
+MovementComponent.__index = MovementComponent
+
+function MovementComponent.new(options)
+    local runtimeOptions = options or {}
+
+    return setmetatable({
+        StepToward = runtimeOptions.StepToward,
+        GetCurrentPosition = runtimeOptions.GetCurrentPosition,
+        SpawnOffset = runtimeOptions.SpawnOffset,
+        Speed = runtimeOptions.Speed,
+        PatrolSpeedMultiplier = runtimeOptions.PatrolSpeedMultiplier,
+        EnableChase = runtimeOptions.EnableChase,
+        EnablePatrol = runtimeOptions.EnablePatrol,
+    }, MovementComponent)
+end
+
+function MovementComponent:update(context, blackboard, state, dt)
+    local currentPosition = self.GetCurrentPosition()
+    local nextPosition
+    local animationName = 'Idle'
+    local animationSpeed = 1
+    local shouldPlayChaseLoop = false
+
+    if
+        state == EnemyStateMachine.State.Alert
+        and blackboard.CurrentTarget ~= nil
+        and self.EnableChase
+    then
+        nextPosition = self.StepToward(
+            currentPosition,
+            blackboard.TargetPositions[blackboard.CurrentTarget],
+            self.Speed,
+            dt
+        )
+        animationName = 'Run'
+        animationSpeed = 1.15
+        shouldPlayChaseLoop = true
+    elseif state == EnemyStateMachine.State.Search and blackboard.LastSeenPosition ~= nil then
+        nextPosition = self.StepToward(currentPosition, blackboard.LastSeenPosition, self.Speed, dt)
+        animationName = 'Walk'
+    elseif self.EnablePatrol and #context.PatrolPoints > 0 then
+        local patrolTarget = context.PatrolPoints[context.PatrolIndex] + self.SpawnOffset
+        nextPosition = self.StepToward(
+            currentPosition,
+            patrolTarget,
+            self.Speed * self.PatrolSpeedMultiplier,
+            dt
+        )
+        animationName = 'Walk'
+
+        if (nextPosition - patrolTarget).Magnitude <= 2 then
+            context.PatrolIndex = (context.PatrolIndex % #context.PatrolPoints) + 1
+        end
+    end
+
+    return {
+        NextPosition = nextPosition,
+        AnimationName = animationName,
+        AnimationSpeed = animationSpeed,
+        ShouldPlayChaseLoop = shouldPlayChaseLoop,
+    }
+end
+
+return MovementComponent

--- a/packages/shared/src/Runtime/MonsterRuntime/PerceptionComponent.luau
+++ b/packages/shared/src/Runtime/MonsterRuntime/PerceptionComponent.luau
@@ -1,0 +1,45 @@
+local PerceptionComponent = {}
+PerceptionComponent.__index = PerceptionComponent
+
+function PerceptionComponent.new(options)
+    local runtimeOptions = options or {}
+
+    return setmetatable({
+        GetPlayers = runtimeOptions.GetPlayers,
+        CanTargetPlayer = runtimeOptions.CanTargetPlayer,
+        GetCurrentPosition = runtimeOptions.GetCurrentPosition,
+        PickNearestTarget = runtimeOptions.PickNearestTarget,
+        SightRange = runtimeOptions.SightRange,
+        EnableSenseNearestTarget = runtimeOptions.EnableSenseNearestTarget,
+        GetNow = runtimeOptions.GetNow,
+    }, PerceptionComponent)
+end
+
+function PerceptionComponent:update(blackboard)
+    local playerPositions = {}
+
+    for _, player in ipairs(self.GetPlayers()) do
+        if self.CanTargetPlayer(player) then
+            local character = player.Character
+            local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+            if rootPart then
+                playerPositions[player] = rootPart.Position
+            end
+        end
+    end
+
+    blackboard.TargetPositions = playerPositions
+
+    local targetPlayer
+    if self.EnableSenseNearestTarget then
+        targetPlayer =
+            self.PickNearestTarget(self.GetCurrentPosition(), playerPositions, self.SightRange)
+    end
+
+    local now = self.GetNow()
+    blackboard:setTarget(targetPlayer, playerPositions[targetPlayer], now)
+
+    return targetPlayer ~= blackboard.PreviousTarget
+end
+
+return PerceptionComponent

--- a/packages/shared/src/Runtime/MonsterRuntime/PerceptionComponent.luau
+++ b/packages/shared/src/Runtime/MonsterRuntime/PerceptionComponent.luau
@@ -36,10 +36,11 @@ function PerceptionComponent:update(blackboard)
             self.PickNearestTarget(self.GetCurrentPosition(), playerPositions, self.SightRange)
     end
 
+    local previousTarget = blackboard.CurrentTarget
     local now = self.GetNow()
     blackboard:setTarget(targetPlayer, playerPositions[targetPlayer], now)
 
-    return targetPlayer ~= blackboard.PreviousTarget
+    return targetPlayer ~= previousTarget
 end
 
 return PerceptionComponent

--- a/packages/shared/src/Runtime/MonsterRuntime/init.luau
+++ b/packages/shared/src/Runtime/MonsterRuntime/init.luau
@@ -1,0 +1,9 @@
+return {
+    EnemyBlackboard = require(script.EnemyBlackboard),
+    EnemyRuntime = require(script.EnemyRuntime),
+    EnemyStateMachine = require(script.EnemyStateMachine),
+    PerceptionComponent = require(script.PerceptionComponent),
+    MovementComponent = require(script.MovementComponent),
+    AttackComponent = require(script.AttackComponent),
+    HealthComponent = require(script.HealthComponent),
+}

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -183,7 +183,7 @@ function MonsterService.new(
     }, MonsterService)
 
     service.EnemyRuntime = EnemyRuntime.new({
-        MemoryDurationSeconds = runtimeOptions.MemoryDurationSeconds or 0,
+        MemoryDurationSeconds = runtimeOptions.MemoryDurationSeconds,
         Perception = {
             GetPlayers = function()
                 return service.GetPlayers()

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -215,7 +215,7 @@ function MonsterService.new(
         },
         Attack = {
             AttackRange = monsterRuntimeProfile.AttackRange or 0,
-            CooldownSeconds = monsterRuntimeProfile.AttackCooldownSeconds or 0.8,
+            CooldownSeconds = monsterRuntimeProfile.AttackCooldownSeconds,
         },
     })
 

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -9,6 +9,7 @@ local Gameplay = require(Packages:WaitForChild('Gameplay'))
 
 local MonsterBehaviorCatalog = Gameplay.Monsters.MonsterBehaviorCatalog
 local MonsterComponentConfig = Gameplay.Monsters.MonsterComponentConfig
+local MonsterLogic = Gameplay.Monsters.MonsterLogic
 local Enemy = Gameplay.Monsters.Enemy
 local MonsterRuntimeProfile = Gameplay.Monsters.MonsterRuntimeProfile
 local EnemyRuntime = require(script.Parent.MonsterRuntime.EnemyRuntime)

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -11,6 +11,7 @@ local MonsterBehaviorCatalog = Gameplay.Monsters.MonsterBehaviorCatalog
 local MonsterComponentConfig = Gameplay.Monsters.MonsterComponentConfig
 local Enemy = Gameplay.Monsters.Enemy
 local MonsterRuntimeProfile = Gameplay.Monsters.MonsterRuntimeProfile
+local EnemyRuntime = require(script.Parent.MonsterRuntime.EnemyRuntime)
 
 local MonsterService = {}
 MonsterService.__index = MonsterService
@@ -121,7 +122,7 @@ function MonsterService.new(
         randomSeed = nil
     end
 
-    return setmetatable({
+    local service = setmetatable({
         Definition = monsterRuntimeProfile,
         IsExpeditionActive = isExpeditionActiveCallback,
         CanTargetPlayer = canTargetPlayerCallback or function()
@@ -180,6 +181,49 @@ function MonsterService.new(
         RandomSource = runtimeOptions.RandomSource
             or if randomSeed ~= nil then Random.new(randomSeed) else Random.new(),
     }, MonsterService)
+
+    service.EnemyRuntime = EnemyRuntime.new({
+        MemoryDurationSeconds = runtimeOptions.MemoryDurationSeconds or 0,
+        Perception = {
+            GetPlayers = function()
+                return service.GetPlayers()
+            end,
+            CanTargetPlayer = function(player)
+                return service.CanTargetPlayer(player)
+            end,
+            GetCurrentPosition = function()
+                return service:_getCurrentPosition()
+            end,
+            PickNearestTarget = MonsterLogic.pickNearestTarget,
+            SightRange = monsterRuntimeProfile.SightRange,
+            EnableSenseNearestTarget = monsterRuntimeProfile.Behaviors[MonsterBehaviorCatalog.Behavior.SenseNearestTarget]
+                == true,
+            GetNow = os.clock,
+        },
+        Movement = {
+            StepToward = MonsterLogic.stepToward,
+            GetCurrentPosition = function()
+                return service:_getCurrentPosition()
+            end,
+            SpawnOffset = monsterRuntimeProfile.SpawnOffset,
+            Speed = monsterRuntimeProfile.Speed,
+            PatrolSpeedMultiplier = monsterRuntimeProfile.PatrolSpeedMultiplier,
+            EnableChase = monsterRuntimeProfile.Behaviors[MonsterBehaviorCatalog.Behavior.Chase]
+                == true,
+            EnablePatrol = monsterRuntimeProfile.Behaviors[MonsterBehaviorCatalog.Behavior.Patrol]
+                == true,
+        },
+        Attack = {
+            AttackRange = monsterRuntimeProfile.AttackRange or 0,
+            CooldownSeconds = monsterRuntimeProfile.AttackCooldownSeconds or 0.8,
+        },
+    })
+
+    return service
+end
+
+function MonsterService:_emitDecisionLog(eventName, fields)
+    self:_recordDecisionEvent(eventName, fields)
 end
 
 function MonsterService:destroy()
@@ -838,6 +882,7 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
     end
 
     self.PatrolIndex = math.clamp(initialPatrolIndex or 1, 1, #patrolPoints)
+    self.EnemyRuntime:reset(self.PatrolPoints, self.PatrolIndex)
     local spawnPosition = patrolPoints[self.PatrolIndex] + self.Definition.SpawnOffset
     local spawnOk, spawnReason = self:_spawnModel(spawnPosition)
     if not spawnOk then
@@ -862,51 +907,33 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
 end
 
 function MonsterService:_runLogicStep(dt)
-    local playerPositions = {}
-
-    for _, player in ipairs(self.GetPlayers()) do
-        if self.CanTargetPlayer(player) then
-            local character = player.Character
-            local rootPart = character and character:FindFirstChild('HumanoidRootPart')
-            if rootPart then
-                playerPositions[player] = rootPart.Position
-            end
-        end
-    end
-
     local currentPosition = self:_getCurrentPosition()
     if currentPosition == nil then
         return
     end
 
-    local patrolTarget = nil
-    if
-        self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.Patrol]
-        and #self.PatrolPoints > 0
-    then
-        patrolTarget = self.PatrolPoints[self.PatrolIndex] + self.Definition.SpawnOffset
+    local decision = self.EnemyRuntime:update(dt)
+    self.PatrolIndex = self.EnemyRuntime.Context.PatrolIndex
+
+    if decision.TargetChanged then
+        self:_emitDecisionLog('TargetChanged', {
+            MonsterId = self.Definition.Id,
+            State = decision.PerceptionState,
+        })
+    end
+    if decision.StateChanged then
+        self:_emitDecisionLog('StateChanged', {
+            MonsterId = self.Definition.Id,
+            State = decision.PerceptionState,
+        })
+    end
+    if decision.AttackQueued then
+        self:_emitDecisionLog('AttackQueued', {
+            MonsterId = self.Definition.Id,
+        })
     end
 
-    local decision = self.EnemyRuntime:update(dt, {
-        Behaviors = self.Definition.Behaviors,
-        ComponentConfig = self.ComponentConfig,
-        CurrentPosition = currentPosition,
-        NextRandomInteger = function(minimum, maximum, reason)
-            return self:_nextRandomInteger(minimum, maximum, reason)
-        end,
-        PatrolReachDistance = 2,
-        PatrolSpeedMultiplier = self.Definition.PatrolSpeedMultiplier,
-        PatrolTargetPosition = patrolTarget,
-        PlayerPositions = playerPositions,
-        SightRange = self.Definition.SightRange,
-        Speed = self.Definition.Speed,
-    }) or {}
-    self:_queueAttackIntent(decision.AttackIntent)
     local nextPosition = decision.NextPosition
-    if decision.ShouldAdvancePatrol and #self.PatrolPoints > 0 then
-        self.PatrolIndex = (self.PatrolIndex % #self.PatrolPoints) + 1
-    end
-
     if nextPosition and self.CanTraverse(currentPosition, nextPosition) then
         local travelOffset = nextPosition - currentPosition
         self.LogicalPosition = nextPosition
@@ -921,11 +948,8 @@ function MonsterService:_runLogicStep(dt)
             else currentRotation + nextPosition
         self.PendingVisualCFrame = facingCFrame
 
-        self:_setAnimationState(
-            decision.DesiredAnimation or 'Idle',
-            decision.DesiredAnimationSpeed or 1
-        )
-        self:_setChaseLoopSoundPlaying(decision.ShouldPlayChaseLoop)
+        self:_setAnimationState(decision.AnimationName or 'Idle', decision.AnimationSpeed or 1)
+        self:_setChaseLoopSoundPlaying(decision.ShouldPlayChaseLoop == true)
     else
         self.PendingVisualCFrame = nil
         self:_setAnimationState('Idle', 1)

--- a/packages/shared/src/Runtime/init.luau
+++ b/packages/shared/src/Runtime/init.luau
@@ -8,6 +8,7 @@ return {
     MazeLightingProfile = require(script.MazeLightingProfile),
     MazeModuleAssetContract = require(script.MazeModuleAssetContract),
     MazeWorldShellBuilder = require(script.MazeWorldShellBuilder),
+    MonsterRuntime = require(script.MonsterRuntime),
     MonsterService = require(script.MonsterService),
     PlayerStateService = require(script.PlayerStateService),
     TeleportInventoryHydrator = require(script.TeleportInventoryHydrator),

--- a/tests/src/Shared/EnemyRuntime.spec.luau
+++ b/tests/src/Shared/EnemyRuntime.spec.luau
@@ -1,0 +1,96 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local packages = ReplicatedStorage:WaitForChild('Packages')
+    local shared = require(packages:WaitForChild('Shared'))
+
+    local enemyRuntimeModule = shared.Runtime.MonsterRuntime.EnemyRuntime
+
+    local currentPosition = Vector3.new(0, 0, 0)
+    local players = {}
+    local clockValue = 100
+
+    local runtime = enemyRuntimeModule.new({
+        MemoryDurationSeconds = 0,
+        Perception = {
+            GetPlayers = function()
+                return players
+            end,
+            CanTargetPlayer = function()
+                return true
+            end,
+            GetCurrentPosition = function()
+                return currentPosition
+            end,
+            PickNearestTarget = function(origin, positions, sightRange)
+                local closest = nil
+                local closestDistance = sightRange
+                for player, position in pairs(positions) do
+                    local distance = (position - origin).Magnitude
+                    if distance <= closestDistance then
+                        closest = player
+                        closestDistance = distance
+                    end
+                end
+                return closest
+            end,
+            SightRange = 36,
+            EnableSenseNearestTarget = true,
+            GetNow = function()
+                return clockValue
+            end,
+        },
+        Movement = {
+            StepToward = function(origin, target, speed, dt)
+                local offset = target - origin
+                local distance = offset.Magnitude
+                if distance == 0 then
+                    return origin
+                end
+                local step = math.min(speed * dt, distance)
+                return origin + offset.Unit * step
+            end,
+            GetCurrentPosition = function()
+                return currentPosition
+            end,
+            SpawnOffset = Vector3.new(0, 4, 0),
+            Speed = 14,
+            PatrolSpeedMultiplier = 0.45,
+            EnableChase = true,
+            EnablePatrol = false,
+        },
+    })
+
+    runtime:reset({ Vector3.new(0, 0, 0) }, 1)
+
+    local idleDecision = runtime:update(0.5)
+    assert(idleDecision.PerceptionState == 'Idle', 'No target should keep enemy in idle state')
+    assert(idleDecision.NextPosition == nil, 'Idle decision should not move the enemy')
+
+    local player = {
+        Character = {
+            FindFirstChild = function(_, childName)
+                if childName ~= 'HumanoidRootPart' then
+                    return nil
+                end
+                return {
+                    Position = Vector3.new(10, 0, 0),
+                }
+            end,
+        },
+    }
+    players = { player }
+
+    local chaseDecision = runtime:update(0.5)
+    assert(chaseDecision.StateChanged == true, 'Acquiring target should cause state transition')
+    assert(chaseDecision.PerceptionState == 'Alert', 'Target detection should enter alert state')
+    assert(chaseDecision.NextPosition ~= nil, 'Alert state should produce chase movement')
+    assert(chaseDecision.AnimationName == 'Run', 'Alert movement should use run animation')
+
+    currentPosition = chaseDecision.NextPosition
+    players = {}
+    clockValue += 1
+
+    local lostDecision = runtime:update(0.5)
+    assert(lostDecision.PerceptionState == 'Idle', 'Memory disabled should return directly to idle')
+    assert(lostDecision.NextPosition == nil, 'Idle after losing target should stop movement')
+end


### PR DESCRIPTION
## Summary

- Extracted enemy decision logic into a new modular runtime package under `packages/shared/src/Runtime/MonsterRuntime`.
- Updated `MonsterService` to delegate perception/state/movement/attack decisions to `EnemyRuntime` while keeping existing spawn/animation/audio wiring.
- Added deterministic coverage for the new runtime decision loop in `tests/src/Shared/EnemyRuntime.spec.luau`.

## Roblox Integration Checklist

- [x] The change updates the active runtime source under `packages/**`, or I explained why another source path had to change.
- [x] If Studio tree structure changed, I updated the relevant `default.project.json` in the same PR.
- [x] If I changed Remote names, replicated schema, or visibility behavior, I updated all linked producers/consumers/tests in the same PR.
- [x] If I changed non-trivial shared/gameplay behavior, I added or updated deterministic coverage under `tests/src/Shared`, or I explained why no test change was needed.
- [x] If I touched `SessionConfig.PlaceIds` or any other real-environment configuration, I documented the required rollout or environment follow-up.
- [x] If this PR includes `.rbxl`, generated output, or other non-source artifacts, I explained why they are required.

## Validation

- [x] `stylua --check .`
- [x] `selene .`
- [x] `rojo build tests/default.project.json -o /tmp/roblox_experience-tests.rbxlx`
- [x] `run-in-roblox --place /tmp/roblox_experience-tests.rbxlx --script tests/run-in-roblox.lua`

## Notes

- Manual test notes: N/A (covered by deterministic test + run-in-roblox run)
- Risks / follow-ups: if future behavior adds suspicion/search tuning, extend `EnemyStateMachine` and its dedicated tests first.
