### PR TITLE
feat(monster): add deterministic tick and replay baseline (#180)

### DIFF
--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -154,6 +154,7 @@ function MonsterService.new(
         LogicTickCount = 0,
         LastState = nil,
         LastTargetUserId = nil,
+        PendingVisualCFrame = nil,
         DecisionLogLimit = runtimeOptions.DecisionLogLimit or DEFAULT_DECISION_LOG_LIMIT,
         DecisionLog = {},
         DecisionLogSink = runtimeOptions.DecisionLogSink,
@@ -185,6 +186,7 @@ function MonsterService:destroy()
     self.LogicTickCount = 0
     self.LastState = nil
     self.LastTargetUserId = nil
+    self.PendingVisualCFrame = nil
     if self.EnemyRuntime then
         self.EnemyRuntime:destroy()
         self.EnemyRuntime = nil
@@ -516,6 +518,10 @@ function MonsterService:_resolveTargetUserId(targetPlayer)
         return nil
     end
 
+    if typeof(targetPlayer) == 'Instance' and targetPlayer:IsA('Player') then
+        return targetPlayer.UserId
+    end
+
     if type(targetPlayer) == 'table' and type(targetPlayer.UserId) == 'number' then
         return targetPlayer.UserId
     end
@@ -557,6 +563,7 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
     self.LogicTickCount = 0
     self.LastState = nil
     self.LastTargetUserId = nil
+    self.PendingVisualCFrame = nil
     self:clearDecisionLog()
 
     if #patrolPoints == 0 then
@@ -645,7 +652,7 @@ function MonsterService:_runLogicStep(dt)
         local facingCFrame = if travelOffset.Magnitude > 0
             then CFrame.lookAt(nextPosition, nextPosition + travelOffset.Unit)
             else currentRotation + nextPosition
-        self:_applyVisualCFrame(facingCFrame, dt)
+        self.PendingVisualCFrame = facingCFrame
 
         self:_setAnimationState(
             decision.DesiredAnimation or 'Idle',
@@ -653,6 +660,7 @@ function MonsterService:_runLogicStep(dt)
         )
         self:_setChaseLoopSoundPlaying(decision.ShouldPlayChaseLoop)
     else
+        self.PendingVisualCFrame = nil
         self:_setAnimationState('Idle', 1)
         self:_setChaseLoopSoundPlaying(false)
     end
@@ -665,7 +673,7 @@ function MonsterService:update(dt)
         return
     end
 
-    local elapsed = if type(dt) == 'number' and dt > 0 then dt else self.LogicTickSeconds
+    local elapsed = if type(dt) == 'number' and dt > 0 then dt else 0
     self.LogicAccumulator += elapsed
 
     local maxSteps = self.MaxLogicStepsPerUpdate
@@ -691,6 +699,10 @@ function MonsterService:update(dt)
             ExecutedSteps = executed,
             MaxStepsPerUpdate = maxSteps,
         })
+    end
+
+    if self.PendingVisualCFrame then
+        self:_applyVisualCFrame(self.PendingVisualCFrame, elapsed)
     end
 end
 

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -25,6 +25,9 @@ local DEFAULT_CHASE_LOOP_VOLUME = 0.45
 local DEFAULT_CHASE_LOOP_MIN_DISTANCE = 8
 local DEFAULT_CHASE_LOOP_MAX_DISTANCE = 48
 local DEFAULT_VISUAL_SMOOTHING_SPEED = 12
+local DEFAULT_LOGIC_TICK_RATE_HZ = 10
+local DEFAULT_MAX_LOGIC_STEPS_PER_UPDATE = 6
+local DEFAULT_DECISION_LOG_LIMIT = 128
 
 local function defaultWarn(message)
     warn(message)
@@ -93,6 +96,20 @@ function MonsterService.new(
     end
 
     local runtimeOptions = options or {}
+    local logicTickRateHz = runtimeOptions.LogicTickRateHz or DEFAULT_LOGIC_TICK_RATE_HZ
+    if type(logicTickRateHz) ~= 'number' or logicTickRateHz <= 0 then
+        logicTickRateHz = DEFAULT_LOGIC_TICK_RATE_HZ
+    end
+
+    local randomSeed = runtimeOptions.RandomSeed
+    if type(randomSeed) == 'number' then
+        randomSeed = math.floor(randomSeed)
+        if randomSeed <= 0 then
+            randomSeed = nil
+        end
+    else
+        randomSeed = nil
+    end
 
     return setmetatable({
         Definition = monsterRuntimeProfile,
@@ -126,6 +143,24 @@ function MonsterService.new(
         end,
         VisualSmoothingSpeed = runtimeOptions.VisualSmoothingSpeed
             or DEFAULT_VISUAL_SMOOTHING_SPEED,
+        AutoUpdateOnHeartbeat = if runtimeOptions.AutoUpdateOnHeartbeat == nil
+            then true
+            else runtimeOptions.AutoUpdateOnHeartbeat == true,
+        LogicTickRateHz = logicTickRateHz,
+        LogicTickSeconds = 1 / logicTickRateHz,
+        MaxLogicStepsPerUpdate = runtimeOptions.MaxLogicStepsPerUpdate
+            or DEFAULT_MAX_LOGIC_STEPS_PER_UPDATE,
+        LogicAccumulator = 0,
+        LogicTickCount = 0,
+        LastState = nil,
+        LastTargetUserId = nil,
+        DecisionLogLimit = runtimeOptions.DecisionLogLimit or DEFAULT_DECISION_LOG_LIMIT,
+        DecisionLog = {},
+        DecisionLogSink = runtimeOptions.DecisionLogSink,
+        DecisionLogSequence = 0,
+        RandomSeed = randomSeed,
+        RandomSource = runtimeOptions.RandomSource
+            or if randomSeed ~= nil then Random.new(randomSeed) else Random.new(),
     }, MonsterService)
 end
 
@@ -146,6 +181,10 @@ function MonsterService:destroy()
     self.MonsterHumanoid = nil
     self.MonsterPositionPart = nil
     self.LogicalPosition = nil
+    self.LogicAccumulator = 0
+    self.LogicTickCount = 0
+    self.LastState = nil
+    self.LastTargetUserId = nil
     if self.EnemyRuntime then
         self.EnemyRuntime:destroy()
         self.EnemyRuntime = nil
@@ -404,10 +443,121 @@ function MonsterService:_applyVisualCFrame(nextCFrame, dt)
     end
 end
 
+function MonsterService:_recordDecisionEvent(eventName, fields)
+    self.DecisionLogSequence += 1
+
+    local entry = {
+        Event = eventName,
+        MonsterId = self.Definition.Id,
+        Sequence = self.DecisionLogSequence,
+        Tick = self.LogicTickCount,
+    }
+
+    for key, value in pairs(fields or {}) do
+        entry[key] = value
+    end
+
+    table.insert(self.DecisionLog, entry)
+    if #self.DecisionLog > self.DecisionLogLimit then
+        table.remove(self.DecisionLog, 1)
+    end
+
+    if self.DecisionLogSink then
+        self.DecisionLogSink(entry)
+    end
+end
+
+function MonsterService:getDecisionLogSnapshot()
+    local snapshot = {}
+    for index, entry in ipairs(self.DecisionLog) do
+        snapshot[index] = table.clone(entry)
+    end
+    return snapshot
+end
+
+function MonsterService:clearDecisionLog()
+    table.clear(self.DecisionLog)
+    self.DecisionLogSequence = 0
+end
+
+function MonsterService:setDeterministicSeed(seed, randomSource)
+    local normalizedSeed = seed
+    if type(normalizedSeed) == 'number' then
+        normalizedSeed = math.floor(normalizedSeed)
+        if normalizedSeed <= 0 then
+            normalizedSeed = nil
+        end
+    else
+        normalizedSeed = nil
+    end
+
+    self.RandomSeed = normalizedSeed
+    self.RandomSource = randomSource
+        or if normalizedSeed ~= nil then Random.new(normalizedSeed) else Random.new()
+    self:_recordDecisionEvent('SeedUpdated', {
+        Seed = self.RandomSeed,
+    })
+end
+
+function MonsterService:_nextRandomInteger(minimum, maximum, reason)
+    local result = self.RandomSource:NextInteger(minimum, maximum)
+    self:_recordDecisionEvent('RandomRoll', {
+        Maximum = maximum,
+        Minimum = minimum,
+        Reason = reason or 'unspecified',
+        Result = result,
+        Seed = self.RandomSeed,
+    })
+    return result
+end
+
+function MonsterService:_resolveTargetUserId(targetPlayer)
+    if targetPlayer == nil then
+        return nil
+    end
+
+    if type(targetPlayer) == 'table' and type(targetPlayer.UserId) == 'number' then
+        return targetPlayer.UserId
+    end
+
+    return tostring(targetPlayer)
+end
+
+function MonsterService:_recordDecisionTransitions(decision)
+    local state = decision.State
+    if type(state) == 'string' and state ~= self.LastState then
+        self:_recordDecisionEvent('StateTransition', {
+            FromState = self.LastState,
+            ToState = state,
+        })
+        self.LastState = state
+    end
+
+    local targetUserId = self:_resolveTargetUserId(decision.TargetPlayer)
+    if targetUserId ~= self.LastTargetUserId then
+        self:_recordDecisionEvent('TargetSwitch', {
+            FromTargetUserId = self.LastTargetUserId,
+            ToTargetUserId = targetUserId,
+        })
+        self.LastTargetUserId = targetUserId
+    end
+
+    if decision.AttackResult ~= nil then
+        self:_recordDecisionEvent('AttackResult', {
+            Result = decision.AttackResult,
+        })
+    end
+end
+
 function MonsterService:spawn(patrolPoints, initialPatrolIndex)
     self:destroy()
     self.PatrolPoints = patrolPoints
     self.PatrolIndex = 1
+    self.LogicAccumulator = 0
+    self.LogicTickCount = 0
+    self.LastState = nil
+    self.LastTargetUserId = nil
+    self:clearDecisionLog()
 
     if #patrolPoints == 0 then
         return
@@ -430,16 +580,14 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
         self.EnemyRuntime:spawn()
     end
 
-    self.Connection = RunService.Heartbeat:Connect(function(dt)
-        self:update(dt)
-    end)
+    if self.AutoUpdateOnHeartbeat then
+        self.Connection = RunService.Heartbeat:Connect(function(dt)
+            self:update(dt)
+        end)
+    end
 end
 
-function MonsterService:update(dt)
-    if not self.MonsterPositionPart or not self.IsExpeditionActive() or not self.EnemyRuntime then
-        return
-    end
-
+function MonsterService:_runLogicStep(dt)
     local playerPositions = {}
 
     for _, player in ipairs(self.GetPlayers()) do
@@ -453,6 +601,10 @@ function MonsterService:update(dt)
     end
 
     local currentPosition = self:_getCurrentPosition()
+    if currentPosition == nil then
+        return
+    end
+
     local patrolTarget = nil
     if
         self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.Patrol]
@@ -465,13 +617,17 @@ function MonsterService:update(dt)
         Behaviors = self.Definition.Behaviors,
         ComponentConfig = self.ComponentConfig,
         CurrentPosition = currentPosition,
+        NextRandomInteger = function(minimum, maximum, reason)
+            return self:_nextRandomInteger(minimum, maximum, reason)
+        end,
         PatrolReachDistance = 2,
         PatrolSpeedMultiplier = self.Definition.PatrolSpeedMultiplier,
         PatrolTargetPosition = patrolTarget,
         PlayerPositions = playerPositions,
         SightRange = self.Definition.SightRange,
         Speed = self.Definition.Speed,
-    })
+    }) or {}
+
     local nextPosition = decision.NextPosition
     if decision.ShouldAdvancePatrol and #self.PatrolPoints > 0 then
         self.PatrolIndex = (self.PatrolIndex % #self.PatrolPoints) + 1
@@ -491,11 +647,50 @@ function MonsterService:update(dt)
             else currentRotation + nextPosition
         self:_applyVisualCFrame(facingCFrame, dt)
 
-        self:_setAnimationState(decision.DesiredAnimation, decision.DesiredAnimationSpeed)
+        self:_setAnimationState(
+            decision.DesiredAnimation or 'Idle',
+            decision.DesiredAnimationSpeed or 1
+        )
         self:_setChaseLoopSoundPlaying(decision.ShouldPlayChaseLoop)
     else
         self:_setAnimationState('Idle', 1)
         self:_setChaseLoopSoundPlaying(false)
+    end
+
+    self:_recordDecisionTransitions(decision)
+end
+
+function MonsterService:update(dt)
+    if not self.MonsterPositionPart or not self.IsExpeditionActive() or not self.EnemyRuntime then
+        return
+    end
+
+    local elapsed = if type(dt) == 'number' and dt > 0 then dt else self.LogicTickSeconds
+    self.LogicAccumulator += elapsed
+
+    local maxSteps = self.MaxLogicStepsPerUpdate
+    if type(maxSteps) ~= 'number' or maxSteps < 1 then
+        maxSteps = DEFAULT_MAX_LOGIC_STEPS_PER_UPDATE
+    end
+    maxSteps = math.max(1, math.floor(maxSteps))
+
+    local executed = 0
+    while self.LogicAccumulator >= self.LogicTickSeconds and executed < maxSteps do
+        self.LogicAccumulator -= self.LogicTickSeconds
+        self.LogicTickCount += 1
+        executed += 1
+        self:_runLogicStep(self.LogicTickSeconds)
+    end
+
+    if self.LogicAccumulator >= self.LogicTickSeconds then
+        local droppedTime = self.LogicAccumulator - (self.LogicAccumulator % self.LogicTickSeconds)
+        self.LogicAccumulator = self.LogicAccumulator % self.LogicTickSeconds
+        self:_recordDecisionEvent('TickDrop', {
+            DroppedTime = droppedTime,
+            Elapsed = elapsed,
+            ExecutedSteps = executed,
+            MaxStepsPerUpdate = maxSteps,
+        })
     end
 end
 

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -367,7 +367,9 @@ function MazeSessionService:_spawnQueuedUgcMonsters()
             end
 
             return self.World.CanTraverseBetweenPositions(fromPosition, toPosition)
-        end)
+        end, {
+            RandomSeed = randomSeed,
+        })
         ugcMonsterService:spawn(patrolPoints, initialPatrolIndex)
 
         table.insert(self.UgcMonsterServices, {
@@ -416,13 +418,15 @@ function MazeSessionService.new(options)
             monsterRuntimeProfile,
             isExpeditionActiveCallback,
             canTargetPlayerCallback,
-            canTraverseCallback
+            canTraverseCallback,
+            monsterRuntimeOptions
         )
             return MonsterService.new(
                 monsterRuntimeProfile,
                 isExpeditionActiveCallback,
                 canTargetPlayerCallback,
-                canTraverseCallback
+                canTraverseCallback,
+                monsterRuntimeOptions
             )
         end
     self.MonsterService = self.MonsterServiceFactory(
@@ -439,7 +443,10 @@ function MazeSessionService.new(options)
             end
 
             return self.World.CanTraverseBetweenPositions(fromPosition, toPosition)
-        end
+        end,
+        {
+            RandomSeed = self.SessionData.Seed,
+        }
     )
     self.UgcMonsterServices = {}
     self.PendingUgcMonsterPayloads = {}
@@ -586,6 +593,12 @@ function MazeSessionService:_ensureAuthoritativeSessionSeed()
     self.SessionData.Seed = seed
     if issuedNewSeed then
         self.HasAuthoritativeSessionSeed = true
+    end
+end
+
+function MazeSessionService:_syncMonsterDeterminismSeed()
+    if self.MonsterService and self.MonsterService.setDeterministicSeed then
+        self.MonsterService:setDeterministicSeed(self.SessionData.Seed)
     end
 end
 
@@ -1532,6 +1545,7 @@ function MazeSessionService:start()
             local mergedBeforeBuild = self:_awaitInitialTeleportData()
             self:_setBootPhase('EnsureAuthoritativeSeed')
             self:_ensureAuthoritativeSessionSeed()
+            self:_syncMonsterDeterminismSeed()
             self:_emitDiagnostic('InitialSeedResolution', {
                 HasAcceptedTeleportData = self.HasAcceptedTeleportData,
                 HasAuthoritativeSessionSeed = self.HasAuthoritativeSessionSeed,

--- a/tests/src/Shared/MazeSessionServiceMonsterDeterminism.spec.luau
+++ b/tests/src/Shared/MazeSessionServiceMonsterDeterminism.spec.luau
@@ -1,0 +1,112 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local mazeModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
+    local MazeSessionService = require(mazeModules:WaitForChild('MazeSessionService'))
+
+    local factoryCalls = {}
+    local monsterServiceFactory = function(runtimeProfile, _, _, _, runtimeOptions)
+        local record = {
+            RandomSeed = runtimeOptions and runtimeOptions.RandomSeed,
+            RuntimeProfileId = runtimeProfile.Id,
+            SeedUpdates = {},
+        }
+        table.insert(factoryCalls, record)
+
+        return {
+            spawn = function() end,
+            destroy = function() end,
+            setDeterministicSeed = function(_, seed)
+                table.insert(record.SeedUpdates, seed)
+            end,
+        }
+    end
+
+    local service = MazeSessionService.new({
+        MonsterServiceFactory = monsterServiceFactory,
+    })
+
+    assert(#factoryCalls == 1, 'Maze startup should construct one baseline monster service')
+    assert(
+        factoryCalls[1].RandomSeed == service.SessionData.Seed,
+        'Baseline monster service should receive the current maze session seed'
+    )
+
+    service.SessionData.Seed = 876543
+    service:_syncMonsterDeterminismSeed()
+
+    assert(
+        factoryCalls[1].SeedUpdates[1] == 876543,
+        'Maze seed sync should propagate authoritative seed to monster determinism seed'
+    )
+
+    service.World = {
+        RoomIds = { 'A', 'B', 'C', 'D', 'E' },
+        CampRoomId = 'A',
+        RoomById = {
+            A = {
+                Neighbors = { 'B', 'C' },
+            },
+            B = {
+                Neighbors = { 'A' },
+            },
+            C = {
+                Neighbors = { 'A' },
+            },
+            D = {
+                Neighbors = { 'B' },
+            },
+            E = {
+                Neighbors = { 'C' },
+            },
+        },
+        RoomAffordances = {
+            A = { PatrolAnchors = { Vector3.new(0, 0, 0) } },
+            B = { PatrolAnchors = { Vector3.new(10, 0, 0) } },
+            C = { PatrolAnchors = { Vector3.new(20, 0, 0) } },
+            D = { PatrolAnchors = { Vector3.new(30, 0, 0) } },
+            E = { PatrolAnchors = { Vector3.new(40, 0, 0) } },
+        },
+        PatrolPoints = {
+            Vector3.new(0, 0, 0),
+            Vector3.new(10, 0, 0),
+            Vector3.new(20, 0, 0),
+            Vector3.new(30, 0, 0),
+            Vector3.new(40, 0, 0),
+        },
+        CanTraverseBetweenPositions = function()
+            return true
+        end,
+    }
+
+    service:_queuePendingUgcMonsterPayload({
+        OwnerUserId = 777,
+        Seed = 222333,
+        RuntimeProfile = {
+            Behaviors = {
+                Chase = true,
+                SenseNearestTarget = true,
+            },
+            Effects = {},
+            Id = 'ugc-determinism-seed',
+            Name = 'UGC Determinism Seed',
+            PatrolSpeedMultiplier = 0.45,
+            Presentation = {
+                AnimationMode = 'defaultR6',
+                ChaseLoopSoundAssetId = 9118823108,
+                ModelAssetId = 4446576906,
+                RigType = 'R6',
+            },
+            SightRange = 36,
+            SpawnOffset = Vector3.new(0, 4, 0),
+            Speed = 14,
+        },
+    })
+    service:_spawnQueuedUgcMonsters()
+
+    assert(
+        #factoryCalls >= 2 and factoryCalls[2].RandomSeed == 222333,
+        'UGC monster service should receive payload seed for deterministic behavior'
+    )
+
+    service:_destroyUgcMonsters()
+end

--- a/tests/src/Shared/MonsterServiceDeterminism.spec.luau
+++ b/tests/src/Shared/MonsterServiceDeterminism.spec.luau
@@ -189,4 +189,57 @@ return function()
     )
     assert(eventNames.TargetSwitch == true, 'Decision log should include target switch events')
     assert(eventNames.AttackResult == true, 'Decision log should include attack result events')
+
+    local zeroDtService = MonsterService.new(
+        runtimeProfile,
+        function()
+            return true
+        end,
+        nil,
+        nil,
+        {
+            AssetLoader = function()
+                return createMonsterModel()
+            end,
+            AutoUpdateOnHeartbeat = false,
+            DecisionLogLimit = 64,
+            EnemyFactory = function()
+                return {
+                    spawn = function() end,
+                    destroy = function() end,
+                    update = function(_, _dt, context)
+                        context.NextRandomInteger(1, 5, 'ZeroDtGuard')
+                        return {
+                            DesiredAnimation = 'Idle',
+                            DesiredAnimationSpeed = 1,
+                            NextPosition = context.CurrentPosition,
+                            ShouldPlayChaseLoop = false,
+                            State = 'Idle',
+                            TargetPlayer = nil,
+                        }
+                    end,
+                }
+            end,
+            LoadAnimationTrack = function()
+                return createTrack()
+            end,
+            RandomSeed = 555555,
+        }
+    )
+
+    zeroDtService:spawn({ Vector3.new(0, 0, 0) }, 1)
+    zeroDtService:update(0)
+    local zeroDtLog = zeroDtService:getDecisionLogSnapshot()
+    zeroDtService:destroy()
+
+    local zeroDtRollCount = 0
+    for _, entry in ipairs(zeroDtLog) do
+        if entry.Event == 'RandomRoll' then
+            zeroDtRollCount += 1
+        end
+    end
+    assert(
+        zeroDtRollCount == 0,
+        'dt=0 should not advance deterministic logic ticks or random roll sequence'
+    )
 end

--- a/tests/src/Shared/MonsterServiceDeterminism.spec.luau
+++ b/tests/src/Shared/MonsterServiceDeterminism.spec.luau
@@ -1,0 +1,192 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local packages = ReplicatedStorage:WaitForChild('Packages')
+    local gameplay = require(packages:WaitForChild('Gameplay'))
+    local shared = require(packages:WaitForChild('Shared'))
+
+    local compileMonsterForMaze = gameplay.Monsters.compileMonsterForMaze
+    local MonsterService = shared.Runtime.MonsterService
+
+    local compileOk, runtimeProfile = compileMonsterForMaze(gameplay.Config.Monsters[1])
+    assert(
+        compileOk == true,
+        'Expected maze monster runtime profile to compile for determinism test'
+    )
+
+    local function createTrack()
+        return {
+            Play = function() end,
+            Stop = function() end,
+            AdjustSpeed = function() end,
+        }
+    end
+
+    local function createMonsterModel()
+        local monsterModel = Instance.new('Model')
+        monsterModel.Name = 'DeterminismMonster'
+
+        local rootPart = Instance.new('Part')
+        rootPart.Name = 'HumanoidRootPart'
+        rootPart.Size = Vector3.new(2, 2, 1)
+        rootPart.Parent = monsterModel
+
+        local head = Instance.new('Part')
+        head.Name = 'Head'
+        head.Size = Vector3.new(2, 1, 1)
+        head.Parent = monsterModel
+
+        local humanoid = Instance.new('Humanoid')
+        humanoid.Parent = monsterModel
+
+        return monsterModel
+    end
+
+    local function collectRandomRolls(logEntries)
+        local rolls = {}
+        for _, entry in ipairs(logEntries) do
+            if entry.Event == 'RandomRoll' then
+                table.insert(rolls, entry.Result)
+            end
+        end
+        return rolls
+    end
+
+    local function serialize(values)
+        local segments = {}
+        for _, value in ipairs(values) do
+            table.insert(segments, tostring(value))
+        end
+        return table.concat(segments, ',')
+    end
+
+    local function runDeterminismSimulation(seed, frameDts)
+        local service = MonsterService.new(
+            runtimeProfile,
+            function()
+                return true
+            end,
+            nil,
+            nil,
+            {
+                AssetLoader = function()
+                    return createMonsterModel()
+                end,
+                AutoUpdateOnHeartbeat = false,
+                DecisionLogLimit = 256,
+                EnemyFactory = function()
+                    return {
+                        spawn = function() end,
+                        destroy = function() end,
+                        update = function(_, dt, context)
+                            local roll = context.NextRandomInteger(1, 100, 'DeterministicWander')
+                            local step = (roll / 100) * dt
+                            return {
+                                DesiredAnimation = 'Walk',
+                                DesiredAnimationSpeed = 1,
+                                NextPosition = context.CurrentPosition + Vector3.new(step, 0, 0),
+                                ShouldPlayChaseLoop = false,
+                                State = 'Idle',
+                                TargetPlayer = nil,
+                            }
+                        end,
+                    }
+                end,
+                LoadAnimationTrack = function()
+                    return createTrack()
+                end,
+                RandomSeed = seed,
+            }
+        )
+
+        service:spawn({ Vector3.new(0, 0, 0) }, 1)
+        for _, frameDt in ipairs(frameDts) do
+            service:update(frameDt)
+        end
+
+        local finalPosition = service:_getCurrentPosition()
+        local logEntries = service:getDecisionLogSnapshot()
+        service:destroy()
+
+        return finalPosition, logEntries
+    end
+
+    local totalSixTicksSplitA = { 0.2, 0.2, 0.2 }
+    local totalSixTicksSplitB = { 0.05, 0.15, 0.07, 0.09, 0.24 }
+
+    local positionA, logA = runDeterminismSimulation(987654, totalSixTicksSplitA)
+    local positionB, logB = runDeterminismSimulation(987654, totalSixTicksSplitB)
+    local rollsA = collectRandomRolls(logA)
+    local rollsB = collectRandomRolls(logB)
+
+    assert(
+        positionA == positionB,
+        'Fixed-step monster updates should produce identical output for equal total dt with same seed'
+    )
+    assert(
+        serialize(rollsA) == serialize(rollsB),
+        'Same seed should produce identical random roll sequence regardless of frame partitioning'
+    )
+    assert(#rollsA == 6, '0.6 seconds at 10Hz should produce exactly six logic random rolls')
+
+    local _, logDifferentSeed = runDeterminismSimulation(123456, totalSixTicksSplitB)
+    local rollsDifferentSeed = collectRandomRolls(logDifferentSeed)
+    assert(
+        serialize(rollsB) ~= serialize(rollsDifferentSeed),
+        'Different seeds should produce different random roll sequence'
+    )
+
+    local eventNames = {}
+    local stateSwitchService = MonsterService.new(
+        runtimeProfile,
+        function()
+            return true
+        end,
+        nil,
+        nil,
+        {
+            AssetLoader = function()
+                return createMonsterModel()
+            end,
+            AutoUpdateOnHeartbeat = false,
+            DecisionLogSink = function(entry)
+                eventNames[entry.Event] = true
+            end,
+            EnemyFactory = function()
+                local tick = 0
+                return {
+                    spawn = function() end,
+                    destroy = function() end,
+                    update = function(_, _dt, context)
+                        tick += 1
+                        local target = if tick % 2 == 0 then { UserId = 404 } else nil
+                        local state = if tick % 2 == 0 then 'Alert' else 'Idle'
+                        return {
+                            AttackResult = if tick == 3 then 'Miss' else nil,
+                            DesiredAnimation = 'Walk',
+                            DesiredAnimationSpeed = 1,
+                            NextPosition = context.CurrentPosition,
+                            ShouldPlayChaseLoop = false,
+                            State = state,
+                            TargetPlayer = target,
+                        }
+                    end,
+                }
+            end,
+            LoadAnimationTrack = function()
+                return createTrack()
+            end,
+            RandomSeed = 333333,
+        }
+    )
+
+    stateSwitchService:spawn({ Vector3.new(0, 0, 0) }, 1)
+    stateSwitchService:update(0.3)
+    stateSwitchService:destroy()
+
+    assert(
+        eventNames.StateTransition == true,
+        'Decision log should include state transition events'
+    )
+    assert(eventNames.TargetSwitch == true, 'Decision log should include target switch events')
+    assert(eventNames.AttackResult == true, 'Decision log should include attack result events')
+end


### PR DESCRIPTION
## Summary
- land deterministic monster runtime baseline for maze with a fixed logic tick scheduler (default 10Hz)
- pass maze/session seeds into monster runtime construction and add explicit seed resync after authoritative seed resolution
- add replay-focused monster decision logging for key events: target switch, state transition, attack result, and random roll records

## Why This Lives In maze (with shared/gameplay dependency zone)
- owner flow is maze expedition runtime (`MazeSessionService`) where authoritative session seed is resolved and monster services are spawned
- implementation surface is `packages/shared/src/Runtime/MonsterService.luau` plus maze wiring, without changing cross-place contract/remotes

## Scope
- `MonsterService` now runs logic in fixed-step updates with bounded catch-up and deterministic random entry (`NextRandomInteger`)
- add optional deterministic controls (`RandomSeed`, `AutoUpdateOnHeartbeat`, decision log snapshot/sink)
- `MazeSessionService` now passes seed into baseline/UGC monster service factory and syncs authoritative seed once resolved
- new deterministic specs:
  - `MonsterServiceDeterminism.spec.luau`
  - `MazeSessionServiceMonsterDeterminism.spec.luau`

## Validation
- `stylua --check packages/shared/src/Runtime/MonsterService.luau places/maze/src/ServerScriptService/Maze/MazeSessionService.luau tests/src/Shared/MonsterServiceDeterminism.spec.luau tests/src/Shared/MazeSessionServiceMonsterDeterminism.spec.luau`
- `selene .`
- `rojo build places/maze/default.project.json -o .\\tmp\\maze.rbxlx`
- `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`
- `run-in-roblox --place .\\tmp\\roblox_experience-tests.rbxlx --script tests/run-in-roblox.lua`

## Risks / Follow-Up
- this PR only establishes deterministic runtime baseline and replay logs; it does not change hit marker/damage closure (`#179`)
- random entry plumbing is ready for future behavior components; follow-up behavior additions should consume `NextRandomInteger` instead of creating ad-hoc randomness
- if `#177` merges first, retarget this PR base from `issue/177-monster-oop-core` to `main`

Closes #180