### PR TITLE
feat(monster): add runtime profile component mapping (#178)

### DIFF
--- a/packages/gameplay/src/Monsters/Components/MovementComponent.luau
+++ b/packages/gameplay/src/Monsters/Components/MovementComponent.luau
@@ -11,6 +11,12 @@ end
 function MovementComponent:init(_blackboard) end
 
 function MovementComponent:update(blackboard, dt)
+    local componentConfig = blackboard.Context.ComponentConfig
+    local movementConfig = if type(componentConfig) == 'table'
+            and type(componentConfig.Movement) == 'table'
+        then componentConfig.Movement
+        else {}
+
     local currentPosition = blackboard.Context.CurrentPosition
     if typeof(currentPosition) ~= 'Vector3' then
         blackboard.Transient.NextPosition = nil
@@ -31,8 +37,12 @@ function MovementComponent:update(blackboard, dt)
         and behaviors[MonsterBehaviorCatalog.Behavior.Chase]
         and typeof(targetPosition) == 'Vector3'
     then
-        nextPosition =
-            MonsterLogic.stepToward(currentPosition, targetPosition, blackboard.Context.Speed, dt)
+        nextPosition = MonsterLogic.stepToward(
+            currentPosition,
+            targetPosition,
+            movementConfig.Speed or blackboard.Context.Speed,
+            dt
+        )
     elseif
         behaviors[MonsterBehaviorCatalog.Behavior.Patrol]
         and typeof(blackboard.Context.PatrolTargetPosition) == 'Vector3'
@@ -41,12 +51,14 @@ function MovementComponent:update(blackboard, dt)
         nextPosition = MonsterLogic.stepToward(
             currentPosition,
             patrolTarget,
-            blackboard.Context.Speed * blackboard.Context.PatrolSpeedMultiplier,
+            (movementConfig.Speed or blackboard.Context.Speed)
+                * (movementConfig.PatrolSpeedMultiplier or blackboard.Context.PatrolSpeedMultiplier),
             dt
         )
 
         if
-            (nextPosition - patrolTarget).Magnitude <= (blackboard.Context.PatrolReachDistance or 2)
+            (nextPosition - patrolTarget).Magnitude
+            <= (movementConfig.PatrolReachDistance or blackboard.Context.PatrolReachDistance or 2)
         then
             shouldAdvancePatrol = true
         end

--- a/packages/gameplay/src/Monsters/Components/PerceptionComponent.luau
+++ b/packages/gameplay/src/Monsters/Components/PerceptionComponent.luau
@@ -11,6 +11,12 @@ end
 function PerceptionComponent:init(_blackboard) end
 
 function PerceptionComponent:update(blackboard, _dt)
+    local componentConfig = blackboard.Context.ComponentConfig
+    local perceptionConfig = if type(componentConfig) == 'table'
+            and type(componentConfig.Perception) == 'table'
+        then componentConfig.Perception
+        else {}
+
     local behaviors = blackboard.Context.Behaviors or {}
     if not behaviors[MonsterBehaviorCatalog.Behavior.SenseNearestTarget] then
         blackboard.Transient.HasTarget = false
@@ -28,7 +34,7 @@ function PerceptionComponent:update(blackboard, _dt)
     end
 
     local playerPositions = blackboard.Context.PlayerPositions or {}
-    local sightRange = blackboard.Context.SightRange
+    local sightRange = perceptionConfig.SightRange or blackboard.Context.SightRange
     local targetPlayer =
         MonsterLogic.pickNearestTarget(currentPosition, playerPositions, sightRange)
 

--- a/packages/gameplay/src/Monsters/Enemy.luau
+++ b/packages/gameplay/src/Monsters/Enemy.luau
@@ -23,6 +23,10 @@ local function defaultComponents()
     }
 end
 
+local function cloneContext(context)
+    return table.clone(context or {})
+end
+
 function Enemy.new(definition, options)
     local enemyOptions = options or {}
     local blackboard = enemyOptions.Blackboard or EnemyBlackboard.new(definition)
@@ -31,6 +35,7 @@ function Enemy.new(definition, options)
 
     return setmetatable({
         Blackboard = blackboard,
+        ComponentConfig = enemyOptions.ComponentConfig or {},
         StateMachine = stateMachine,
         Components = components,
         StageObserver = enemyOptions.StageObserver,
@@ -53,7 +58,9 @@ function Enemy:spawn()
 end
 
 function Enemy:update(dt, context)
-    self.Blackboard:beginTick(context)
+    local blackboardContext = cloneContext(context)
+    blackboardContext.ComponentConfig = self.ComponentConfig
+    self.Blackboard:beginTick(blackboardContext)
 
     self:_emitStage('Perception')
     self.Components.Perception:update(self.Blackboard, dt)

--- a/packages/gameplay/src/Monsters/MonsterCompiler.luau
+++ b/packages/gameplay/src/Monsters/MonsterCompiler.luau
@@ -1,5 +1,6 @@
 local MonsterAuthorProfile = require(script.Parent.MonsterAuthorProfile)
 local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
+local MonsterComponentConfig = require(script.Parent.MonsterComponentConfig)
 local MonsterEffectCatalog = require(script.Parent.MonsterEffectCatalog)
 local MonsterRuntimeProfile = require(script.Parent.MonsterRuntimeProfile)
 
@@ -67,7 +68,7 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
         end
     end
 
-    local runtimeProfile = table.freeze({
+    local runtimeProfile = {
         Id = normalizedProfile.Id,
         Name = normalizedProfile.Name,
         Presentation = cloneRuntimePresentation(normalizedProfile.Executable.Presentation),
@@ -77,7 +78,9 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
         SpawnOffset = normalizedProfile.Tuning.SpawnOffset or DEFAULT_SPAWN_OFFSET,
         Behaviors = table.freeze(behaviors),
         Effects = table.freeze(runtimeEffects),
-    })
+    }
+    runtimeProfile.Components = MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)
+    runtimeProfile = table.freeze(runtimeProfile)
 
     local validRuntimeProfile, runtimeReason = MonsterRuntimeProfile.validate(runtimeProfile)
     if not validRuntimeProfile then

--- a/packages/gameplay/src/Monsters/MonsterComponentConfig.luau
+++ b/packages/gameplay/src/Monsters/MonsterComponentConfig.luau
@@ -1,0 +1,67 @@
+local DEFAULT_ATTACK_COOLDOWN_SECONDS = 1
+local DEFAULT_ATTACK_RANGE = 4
+local DEFAULT_PATROL_REACH_DISTANCE = 2
+local DEFAULT_SPAWN_OFFSET = Vector3.new(0, 4, 0)
+
+local MonsterComponentConfig = {}
+
+local function getPositiveNumber(value, fallback, defaultValue)
+    if type(value) == 'number' and value > 0 then
+        return value
+    end
+    if type(fallback) == 'number' and fallback > 0 then
+        return fallback
+    end
+    return defaultValue
+end
+
+local function getSpawnOffset(primary, fallback)
+    if typeof(primary) == 'Vector3' then
+        return primary
+    end
+    if typeof(fallback) == 'Vector3' then
+        return fallback
+    end
+    return DEFAULT_SPAWN_OFFSET
+end
+
+function MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)
+    local profile = runtimeProfile or {}
+    local components = if type(profile.Components) == 'table' then profile.Components else {}
+
+    local perception = if type(components.Perception) == 'table' then components.Perception else {}
+    local movement = if type(components.Movement) == 'table' then components.Movement else {}
+    local attack = if type(components.Attack) == 'table' then components.Attack else {}
+
+    local componentConfig = {
+        Perception = table.freeze({
+            SightRange = getPositiveNumber(perception.SightRange, profile.SightRange, 30),
+        }),
+        Movement = table.freeze({
+            PatrolReachDistance = getPositiveNumber(
+                movement.PatrolReachDistance,
+                nil,
+                DEFAULT_PATROL_REACH_DISTANCE
+            ),
+            PatrolSpeedMultiplier = getPositiveNumber(
+                movement.PatrolSpeedMultiplier,
+                profile.PatrolSpeedMultiplier,
+                0.45
+            ),
+            SpawnOffset = getSpawnOffset(movement.SpawnOffset, profile.SpawnOffset),
+            Speed = getPositiveNumber(movement.Speed, profile.Speed, 14),
+        }),
+        Attack = table.freeze({
+            CooldownSeconds = getPositiveNumber(
+                attack.CooldownSeconds,
+                nil,
+                DEFAULT_ATTACK_COOLDOWN_SECONDS
+            ),
+            Range = getPositiveNumber(attack.Range, nil, DEFAULT_ATTACK_RANGE),
+        }),
+    }
+
+    return table.freeze(componentConfig)
+end
+
+return MonsterComponentConfig

--- a/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
@@ -6,6 +6,30 @@ local function isNonEmptyString(value)
     return type(value) == 'string' and value ~= ''
 end
 
+local function isPositiveNumber(value)
+    return type(value) == 'number' and value > 0
+end
+
+local function readComponentTable(profile, name)
+    local components = profile.Components
+    if components == nil then
+        return nil, nil
+    end
+    if type(components) ~= 'table' then
+        return nil, 'InvalidRuntimeComponents'
+    end
+
+    local component = components[name]
+    if component == nil then
+        return nil, nil
+    end
+    if type(component) ~= 'table' then
+        return nil, string.format('InvalidRuntimeComponent%s', name)
+    end
+
+    return component, nil
+end
+
 function MonsterRuntimeProfile.validate(profile)
     if type(profile) ~= 'table' then
         return false, 'MalformedMonsterRuntimeProfile'
@@ -46,19 +70,92 @@ function MonsterRuntimeProfile.validate(profile)
         return false, 'InvalidRuntimeChaseLoopSoundAssetId'
     end
 
-    if type(profile.Speed) ~= 'number' or profile.Speed <= 0 then
+    local perceptionConfig, perceptionConfigErr = readComponentTable(profile, 'Perception')
+    if perceptionConfigErr then
+        return false, perceptionConfigErr
+    end
+    local movementConfig, movementConfigErr = readComponentTable(profile, 'Movement')
+    if movementConfigErr then
+        return false, movementConfigErr
+    end
+    local attackConfig, attackConfigErr = readComponentTable(profile, 'Attack')
+    if attackConfigErr then
+        return false, attackConfigErr
+    end
+
+    if
+        perceptionConfig
+        and perceptionConfig.SightRange ~= nil
+        and not isPositiveNumber(perceptionConfig.SightRange)
+    then
+        return false, 'InvalidRuntimeComponentPerceptionSightRange'
+    end
+
+    if movementConfig then
+        if movementConfig.Speed ~= nil and not isPositiveNumber(movementConfig.Speed) then
+            return false, 'InvalidRuntimeComponentMovementSpeed'
+        end
+        if
+            movementConfig.PatrolSpeedMultiplier ~= nil
+            and not isPositiveNumber(movementConfig.PatrolSpeedMultiplier)
+        then
+            return false, 'InvalidRuntimeComponentMovementPatrolSpeedMultiplier'
+        end
+        if
+            movementConfig.PatrolReachDistance ~= nil
+            and not isPositiveNumber(movementConfig.PatrolReachDistance)
+        then
+            return false, 'InvalidRuntimeComponentMovementPatrolReachDistance'
+        end
+        if
+            movementConfig.SpawnOffset ~= nil
+            and typeof(movementConfig.SpawnOffset) ~= 'Vector3'
+        then
+            return false, 'InvalidRuntimeComponentMovementSpawnOffset'
+        end
+    end
+
+    if attackConfig then
+        if attackConfig.Range ~= nil and not isPositiveNumber(attackConfig.Range) then
+            return false, 'InvalidRuntimeComponentAttackRange'
+        end
+        if
+            attackConfig.CooldownSeconds ~= nil
+            and not isPositiveNumber(attackConfig.CooldownSeconds)
+        then
+            return false, 'InvalidRuntimeComponentAttackCooldown'
+        end
+    end
+
+    local runtimeSpeed = profile.Speed
+    if runtimeSpeed == nil and movementConfig then
+        runtimeSpeed = movementConfig.Speed
+    end
+    if not isPositiveNumber(runtimeSpeed) then
         return false, 'InvalidRuntimeSpeed'
     end
 
-    if type(profile.SightRange) ~= 'number' or profile.SightRange <= 0 then
+    local runtimeSightRange = profile.SightRange
+    if runtimeSightRange == nil and perceptionConfig then
+        runtimeSightRange = perceptionConfig.SightRange
+    end
+    if not isPositiveNumber(runtimeSightRange) then
         return false, 'InvalidRuntimeSightRange'
     end
 
-    if type(profile.PatrolSpeedMultiplier) ~= 'number' or profile.PatrolSpeedMultiplier <= 0 then
+    local runtimePatrolSpeedMultiplier = profile.PatrolSpeedMultiplier
+    if runtimePatrolSpeedMultiplier == nil and movementConfig then
+        runtimePatrolSpeedMultiplier = movementConfig.PatrolSpeedMultiplier
+    end
+    if not isPositiveNumber(runtimePatrolSpeedMultiplier) then
         return false, 'InvalidRuntimePatrolSpeedMultiplier'
     end
 
-    if typeof(profile.SpawnOffset) ~= 'Vector3' then
+    local runtimeSpawnOffset = profile.SpawnOffset
+    if runtimeSpawnOffset == nil and movementConfig then
+        runtimeSpawnOffset = movementConfig.SpawnOffset
+    end
+    if typeof(runtimeSpawnOffset) ~= 'Vector3' then
         return false, 'InvalidRuntimeSpawnOffset'
     end
 

--- a/packages/gameplay/src/Monsters/init.luau
+++ b/packages/gameplay/src/Monsters/init.luau
@@ -1,6 +1,7 @@
 local MonsterCompiler = require(script.MonsterCompiler)
 
 return {
+    MonsterComponentConfig = require(script.MonsterComponentConfig),
     Enemy = require(script.Enemy),
     EnemyBlackboard = require(script.EnemyBlackboard),
     EnemyStateMachine = require(script.EnemyStateMachine),

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -8,6 +8,7 @@ local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
 
 local MonsterBehaviorCatalog = Gameplay.Monsters.MonsterBehaviorCatalog
+local MonsterComponentConfig = Gameplay.Monsters.MonsterComponentConfig
 local Enemy = Gameplay.Monsters.Enemy
 local MonsterRuntimeProfile = Gameplay.Monsters.MonsterRuntimeProfile
 
@@ -114,6 +115,7 @@ function MonsterService.new(
         Connection = nil,
         LogicalPosition = nil,
         EnemyRuntime = nil,
+        ComponentConfig = MonsterComponentConfig.fromRuntimeProfile(monsterRuntimeProfile),
         Warn = runtimeOptions.Warn or defaultWarn,
         LoadMonsterModel = runtimeOptions.AssetLoader or defaultLoadMonsterModel,
         LoadAnimationTrack = runtimeOptions.LoadAnimationTrack or defaultLoadAnimationTrack,
@@ -421,7 +423,9 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
         self:_setAnimationState('Idle', 1)
     end
 
-    self.EnemyRuntime = self.EnemyFactory(self.Definition)
+    self.EnemyRuntime = self.EnemyFactory(self.Definition, {
+        ComponentConfig = self.ComponentConfig,
+    })
     if self.EnemyRuntime and self.EnemyRuntime.spawn then
         self.EnemyRuntime:spawn()
     end
@@ -459,6 +463,7 @@ function MonsterService:update(dt)
 
     local decision = self.EnemyRuntime:update(dt, {
         Behaviors = self.Definition.Behaviors,
+        ComponentConfig = self.ComponentConfig,
         CurrentPosition = currentPosition,
         PatrolReachDistance = 2,
         PatrolSpeedMultiplier = self.Definition.PatrolSpeedMultiplier,

--- a/tests/src/Shared/MonsterCompiler.spec.luau
+++ b/tests/src/Shared/MonsterCompiler.spec.luau
@@ -59,6 +59,27 @@ return function()
         'Compiled runtime should expose the configured patrol speed multiplier'
     )
     assert(
+        runtimeProfile.Components ~= nil and runtimeProfile.Components.Perception ~= nil,
+        'Compiled runtime should include component mapping payload'
+    )
+    assert(
+        runtimeProfile.Components.Perception.SightRange == runtimeProfile.SightRange,
+        'Component perception config should map from runtime sight range'
+    )
+    assert(
+        runtimeProfile.Components.Movement.Speed == runtimeProfile.Speed,
+        'Component movement config should map from runtime speed'
+    )
+    assert(
+        runtimeProfile.Components.Movement.PatrolSpeedMultiplier
+            == runtimeProfile.PatrolSpeedMultiplier,
+        'Component movement config should map patrol speed multiplier'
+    )
+    assert(
+        runtimeProfile.Components.Movement.SpawnOffset == runtimeProfile.SpawnOffset,
+        'Component movement spawn offset should map from runtime spawn offset'
+    )
+    assert(
         runtimeProfile.Behaviors[behaviorCatalog.Behavior.Patrol] == nil,
         'Disabled patrol intents should not reach the maze runtime profile'
     )

--- a/tests/src/Shared/MonsterRuntimeProfile.spec.luau
+++ b/tests/src/Shared/MonsterRuntimeProfile.spec.luau
@@ -1,0 +1,62 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
+
+    local runtimeProfileModule = gameplay.Monsters.MonsterRuntimeProfile
+    local presentationCatalog = gameplay.Monsters.MonsterPresentationCatalog
+
+    local componentOnlyProfile = {
+        Id = 'component-only-spec',
+        Name = 'Component Only Spec',
+        Presentation = {
+            ModelAssetId = 4446576906,
+            RigType = presentationCatalog.RigType.R6,
+            AnimationMode = presentationCatalog.AnimationMode.DefaultR6,
+            ChaseLoopSoundAssetId = 9118823108,
+        },
+        Behaviors = {
+            SenseNearestTarget = true,
+            Chase = true,
+        },
+        Effects = {},
+        Components = {
+            Perception = {
+                SightRange = 28,
+            },
+            Movement = {
+                Speed = 12,
+                PatrolSpeedMultiplier = 0.4,
+                PatrolReachDistance = 2,
+                SpawnOffset = Vector3.new(0, 4, 0),
+            },
+            Attack = {
+                Range = 4,
+                CooldownSeconds = 1,
+            },
+        },
+    }
+
+    local validComponentOnly, componentOnlyReason =
+        runtimeProfileModule.validate(componentOnlyProfile)
+    assert(
+        validComponentOnly == true,
+        string.format(
+            'Component-only runtime payload should stay valid, got %s',
+            tostring(componentOnlyReason)
+        )
+    )
+
+    local invalidMovementProfile = table.clone(componentOnlyProfile)
+    invalidMovementProfile.Components = table.clone(componentOnlyProfile.Components)
+    invalidMovementProfile.Components.Movement =
+        table.clone(componentOnlyProfile.Components.Movement)
+    invalidMovementProfile.Components.Movement.Speed = 0
+
+    local invalidMovementOk, invalidMovementReason =
+        runtimeProfileModule.validate(invalidMovementProfile)
+    assert(invalidMovementOk == false, 'Invalid movement component speed should fail validation')
+    assert(
+        invalidMovementReason == 'InvalidRuntimeComponentMovementSpeed',
+        'Invalid movement component speed should surface a dedicated reason'
+    )
+end

--- a/tests/src/Shared/MonsterUgcPipeline.spec.luau
+++ b/tests/src/Shared/MonsterUgcPipeline.spec.luau
@@ -104,6 +104,16 @@ return function()
         'Out-of-range speed should be clamped into allowed tuning range'
     )
     assert(
+        generationResult.RuntimeProfile.Components.Movement.Speed
+            == generationResult.RuntimeProfile.Speed,
+        'UGC runtime output should map movement speed into component config'
+    )
+    assert(
+        generationResult.RuntimeProfile.Components.Perception.SightRange
+            == generationResult.RuntimeProfile.SightRange,
+        'UGC runtime output should map perception sight range into component config'
+    )
+    assert(
         generationResult.Diagnostics.SkippedBehaviorIds[1] == behaviorCatalog.Behavior.LoseTarget,
         'Known but non-maze behaviors should appear in compile skipped diagnostics'
     )


### PR DESCRIPTION
## Summary
- Added `MonsterComponentConfig` as a runtime mapping layer that converts legacy runtime fields into component-facing config.
- Extended runtime profile validation to support both legacy top-level fields and component-first payloads.
- Updated compiler/service path to emit and consume `RuntimeProfile.Components` while keeping old runtime fields compatible.

## Why This Lives In maze (with shared/gameplay dependency zone)
- `#178` is the mapping/compatibility slice on the maze monster runtime path.
- Changes are limited to `packages/gameplay/src/Monsters/**` and `packages/shared/src/Runtime/MonsterService.luau` consumer wiring.
- No remotes, teleport payload contract, or cross-place handoff semantics were changed.

## Scope
- New mapping module: `MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)`.
- RuntimeProfile validation now accepts component-only payloads and validates component fields.
- Compiler now emits `RuntimeProfile.Components` from the same source tuning.
- MonsterService now passes mapped component config into Enemy runtime context.
- Added deterministic tests for compiler/runtime profile/pipeline compatibility.

## Validation
- `stylua --check` on touched files
- `selene packages/gameplay/src/Monsters packages/shared/src/Runtime/MonsterService.luau tests/src/Shared/MonsterCompiler.spec.luau tests/src/Shared/MonsterUgcPipeline.spec.luau tests/src/Shared/MonsterRuntimeProfile.spec.luau tests/src/Shared/MonsterService.spec.luau`
- `rojo build places/maze/default.project.json -o .\\tmp\\maze.rbxlx`
- `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`
- `run-in-roblox --place .\\tmp\\roblox_experience-tests.rbxlx --script tests/run-in-roblox.lua`

## Risks / Follow-Up
- This PR intentionally does not introduce fixed tick / seed replay logging (handled by #180).
- This PR intentionally does not implement attack marker damage settlement (handled by #179).
- This is stacked on `issue/177-monster-oop-core`; retarget to `main` after #177 merges.

Closes #178