### PR TITLE
[Monster][Combat] 动画 marker 命中链路（Range+Arc+LOS）

### DIFF
--- a/packages/gameplay/src/Config/Monsters.luau
+++ b/packages/gameplay/src/Config/Monsters.luau
@@ -19,6 +19,9 @@ return {
             },
         },
         Tuning = {
+            AttackCooldownSeconds = 1,
+            AttackDamagePips = 1,
+            AttackRange = 4,
             Speed = 14,
             SightRange = 36,
             PatrolSpeedMultiplier = 0.45,
@@ -41,6 +44,9 @@ return {
                 },
                 {
                     Id = MonsterBehaviorCatalog.Behavior.Chase,
+                },
+                {
+                    Id = MonsterBehaviorCatalog.Behavior.Attack,
                 },
                 {
                     Id = MonsterBehaviorCatalog.Behavior.LoseTarget,

--- a/packages/gameplay/src/Monsters/Components/AttackComponent.luau
+++ b/packages/gameplay/src/Monsters/Components/AttackComponent.luau
@@ -1,15 +1,77 @@
+local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
+
 local AttackComponent = {}
 AttackComponent.__index = AttackComponent
 
-function AttackComponent.new()
-    return setmetatable({}, AttackComponent)
+local DEFAULT_ATTACK_ARC_DEGREES = 100
+local DEFAULT_ATTACK_COOLDOWN_SECONDS = 1
+local DEFAULT_ATTACK_DAMAGE_PIPS = 1
+local DEFAULT_ATTACK_MARKER_NAME = 'Hit'
+local DEFAULT_ATTACK_RANGE = 4
+
+local function readAttackConfig(context)
+    local componentConfig = context.ComponentConfig
+    if type(componentConfig) == 'table' and type(componentConfig.Attack) == 'table' then
+        return componentConfig.Attack
+    end
+
+    return {}
 end
 
-function AttackComponent:init(_blackboard) end
+function AttackComponent.new()
+    return setmetatable({
+        CooldownRemaining = 0,
+    }, AttackComponent)
+end
 
-function AttackComponent:update(blackboard, _dt)
-    -- #177 only wires the execution slot. Real damage/marker logic lands in #179.
+function AttackComponent:init(_blackboard)
+    self.CooldownRemaining = 0
+end
+
+function AttackComponent:update(blackboard, dt)
+    local deltaTime = math.max(0, dt or 0)
+    self.CooldownRemaining = math.max(0, self.CooldownRemaining - deltaTime)
+
     blackboard.Transient.AttackIntent = nil
+    local behaviors = blackboard.Context.Behaviors or {}
+    if not behaviors[MonsterBehaviorCatalog.Behavior.Attack] then
+        return
+    end
+
+    local hasTarget = blackboard.Transient.HasTarget == true
+    if not hasTarget then
+        return
+    end
+
+    local currentPosition = blackboard.Context.CurrentPosition
+    local targetPlayer = blackboard.Transient.TargetPlayer
+    local targetPosition = blackboard.Transient.TargetPosition
+    if
+        typeof(currentPosition) ~= 'Vector3'
+        or targetPlayer == nil
+        or typeof(targetPosition) ~= 'Vector3'
+    then
+        return
+    end
+
+    local attackConfig = readAttackConfig(blackboard.Context)
+    local attackRange = attackConfig.Range or DEFAULT_ATTACK_RANGE
+    if (targetPosition - currentPosition).Magnitude > attackRange then
+        return
+    end
+
+    if self.CooldownRemaining > 0 then
+        return
+    end
+
+    self.CooldownRemaining = attackConfig.CooldownSeconds or DEFAULT_ATTACK_COOLDOWN_SECONDS
+    blackboard.Transient.AttackIntent = {
+        ArcDegrees = attackConfig.ArcDegrees or DEFAULT_ATTACK_ARC_DEGREES,
+        DamagePips = attackConfig.DamagePips or DEFAULT_ATTACK_DAMAGE_PIPS,
+        MarkerName = attackConfig.HitMarkerName or DEFAULT_ATTACK_MARKER_NAME,
+        Range = attackRange,
+        TargetPlayer = targetPlayer,
+    }
 end
 
 function AttackComponent:destroy(_blackboard) end

--- a/packages/gameplay/src/Monsters/Components/AttackComponent.luau
+++ b/packages/gameplay/src/Monsters/Components/AttackComponent.luau
@@ -1,0 +1,17 @@
+local AttackComponent = {}
+AttackComponent.__index = AttackComponent
+
+function AttackComponent.new()
+    return setmetatable({}, AttackComponent)
+end
+
+function AttackComponent:init(_blackboard) end
+
+function AttackComponent:update(blackboard, _dt)
+    -- #177 only wires the execution slot. Real damage/marker logic lands in #179.
+    blackboard.Transient.AttackIntent = nil
+end
+
+function AttackComponent:destroy(_blackboard) end
+
+return AttackComponent

--- a/packages/gameplay/src/Monsters/Components/MovementComponent.luau
+++ b/packages/gameplay/src/Monsters/Components/MovementComponent.luau
@@ -11,6 +11,12 @@ end
 function MovementComponent:init(_blackboard) end
 
 function MovementComponent:update(blackboard, dt)
+    local componentConfig = blackboard.Context.ComponentConfig
+    local movementConfig = if type(componentConfig) == 'table'
+            and type(componentConfig.Movement) == 'table'
+        then componentConfig.Movement
+        else {}
+
     local currentPosition = blackboard.Context.CurrentPosition
     if typeof(currentPosition) ~= 'Vector3' then
         blackboard.Transient.NextPosition = nil
@@ -31,8 +37,12 @@ function MovementComponent:update(blackboard, dt)
         and behaviors[MonsterBehaviorCatalog.Behavior.Chase]
         and typeof(targetPosition) == 'Vector3'
     then
-        nextPosition =
-            MonsterLogic.stepToward(currentPosition, targetPosition, blackboard.Context.Speed, dt)
+        nextPosition = MonsterLogic.stepToward(
+            currentPosition,
+            targetPosition,
+            movementConfig.Speed or blackboard.Context.Speed,
+            dt
+        )
     elseif
         behaviors[MonsterBehaviorCatalog.Behavior.Patrol]
         and typeof(blackboard.Context.PatrolTargetPosition) == 'Vector3'
@@ -41,12 +51,14 @@ function MovementComponent:update(blackboard, dt)
         nextPosition = MonsterLogic.stepToward(
             currentPosition,
             patrolTarget,
-            blackboard.Context.Speed * blackboard.Context.PatrolSpeedMultiplier,
+            (movementConfig.Speed or blackboard.Context.Speed)
+                * (movementConfig.PatrolSpeedMultiplier or blackboard.Context.PatrolSpeedMultiplier),
             dt
         )
 
         if
-            (nextPosition - patrolTarget).Magnitude <= (blackboard.Context.PatrolReachDistance or 2)
+            (nextPosition - patrolTarget).Magnitude
+            <= (movementConfig.PatrolReachDistance or blackboard.Context.PatrolReachDistance or 2)
         then
             shouldAdvancePatrol = true
         end

--- a/packages/gameplay/src/Monsters/Components/MovementComponent.luau
+++ b/packages/gameplay/src/Monsters/Components/MovementComponent.luau
@@ -1,0 +1,71 @@
+local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
+local MonsterLogic = require(script.Parent.Parent.MonsterLogic)
+
+local MovementComponent = {}
+MovementComponent.__index = MovementComponent
+
+function MovementComponent.new()
+    return setmetatable({}, MovementComponent)
+end
+
+function MovementComponent:init(_blackboard) end
+
+function MovementComponent:update(blackboard, dt)
+    local currentPosition = blackboard.Context.CurrentPosition
+    if typeof(currentPosition) ~= 'Vector3' then
+        blackboard.Transient.NextPosition = nil
+        blackboard.Transient.DesiredAnimation = 'Idle'
+        blackboard.Transient.DesiredAnimationSpeed = 1
+        blackboard.Transient.ShouldPlayChaseLoop = false
+        return
+    end
+
+    local behaviors = blackboard.Context.Behaviors or {}
+    local hasTarget = blackboard.Transient.HasTarget == true
+    local targetPosition = blackboard.Transient.TargetPosition
+    local nextPosition = nil
+    local shouldAdvancePatrol = false
+
+    if
+        hasTarget
+        and behaviors[MonsterBehaviorCatalog.Behavior.Chase]
+        and typeof(targetPosition) == 'Vector3'
+    then
+        nextPosition =
+            MonsterLogic.stepToward(currentPosition, targetPosition, blackboard.Context.Speed, dt)
+    elseif
+        behaviors[MonsterBehaviorCatalog.Behavior.Patrol]
+        and typeof(blackboard.Context.PatrolTargetPosition) == 'Vector3'
+    then
+        local patrolTarget = blackboard.Context.PatrolTargetPosition
+        nextPosition = MonsterLogic.stepToward(
+            currentPosition,
+            patrolTarget,
+            blackboard.Context.Speed * blackboard.Context.PatrolSpeedMultiplier,
+            dt
+        )
+
+        if
+            (nextPosition - patrolTarget).Magnitude <= (blackboard.Context.PatrolReachDistance or 2)
+        then
+            shouldAdvancePatrol = true
+        end
+    end
+
+    local travelOffset = if nextPosition then nextPosition - currentPosition else Vector3.zero
+    local isMoving = travelOffset.Magnitude > 0
+
+    blackboard.Transient.NextPosition = nextPosition
+    blackboard.Transient.ShouldAdvancePatrol = shouldAdvancePatrol
+    blackboard.Transient.TravelOffset = travelOffset
+    blackboard.Transient.DesiredAnimation = if hasTarget and isMoving
+        then 'Run'
+        elseif isMoving then 'Walk'
+        else 'Idle'
+    blackboard.Transient.DesiredAnimationSpeed = if hasTarget and isMoving then 1.15 else 1
+    blackboard.Transient.ShouldPlayChaseLoop = hasTarget and isMoving
+end
+
+function MovementComponent:destroy(_blackboard) end
+
+return MovementComponent

--- a/packages/gameplay/src/Monsters/Components/PerceptionComponent.luau
+++ b/packages/gameplay/src/Monsters/Components/PerceptionComponent.luau
@@ -1,0 +1,44 @@
+local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
+local MonsterLogic = require(script.Parent.Parent.MonsterLogic)
+
+local PerceptionComponent = {}
+PerceptionComponent.__index = PerceptionComponent
+
+function PerceptionComponent.new()
+    return setmetatable({}, PerceptionComponent)
+end
+
+function PerceptionComponent:init(_blackboard) end
+
+function PerceptionComponent:update(blackboard, _dt)
+    local behaviors = blackboard.Context.Behaviors or {}
+    if not behaviors[MonsterBehaviorCatalog.Behavior.SenseNearestTarget] then
+        blackboard.Transient.HasTarget = false
+        blackboard.Transient.TargetPlayer = nil
+        blackboard.Transient.TargetPosition = nil
+        return
+    end
+
+    local currentPosition = blackboard.Context.CurrentPosition
+    if typeof(currentPosition) ~= 'Vector3' then
+        blackboard.Transient.HasTarget = false
+        blackboard.Transient.TargetPlayer = nil
+        blackboard.Transient.TargetPosition = nil
+        return
+    end
+
+    local playerPositions = blackboard.Context.PlayerPositions or {}
+    local sightRange = blackboard.Context.SightRange
+    local targetPlayer =
+        MonsterLogic.pickNearestTarget(currentPosition, playerPositions, sightRange)
+
+    blackboard.Transient.HasTarget = targetPlayer ~= nil
+    blackboard.Transient.TargetPlayer = targetPlayer
+    blackboard.Transient.TargetPosition = if targetPlayer
+        then playerPositions[targetPlayer]
+        else nil
+end
+
+function PerceptionComponent:destroy(_blackboard) end
+
+return PerceptionComponent

--- a/packages/gameplay/src/Monsters/Components/PerceptionComponent.luau
+++ b/packages/gameplay/src/Monsters/Components/PerceptionComponent.luau
@@ -11,6 +11,12 @@ end
 function PerceptionComponent:init(_blackboard) end
 
 function PerceptionComponent:update(blackboard, _dt)
+    local componentConfig = blackboard.Context.ComponentConfig
+    local perceptionConfig = if type(componentConfig) == 'table'
+            and type(componentConfig.Perception) == 'table'
+        then componentConfig.Perception
+        else {}
+
     local behaviors = blackboard.Context.Behaviors or {}
     if not behaviors[MonsterBehaviorCatalog.Behavior.SenseNearestTarget] then
         blackboard.Transient.HasTarget = false
@@ -28,7 +34,7 @@ function PerceptionComponent:update(blackboard, _dt)
     end
 
     local playerPositions = blackboard.Context.PlayerPositions or {}
-    local sightRange = blackboard.Context.SightRange
+    local sightRange = perceptionConfig.SightRange or blackboard.Context.SightRange
     local targetPlayer =
         MonsterLogic.pickNearestTarget(currentPosition, playerPositions, sightRange)
 

--- a/packages/gameplay/src/Monsters/Enemy.luau
+++ b/packages/gameplay/src/Monsters/Enemy.luau
@@ -23,6 +23,10 @@ local function defaultComponents()
     }
 end
 
+local function cloneContext(context)
+    return table.clone(context or {})
+end
+
 function Enemy.new(definition, options)
     local enemyOptions = options or {}
     local blackboard = enemyOptions.Blackboard or EnemyBlackboard.new(definition)
@@ -31,6 +35,7 @@ function Enemy.new(definition, options)
 
     return setmetatable({
         Blackboard = blackboard,
+        ComponentConfig = enemyOptions.ComponentConfig or {},
         StateMachine = stateMachine,
         Components = components,
         StageObserver = enemyOptions.StageObserver,
@@ -53,7 +58,9 @@ function Enemy:spawn()
 end
 
 function Enemy:update(dt, context)
-    self.Blackboard:beginTick(context)
+    local blackboardContext = cloneContext(context)
+    blackboardContext.ComponentConfig = self.ComponentConfig
+    self.Blackboard:beginTick(blackboardContext)
 
     self:_emitStage('Perception')
     self.Components.Perception:update(self.Blackboard, dt)

--- a/packages/gameplay/src/Monsters/Enemy.luau
+++ b/packages/gameplay/src/Monsters/Enemy.luau
@@ -1,0 +1,92 @@
+local EnemyBlackboard = require(script.Parent.EnemyBlackboard)
+local EnemyStateMachine = require(script.Parent.EnemyStateMachine)
+
+local AttackComponent = require(script.Parent.Components.AttackComponent)
+local MovementComponent = require(script.Parent.Components.MovementComponent)
+local PerceptionComponent = require(script.Parent.Components.PerceptionComponent)
+
+local Enemy = {}
+Enemy.__index = Enemy
+
+local UPDATE_ORDER = table.freeze({
+    'Perception',
+    'FSM',
+    'Movement',
+    'Attack',
+})
+
+local function defaultComponents()
+    return {
+        Perception = PerceptionComponent.new(),
+        Movement = MovementComponent.new(),
+        Attack = AttackComponent.new(),
+    }
+end
+
+function Enemy.new(definition, options)
+    local enemyOptions = options or {}
+    local blackboard = enemyOptions.Blackboard or EnemyBlackboard.new(definition)
+    local stateMachine = enemyOptions.StateMachine or EnemyStateMachine.new()
+    local components = enemyOptions.Components or defaultComponents()
+
+    return setmetatable({
+        Blackboard = blackboard,
+        StateMachine = stateMachine,
+        Components = components,
+        StageObserver = enemyOptions.StageObserver,
+    }, Enemy)
+end
+
+function Enemy:_emitStage(stageName)
+    if self.StageObserver then
+        self.StageObserver(stageName, self.Blackboard)
+    end
+end
+
+function Enemy:spawn()
+    self.Blackboard:setState(self.StateMachine:getState())
+    for _, component in pairs(self.Components) do
+        if component.init then
+            component:init(self.Blackboard)
+        end
+    end
+end
+
+function Enemy:update(dt, context)
+    self.Blackboard:beginTick(context)
+
+    self:_emitStage('Perception')
+    self.Components.Perception:update(self.Blackboard, dt)
+
+    self:_emitStage('FSM')
+    self.StateMachine:update(self.Blackboard)
+
+    self:_emitStage('Movement')
+    self.Components.Movement:update(self.Blackboard, dt)
+
+    self:_emitStage('Attack')
+    self.Components.Attack:update(self.Blackboard, dt)
+
+    return {
+        State = self.Blackboard:getState(),
+        TargetPlayer = self.Blackboard.Transient.TargetPlayer,
+        NextPosition = self.Blackboard.Transient.NextPosition,
+        ShouldAdvancePatrol = self.Blackboard.Transient.ShouldAdvancePatrol == true,
+        DesiredAnimation = self.Blackboard.Transient.DesiredAnimation or 'Idle',
+        DesiredAnimationSpeed = self.Blackboard.Transient.DesiredAnimationSpeed or 1,
+        ShouldPlayChaseLoop = self.Blackboard.Transient.ShouldPlayChaseLoop == true,
+        TravelOffset = self.Blackboard.Transient.TravelOffset or Vector3.zero,
+    }
+end
+
+function Enemy:destroy()
+    for _, component in pairs(self.Components) do
+        if component.destroy then
+            component:destroy(self.Blackboard)
+        end
+    end
+end
+
+Enemy.UpdateOrder = UPDATE_ORDER
+
+return Enemy

--- a/packages/gameplay/src/Monsters/Enemy.luau
+++ b/packages/gameplay/src/Monsters/Enemy.luau
@@ -75,6 +75,7 @@ function Enemy:update(dt, context)
     self.Components.Attack:update(self.Blackboard, dt)
 
     return {
+        AttackIntent = self.Blackboard.Transient.AttackIntent,
         State = self.Blackboard:getState(),
         TargetPlayer = self.Blackboard.Transient.TargetPlayer,
         NextPosition = self.Blackboard.Transient.NextPosition,

--- a/packages/gameplay/src/Monsters/EnemyBlackboard.luau
+++ b/packages/gameplay/src/Monsters/EnemyBlackboard.luau
@@ -1,0 +1,39 @@
+local EnemyBlackboard = {}
+EnemyBlackboard.__index = EnemyBlackboard
+
+local function cloneTable(source)
+    local clone = {}
+    if type(source) ~= 'table' then
+        return clone
+    end
+
+    for key, value in pairs(source) do
+        clone[key] = value
+    end
+
+    return clone
+end
+
+function EnemyBlackboard.new(definition)
+    return setmetatable({
+        Definition = definition,
+        State = nil,
+        Context = {},
+        Transient = {},
+    }, EnemyBlackboard)
+end
+
+function EnemyBlackboard:beginTick(context)
+    self.Context = cloneTable(context)
+    self.Transient = {}
+end
+
+function EnemyBlackboard:setState(state)
+    self.State = state
+end
+
+function EnemyBlackboard:getState()
+    return self.State
+end
+
+return EnemyBlackboard

--- a/packages/gameplay/src/Monsters/EnemyStateMachine.luau
+++ b/packages/gameplay/src/Monsters/EnemyStateMachine.luau
@@ -1,0 +1,55 @@
+local EnemyStateMachine = {}
+EnemyStateMachine.__index = EnemyStateMachine
+
+local STATE = table.freeze({
+    Idle = 'Idle',
+    Suspect = 'Suspect',
+    Alert = 'Alert',
+    Search = 'Search',
+})
+
+function EnemyStateMachine.new(initialState)
+    return setmetatable({
+        Current = initialState or STATE.Idle,
+        LostTargetTicks = 0,
+    }, EnemyStateMachine)
+end
+
+function EnemyStateMachine:getState()
+    return self.Current
+end
+
+function EnemyStateMachine:update(blackboard)
+    local hasTarget = blackboard.Transient.HasTarget == true
+
+    if hasTarget then
+        self.Current = STATE.Alert
+        self.LostTargetTicks = 0
+        blackboard:setState(self.Current)
+        return self.Current
+    end
+
+    if self.Current == STATE.Alert then
+        self.Current = STATE.Search
+        self.LostTargetTicks = 1
+        blackboard:setState(self.Current)
+        return self.Current
+    end
+
+    if self.Current == STATE.Search then
+        self.LostTargetTicks += 1
+        if self.LostTargetTicks >= 2 then
+            self.Current = STATE.Idle
+        end
+        blackboard:setState(self.Current)
+        return self.Current
+    end
+
+    self.Current = STATE.Idle
+    blackboard:setState(self.Current)
+    return self.Current
+end
+
+EnemyStateMachine.State = STATE
+
+return EnemyStateMachine

--- a/packages/gameplay/src/Monsters/MonsterAuthorProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterAuthorProfile.luau
@@ -17,6 +17,9 @@ local SEMANTIC_FIELDS = table.freeze({
     CounterplayIntent = true,
 })
 local TUNING_FIELDS = table.freeze({
+    AttackCooldownSeconds = true,
+    AttackDamagePips = true,
+    AttackRange = true,
     Speed = true,
     SightRange = true,
     PatrolSpeedMultiplier = true,
@@ -226,6 +229,27 @@ function MonsterAuthorProfile.validate(profile)
 
     if type(tuning.PatrolSpeedMultiplier) ~= 'number' or tuning.PatrolSpeedMultiplier <= 0 then
         return false, 'InvalidPatrolSpeedMultiplier'
+    end
+
+    if
+        tuning.AttackRange ~= nil
+        and (type(tuning.AttackRange) ~= 'number' or tuning.AttackRange <= 0)
+    then
+        return false, 'InvalidAttackRange'
+    end
+
+    if tuning.AttackCooldownSeconds ~= nil then
+        if type(tuning.AttackCooldownSeconds) ~= 'number' or tuning.AttackCooldownSeconds <= 0 then
+            return false, 'InvalidAttackCooldownSeconds'
+        end
+    end
+
+    if
+        tuning.AttackDamagePips ~= nil
+        and tuning.AttackDamagePips ~= 1
+        and tuning.AttackDamagePips ~= 2
+    then
+        return false, 'InvalidAttackDamagePips'
     end
 
     if tuning.SpawnOffset ~= nil and typeof(tuning.SpawnOffset) ~= 'Vector3' then

--- a/packages/gameplay/src/Monsters/MonsterBehaviorCatalog.luau
+++ b/packages/gameplay/src/Monsters/MonsterBehaviorCatalog.luau
@@ -19,6 +19,7 @@ local MonsterBehaviorCatalog = table.freeze({
         [BEHAVIOR.Patrol] = true,
         [BEHAVIOR.SenseNearestTarget] = true,
         [BEHAVIOR.Chase] = true,
+        [BEHAVIOR.Attack] = true,
     }),
 })
 

--- a/packages/gameplay/src/Monsters/MonsterCompiler.luau
+++ b/packages/gameplay/src/Monsters/MonsterCompiler.luau
@@ -5,6 +5,9 @@ local MonsterEffectCatalog = require(script.Parent.MonsterEffectCatalog)
 local MonsterRuntimeProfile = require(script.Parent.MonsterRuntimeProfile)
 
 local DEFAULT_SPAWN_OFFSET = Vector3.new(0, 4, 0)
+local DEFAULT_ATTACK_COOLDOWN_SECONDS = 1
+local DEFAULT_ATTACK_DAMAGE_PIPS = 1
+local DEFAULT_ATTACK_RANGE = 4
 
 local MonsterCompiler = {}
 
@@ -72,6 +75,10 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
         Id = normalizedProfile.Id,
         Name = normalizedProfile.Name,
         Presentation = cloneRuntimePresentation(normalizedProfile.Executable.Presentation),
+        AttackCooldownSeconds = normalizedProfile.Tuning.AttackCooldownSeconds
+            or DEFAULT_ATTACK_COOLDOWN_SECONDS,
+        AttackDamagePips = normalizedProfile.Tuning.AttackDamagePips or DEFAULT_ATTACK_DAMAGE_PIPS,
+        AttackRange = normalizedProfile.Tuning.AttackRange or DEFAULT_ATTACK_RANGE,
         Speed = normalizedProfile.Tuning.Speed,
         SightRange = normalizedProfile.Tuning.SightRange,
         PatrolSpeedMultiplier = normalizedProfile.Tuning.PatrolSpeedMultiplier,

--- a/packages/gameplay/src/Monsters/MonsterCompiler.luau
+++ b/packages/gameplay/src/Monsters/MonsterCompiler.luau
@@ -1,5 +1,6 @@
 local MonsterAuthorProfile = require(script.Parent.MonsterAuthorProfile)
 local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
+local MonsterComponentConfig = require(script.Parent.MonsterComponentConfig)
 local MonsterEffectCatalog = require(script.Parent.MonsterEffectCatalog)
 local MonsterRuntimeProfile = require(script.Parent.MonsterRuntimeProfile)
 
@@ -67,7 +68,7 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
         end
     end
 
-    local runtimeProfile = table.freeze({
+    local runtimeProfile = {
         Id = normalizedProfile.Id,
         Name = normalizedProfile.Name,
         Presentation = cloneRuntimePresentation(normalizedProfile.Executable.Presentation),
@@ -77,7 +78,9 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
         SpawnOffset = normalizedProfile.Tuning.SpawnOffset or DEFAULT_SPAWN_OFFSET,
         Behaviors = table.freeze(behaviors),
         Effects = table.freeze(runtimeEffects),
-    })
+    }
+    runtimeProfile.Components = MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)
+    runtimeProfile = table.freeze(runtimeProfile)
 
     local validRuntimeProfile, runtimeReason = MonsterRuntimeProfile.validate(runtimeProfile)
     if not validRuntimeProfile then

--- a/packages/gameplay/src/Monsters/MonsterComponentConfig.luau
+++ b/packages/gameplay/src/Monsters/MonsterComponentConfig.luau
@@ -1,5 +1,8 @@
 local DEFAULT_ATTACK_COOLDOWN_SECONDS = 1
+local DEFAULT_ATTACK_DAMAGE_PIPS = 1
+local DEFAULT_ATTACK_HIT_MARKER_NAME = 'Hit'
 local DEFAULT_ATTACK_RANGE = 4
+local DEFAULT_ATTACK_ARC_DEGREES = 100
 local DEFAULT_PATROL_REACH_DISTANCE = 2
 local DEFAULT_SPAWN_OFFSET = Vector3.new(0, 4, 0)
 
@@ -23,6 +26,16 @@ local function getSpawnOffset(primary, fallback)
         return fallback
     end
     return DEFAULT_SPAWN_OFFSET
+end
+
+local function getAttackDamagePips(value, fallback)
+    if value == 1 or value == 2 then
+        return value
+    end
+    if fallback == 1 or fallback == 2 then
+        return fallback
+    end
+    return DEFAULT_ATTACK_DAMAGE_PIPS
 end
 
 function MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)
@@ -52,12 +65,18 @@ function MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)
             Speed = getPositiveNumber(movement.Speed, profile.Speed, 14),
         }),
         Attack = table.freeze({
+            ArcDegrees = getPositiveNumber(attack.ArcDegrees, nil, DEFAULT_ATTACK_ARC_DEGREES),
             CooldownSeconds = getPositiveNumber(
                 attack.CooldownSeconds,
-                nil,
+                profile.AttackCooldownSeconds,
                 DEFAULT_ATTACK_COOLDOWN_SECONDS
             ),
-            Range = getPositiveNumber(attack.Range, nil, DEFAULT_ATTACK_RANGE),
+            DamagePips = getAttackDamagePips(attack.DamagePips, profile.AttackDamagePips),
+            HitMarkerName = if type(attack.HitMarkerName) == 'string'
+                    and attack.HitMarkerName ~= ''
+                then attack.HitMarkerName
+                else DEFAULT_ATTACK_HIT_MARKER_NAME,
+            Range = getPositiveNumber(attack.Range, profile.AttackRange, DEFAULT_ATTACK_RANGE),
         }),
     }
 

--- a/packages/gameplay/src/Monsters/MonsterComponentConfig.luau
+++ b/packages/gameplay/src/Monsters/MonsterComponentConfig.luau
@@ -1,0 +1,67 @@
+local DEFAULT_ATTACK_COOLDOWN_SECONDS = 1
+local DEFAULT_ATTACK_RANGE = 4
+local DEFAULT_PATROL_REACH_DISTANCE = 2
+local DEFAULT_SPAWN_OFFSET = Vector3.new(0, 4, 0)
+
+local MonsterComponentConfig = {}
+
+local function getPositiveNumber(value, fallback, defaultValue)
+    if type(value) == 'number' and value > 0 then
+        return value
+    end
+    if type(fallback) == 'number' and fallback > 0 then
+        return fallback
+    end
+    return defaultValue
+end
+
+local function getSpawnOffset(primary, fallback)
+    if typeof(primary) == 'Vector3' then
+        return primary
+    end
+    if typeof(fallback) == 'Vector3' then
+        return fallback
+    end
+    return DEFAULT_SPAWN_OFFSET
+end
+
+function MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)
+    local profile = runtimeProfile or {}
+    local components = if type(profile.Components) == 'table' then profile.Components else {}
+
+    local perception = if type(components.Perception) == 'table' then components.Perception else {}
+    local movement = if type(components.Movement) == 'table' then components.Movement else {}
+    local attack = if type(components.Attack) == 'table' then components.Attack else {}
+
+    local componentConfig = {
+        Perception = table.freeze({
+            SightRange = getPositiveNumber(perception.SightRange, profile.SightRange, 30),
+        }),
+        Movement = table.freeze({
+            PatrolReachDistance = getPositiveNumber(
+                movement.PatrolReachDistance,
+                nil,
+                DEFAULT_PATROL_REACH_DISTANCE
+            ),
+            PatrolSpeedMultiplier = getPositiveNumber(
+                movement.PatrolSpeedMultiplier,
+                profile.PatrolSpeedMultiplier,
+                0.45
+            ),
+            SpawnOffset = getSpawnOffset(movement.SpawnOffset, profile.SpawnOffset),
+            Speed = getPositiveNumber(movement.Speed, profile.Speed, 14),
+        }),
+        Attack = table.freeze({
+            CooldownSeconds = getPositiveNumber(
+                attack.CooldownSeconds,
+                nil,
+                DEFAULT_ATTACK_COOLDOWN_SECONDS
+            ),
+            Range = getPositiveNumber(attack.Range, nil, DEFAULT_ATTACK_RANGE),
+        }),
+    }
+
+    return table.freeze(componentConfig)
+end
+
+return MonsterComponentConfig

--- a/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
@@ -6,6 +6,30 @@ local function isNonEmptyString(value)
     return type(value) == 'string' and value ~= ''
 end
 
+local function isPositiveNumber(value)
+    return type(value) == 'number' and value > 0
+end
+
+local function readComponentTable(profile, name)
+    local components = profile.Components
+    if components == nil then
+        return nil, nil
+    end
+    if type(components) ~= 'table' then
+        return nil, 'InvalidRuntimeComponents'
+    end
+
+    local component = components[name]
+    if component == nil then
+        return nil, nil
+    end
+    if type(component) ~= 'table' then
+        return nil, string.format('InvalidRuntimeComponent%s', name)
+    end
+
+    return component, nil
+end
+
 function MonsterRuntimeProfile.validate(profile)
     if type(profile) ~= 'table' then
         return false, 'MalformedMonsterRuntimeProfile'
@@ -46,19 +70,92 @@ function MonsterRuntimeProfile.validate(profile)
         return false, 'InvalidRuntimeChaseLoopSoundAssetId'
     end
 
-    if type(profile.Speed) ~= 'number' or profile.Speed <= 0 then
+    local perceptionConfig, perceptionConfigErr = readComponentTable(profile, 'Perception')
+    if perceptionConfigErr then
+        return false, perceptionConfigErr
+    end
+    local movementConfig, movementConfigErr = readComponentTable(profile, 'Movement')
+    if movementConfigErr then
+        return false, movementConfigErr
+    end
+    local attackConfig, attackConfigErr = readComponentTable(profile, 'Attack')
+    if attackConfigErr then
+        return false, attackConfigErr
+    end
+
+    if
+        perceptionConfig
+        and perceptionConfig.SightRange ~= nil
+        and not isPositiveNumber(perceptionConfig.SightRange)
+    then
+        return false, 'InvalidRuntimeComponentPerceptionSightRange'
+    end
+
+    if movementConfig then
+        if movementConfig.Speed ~= nil and not isPositiveNumber(movementConfig.Speed) then
+            return false, 'InvalidRuntimeComponentMovementSpeed'
+        end
+        if
+            movementConfig.PatrolSpeedMultiplier ~= nil
+            and not isPositiveNumber(movementConfig.PatrolSpeedMultiplier)
+        then
+            return false, 'InvalidRuntimeComponentMovementPatrolSpeedMultiplier'
+        end
+        if
+            movementConfig.PatrolReachDistance ~= nil
+            and not isPositiveNumber(movementConfig.PatrolReachDistance)
+        then
+            return false, 'InvalidRuntimeComponentMovementPatrolReachDistance'
+        end
+        if
+            movementConfig.SpawnOffset ~= nil
+            and typeof(movementConfig.SpawnOffset) ~= 'Vector3'
+        then
+            return false, 'InvalidRuntimeComponentMovementSpawnOffset'
+        end
+    end
+
+    if attackConfig then
+        if attackConfig.Range ~= nil and not isPositiveNumber(attackConfig.Range) then
+            return false, 'InvalidRuntimeComponentAttackRange'
+        end
+        if
+            attackConfig.CooldownSeconds ~= nil
+            and not isPositiveNumber(attackConfig.CooldownSeconds)
+        then
+            return false, 'InvalidRuntimeComponentAttackCooldown'
+        end
+    end
+
+    local runtimeSpeed = profile.Speed
+    if runtimeSpeed == nil and movementConfig then
+        runtimeSpeed = movementConfig.Speed
+    end
+    if not isPositiveNumber(runtimeSpeed) then
         return false, 'InvalidRuntimeSpeed'
     end
 
-    if type(profile.SightRange) ~= 'number' or profile.SightRange <= 0 then
+    local runtimeSightRange = profile.SightRange
+    if runtimeSightRange == nil and perceptionConfig then
+        runtimeSightRange = perceptionConfig.SightRange
+    end
+    if not isPositiveNumber(runtimeSightRange) then
         return false, 'InvalidRuntimeSightRange'
     end
 
-    if type(profile.PatrolSpeedMultiplier) ~= 'number' or profile.PatrolSpeedMultiplier <= 0 then
+    local runtimePatrolSpeedMultiplier = profile.PatrolSpeedMultiplier
+    if runtimePatrolSpeedMultiplier == nil and movementConfig then
+        runtimePatrolSpeedMultiplier = movementConfig.PatrolSpeedMultiplier
+    end
+    if not isPositiveNumber(runtimePatrolSpeedMultiplier) then
         return false, 'InvalidRuntimePatrolSpeedMultiplier'
     end
 
-    if typeof(profile.SpawnOffset) ~= 'Vector3' then
+    local runtimeSpawnOffset = profile.SpawnOffset
+    if runtimeSpawnOffset == nil and movementConfig then
+        runtimeSpawnOffset = movementConfig.SpawnOffset
+    end
+    if typeof(runtimeSpawnOffset) ~= 'Vector3' then
         return false, 'InvalidRuntimeSpawnOffset'
     end
 

--- a/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
@@ -10,6 +10,10 @@ local function isPositiveNumber(value)
     return type(value) == 'number' and value > 0
 end
 
+local function isValidDamagePips(value)
+    return value == 1 or value == 2
+end
+
 local function readComponentTable(profile, name)
     local components = profile.Components
     if components == nil then
@@ -125,6 +129,9 @@ function MonsterRuntimeProfile.validate(profile)
         then
             return false, 'InvalidRuntimeComponentAttackCooldown'
         end
+        if attackConfig.DamagePips ~= nil and not isValidDamagePips(attackConfig.DamagePips) then
+            return false, 'InvalidRuntimeComponentAttackDamagePips'
+        end
     end
 
     local runtimeSpeed = profile.Speed
@@ -157,6 +164,39 @@ function MonsterRuntimeProfile.validate(profile)
     end
     if typeof(runtimeSpawnOffset) ~= 'Vector3' then
         return false, 'InvalidRuntimeSpawnOffset'
+    end
+
+    local runtimeAttackRange = profile.AttackRange
+    if runtimeAttackRange == nil and attackConfig then
+        runtimeAttackRange = attackConfig.Range
+    end
+    if runtimeAttackRange == nil then
+        runtimeAttackRange = 4
+    end
+    if not isPositiveNumber(runtimeAttackRange) then
+        return false, 'InvalidRuntimeAttackRange'
+    end
+
+    local runtimeAttackCooldownSeconds = profile.AttackCooldownSeconds
+    if runtimeAttackCooldownSeconds == nil and attackConfig then
+        runtimeAttackCooldownSeconds = attackConfig.CooldownSeconds
+    end
+    if runtimeAttackCooldownSeconds == nil then
+        runtimeAttackCooldownSeconds = 1
+    end
+    if not isPositiveNumber(runtimeAttackCooldownSeconds) then
+        return false, 'InvalidRuntimeAttackCooldownSeconds'
+    end
+
+    local runtimeAttackDamagePips = profile.AttackDamagePips
+    if runtimeAttackDamagePips == nil and attackConfig then
+        runtimeAttackDamagePips = attackConfig.DamagePips
+    end
+    if runtimeAttackDamagePips == nil then
+        runtimeAttackDamagePips = 1
+    end
+    if not isValidDamagePips(runtimeAttackDamagePips) then
+        return false, 'InvalidRuntimeAttackDamagePips'
     end
 
     if type(profile.Behaviors) ~= 'table' then

--- a/packages/gameplay/src/Monsters/init.luau
+++ b/packages/gameplay/src/Monsters/init.luau
@@ -1,6 +1,7 @@
 local MonsterCompiler = require(script.MonsterCompiler)
 
 return {
+    MonsterComponentConfig = require(script.MonsterComponentConfig),
     Enemy = require(script.Enemy),
     EnemyBlackboard = require(script.EnemyBlackboard),
     EnemyStateMachine = require(script.EnemyStateMachine),

--- a/packages/gameplay/src/Monsters/init.luau
+++ b/packages/gameplay/src/Monsters/init.luau
@@ -1,6 +1,9 @@
 local MonsterCompiler = require(script.MonsterCompiler)
 
 return {
+    Enemy = require(script.Enemy),
+    EnemyBlackboard = require(script.EnemyBlackboard),
+    EnemyStateMachine = require(script.EnemyStateMachine),
     MonsterAuthorProfile = require(script.MonsterAuthorProfile),
     MonsterBehaviorCatalog = require(script.MonsterBehaviorCatalog),
     MonsterCompiler = MonsterCompiler,

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -20,11 +20,21 @@ local DEFAULT_R6_ANIMATIONS = table.freeze({
     Idle = 180435571,
     Walk = 180426354,
     Run = 180426354,
+    Attack = 10469493270,
 })
 local DEFAULT_CHASE_LOOP_VOLUME = 0.45
 local DEFAULT_CHASE_LOOP_MIN_DISTANCE = 8
 local DEFAULT_CHASE_LOOP_MAX_DISTANCE = 48
+local DEFAULT_ATTACK_ARC_DEGREES = 100
+local DEFAULT_ATTACK_MARKER_NAME = 'Hit'
+local DEFAULT_ATTACK_MARKER_TIMEOUT_SECONDS = 1.5
 local DEFAULT_VISUAL_SMOOTHING_SPEED = 12
+
+local function defaultOnAttackHit(_player, _damagePips, _hitContext) end
+
+local function defaultRaycast(origin, direction, raycastParams)
+    return Workspace:Raycast(origin, direction, raycastParams)
+end
 
 local function defaultWarn(message)
     warn(message)
@@ -111,6 +121,9 @@ function MonsterService.new(
         ChaseLoopSound = nil,
         IsChaseLoopSoundPlaying = false,
         AnimationTracks = {},
+        AttackAnimationTrack = nil,
+        AttackMarkerConnection = nil,
+        PendingAttack = nil,
         ActiveAnimation = nil,
         Connection = nil,
         LogicalPosition = nil,
@@ -121,9 +134,13 @@ function MonsterService.new(
         LoadAnimationTrack = runtimeOptions.LoadAnimationTrack or defaultLoadAnimationTrack,
         CreateLoopSound = runtimeOptions.CreateLoopSound or defaultCreateLoopSound,
         EnemyFactory = runtimeOptions.EnemyFactory or defaultEnemyFactory,
+        OnAttackHit = runtimeOptions.OnAttackHit or defaultOnAttackHit,
+        Raycast = runtimeOptions.Raycast or defaultRaycast,
         GetPlayers = runtimeOptions.GetPlayers or function()
             return Players:GetPlayers()
         end,
+        AttackMarkerTimeoutSeconds = runtimeOptions.AttackMarkerTimeoutSeconds
+            or DEFAULT_ATTACK_MARKER_TIMEOUT_SECONDS,
         VisualSmoothingSpeed = runtimeOptions.VisualSmoothingSpeed
             or DEFAULT_VISUAL_SMOOTHING_SPEED,
     }, MonsterService)
@@ -135,13 +152,23 @@ function MonsterService:destroy()
         self.Connection = nil
     end
 
+    if self.AttackMarkerConnection then
+        self.AttackMarkerConnection:Disconnect()
+        self.AttackMarkerConnection = nil
+    end
+
     for _, track in pairs(self.AnimationTracks) do
         if track.Stop then
             track:Stop(0)
         end
     end
+    if self.AttackAnimationTrack and self.AttackAnimationTrack.Stop then
+        self.AttackAnimationTrack:Stop(0)
+    end
 
     self.AnimationTracks = {}
+    self.AttackAnimationTrack = nil
+    self.PendingAttack = nil
     self.ActiveAnimation = nil
     self.MonsterHumanoid = nil
     self.MonsterPositionPart = nil
@@ -259,7 +286,23 @@ function MonsterService:_loadAnimationTracks(humanoid)
         animationTracks.Run.Priority = Enum.AnimationPriority.Movement
     end
 
+    local attackTrack =
+        self.LoadAnimationTrack(animator, DEFAULT_R6_ANIMATIONS.Attack, 'MonsterAttack')
+    if attackTrack then
+        attackTrack.Looped = false
+        attackTrack.Priority = Enum.AnimationPriority.Action
+        if attackTrack.GetMarkerReachedSignal then
+            local markerSignal = attackTrack:GetMarkerReachedSignal(DEFAULT_ATTACK_MARKER_NAME)
+            if markerSignal then
+                self.AttackMarkerConnection = markerSignal:Connect(function()
+                    self:_onAttackMarkerReached(DEFAULT_ATTACK_MARKER_NAME)
+                end)
+            end
+        end
+    end
+
     self.AnimationTracks = animationTracks
+    self.AttackAnimationTrack = attackTrack
     self.MonsterHumanoid = humanoid
 end
 
@@ -404,6 +447,231 @@ function MonsterService:_applyVisualCFrame(nextCFrame, dt)
     end
 end
 
+function MonsterService:_getAttackFacingDirection()
+    local lookVector = nil
+    if self.MonsterRoot and self.MonsterRoot:IsA('Model') then
+        lookVector = self.MonsterRoot:GetPivot().LookVector
+    elseif self.MonsterPositionPart then
+        lookVector = self.MonsterPositionPart.CFrame.LookVector
+    end
+
+    if typeof(lookVector) ~= 'Vector3' then
+        return Vector3.new(0, 0, -1)
+    end
+
+    local horizontalLook = Vector3.new(lookVector.X, 0, lookVector.Z)
+    if horizontalLook.Magnitude <= 1e-5 then
+        return lookVector.Unit
+    end
+
+    return horizontalLook.Unit
+end
+
+function MonsterService:_isWithinAttackArc(monsterPosition, targetPosition, arcDegrees)
+    local toTarget = targetPosition - monsterPosition
+    local horizontalToTarget = Vector3.new(toTarget.X, 0, toTarget.Z)
+    if horizontalToTarget.Magnitude <= 1e-5 then
+        return true
+    end
+
+    local facingDirection = self:_getAttackFacingDirection()
+    local facingHorizontal = Vector3.new(facingDirection.X, 0, facingDirection.Z)
+    if facingHorizontal.Magnitude <= 1e-5 then
+        return true
+    end
+    facingHorizontal = facingHorizontal.Unit
+
+    local targetDirection = horizontalToTarget.Unit
+    local halfArcCosine = math.cos(math.rad((arcDegrees or DEFAULT_ATTACK_ARC_DEGREES) * 0.5))
+    local dot = facingHorizontal:Dot(targetDirection)
+    return dot + 1e-6 >= halfArcCosine
+end
+
+function MonsterService:_hasLineOfSight(targetPlayer, originPosition, targetPosition)
+    local direction = targetPosition - originPosition
+    if direction.Magnitude <= 1e-5 then
+        return true
+    end
+
+    local raycastParams = RaycastParams.new()
+    raycastParams.FilterType = Enum.RaycastFilterType.Exclude
+    raycastParams.IgnoreWater = true
+    if self.MonsterRoot then
+        raycastParams.FilterDescendantsInstances = { self.MonsterRoot }
+    end
+
+    local raycastResult = self.Raycast(originPosition, direction, raycastParams)
+    if raycastResult == nil then
+        return true
+    end
+
+    local character = targetPlayer and targetPlayer.Character
+    if
+        character
+        and raycastResult.Instance
+        and raycastResult.Instance:IsDescendantOf(character)
+    then
+        return true
+    end
+
+    return false
+end
+
+function MonsterService:_resolveAttackHitContext(pendingAttack)
+    local targetPlayer = pendingAttack.TargetPlayer
+    if targetPlayer == nil or not self.CanTargetPlayer(targetPlayer) then
+        return {
+            Hit = false,
+            Reason = 'InvalidTarget',
+        }
+    end
+
+    local targetCharacter = targetPlayer.Character
+    local targetRoot = targetCharacter and targetCharacter:FindFirstChild('HumanoidRootPart')
+    if not targetRoot then
+        return {
+            Hit = false,
+            Reason = 'MissingTargetRoot',
+        }
+    end
+
+    local monsterPosition = self:_getCurrentPosition()
+    if typeof(monsterPosition) ~= 'Vector3' then
+        return {
+            Hit = false,
+            Reason = 'MissingMonsterPosition',
+        }
+    end
+
+    local targetPosition = targetRoot.Position
+    local distance = (targetPosition - monsterPosition).Magnitude
+    if distance > pendingAttack.Range then
+        return {
+            Hit = false,
+            Reason = 'OutOfRange',
+        }
+    end
+
+    if not self:_isWithinAttackArc(monsterPosition, targetPosition, pendingAttack.ArcDegrees) then
+        return {
+            Hit = false,
+            Reason = 'OutOfArc',
+        }
+    end
+
+    if not self:_hasLineOfSight(targetPlayer, monsterPosition, targetPosition) then
+        return {
+            Hit = false,
+            Reason = 'BlockedLineOfSight',
+        }
+    end
+
+    return {
+        Hit = true,
+        Reason = 'HitConfirmed',
+        Distance = distance,
+    }
+end
+
+function MonsterService:_playAttackAnimation()
+    local attackTrack = self.AttackAnimationTrack
+    if not attackTrack then
+        return false
+    end
+
+    if attackTrack.Stop then
+        attackTrack:Stop(0)
+    end
+    if attackTrack.Play then
+        attackTrack:Play(0.05)
+    else
+        return false
+    end
+    if attackTrack.AdjustSpeed then
+        attackTrack:AdjustSpeed(1)
+    end
+
+    return true
+end
+
+function MonsterService:_queueAttackIntent(attackIntent)
+    if type(attackIntent) ~= 'table' then
+        return
+    end
+
+    local targetPlayer = attackIntent.TargetPlayer
+    if targetPlayer == nil or not self.CanTargetPlayer(targetPlayer) then
+        return
+    end
+
+    local damagePips = attackIntent.DamagePips
+    if damagePips ~= 1 and damagePips ~= 2 then
+        return
+    end
+
+    local range = attackIntent.Range
+    if type(range) ~= 'number' or range <= 0 then
+        return
+    end
+
+    local markerName = if type(attackIntent.MarkerName) == 'string'
+            and attackIntent.MarkerName ~= ''
+        then attackIntent.MarkerName
+        else DEFAULT_ATTACK_MARKER_NAME
+
+    local hasMarkerConnection = self.AttackMarkerConnection ~= nil
+    if hasMarkerConnection then
+        if self.PendingAttack ~= nil then
+            return
+        end
+
+        self.PendingAttack = {
+            ArcDegrees = attackIntent.ArcDegrees or DEFAULT_ATTACK_ARC_DEGREES,
+            DamagePips = damagePips,
+            MarkerName = markerName,
+            Range = range,
+            RemainingWindowSeconds = self.AttackMarkerTimeoutSeconds,
+            TargetPlayer = targetPlayer,
+        }
+    end
+
+    local animationPlayed = self:_playAttackAnimation()
+    if hasMarkerConnection and not animationPlayed then
+        self.PendingAttack = nil
+    end
+end
+
+function MonsterService:_stepPendingAttack(dt)
+    if self.PendingAttack == nil then
+        return
+    end
+
+    self.PendingAttack.RemainingWindowSeconds -= math.max(0, dt or 0)
+    if self.PendingAttack.RemainingWindowSeconds <= 0 then
+        self.PendingAttack = nil
+    end
+end
+
+function MonsterService:_onAttackMarkerReached(markerName)
+    local pendingAttack = self.PendingAttack
+    if pendingAttack == nil then
+        return
+    end
+
+    if markerName ~= pendingAttack.MarkerName then
+        return
+    end
+
+    self.PendingAttack = nil
+
+    local hitContext = self:_resolveAttackHitContext(pendingAttack)
+    if hitContext.Hit ~= true then
+        return
+    end
+
+    self.OnAttackHit(pendingAttack.TargetPlayer, pendingAttack.DamagePips, hitContext)
+end
+
 function MonsterService:spawn(patrolPoints, initialPatrolIndex)
     self:destroy()
     self.PatrolPoints = patrolPoints
@@ -439,6 +707,7 @@ function MonsterService:update(dt)
     if not self.MonsterPositionPart or not self.IsExpeditionActive() or not self.EnemyRuntime then
         return
     end
+    self:_stepPendingAttack(dt)
 
     local playerPositions = {}
 
@@ -472,6 +741,7 @@ function MonsterService:update(dt)
         SightRange = self.Definition.SightRange,
         Speed = self.Definition.Speed,
     })
+    self:_queueAttackIntent(decision.AttackIntent)
     local nextPosition = decision.NextPosition
     if decision.ShouldAdvancePatrol and #self.PatrolPoints > 0 then
         self.PatrolIndex = (self.PatrolIndex % #self.PatrolPoints) + 1

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -8,7 +8,7 @@ local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
 
 local MonsterBehaviorCatalog = Gameplay.Monsters.MonsterBehaviorCatalog
-local MonsterLogic = Gameplay.Monsters.MonsterLogic
+local Enemy = Gameplay.Monsters.Enemy
 local MonsterRuntimeProfile = Gameplay.Monsters.MonsterRuntimeProfile
 
 local MonsterService = {}
@@ -75,6 +75,10 @@ local function defaultCreateLoopSound(parent, soundAssetId, soundName)
     return sound
 end
 
+local function defaultEnemyFactory(monsterRuntimeProfile, options)
+    return Enemy.new(monsterRuntimeProfile, options)
+end
+
 function MonsterService.new(
     monsterRuntimeProfile,
     isExpeditionActiveCallback,
@@ -109,10 +113,12 @@ function MonsterService.new(
         ActiveAnimation = nil,
         Connection = nil,
         LogicalPosition = nil,
+        EnemyRuntime = nil,
         Warn = runtimeOptions.Warn or defaultWarn,
         LoadMonsterModel = runtimeOptions.AssetLoader or defaultLoadMonsterModel,
         LoadAnimationTrack = runtimeOptions.LoadAnimationTrack or defaultLoadAnimationTrack,
         CreateLoopSound = runtimeOptions.CreateLoopSound or defaultCreateLoopSound,
+        EnemyFactory = runtimeOptions.EnemyFactory or defaultEnemyFactory,
         GetPlayers = runtimeOptions.GetPlayers or function()
             return Players:GetPlayers()
         end,
@@ -138,6 +144,10 @@ function MonsterService:destroy()
     self.MonsterHumanoid = nil
     self.MonsterPositionPart = nil
     self.LogicalPosition = nil
+    if self.EnemyRuntime then
+        self.EnemyRuntime:destroy()
+        self.EnemyRuntime = nil
+    end
 
     if self.ChaseLoopSound then
         if self.ChaseLoopSound.Stop then
@@ -411,13 +421,18 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
         self:_setAnimationState('Idle', 1)
     end
 
+    self.EnemyRuntime = self.EnemyFactory(self.Definition)
+    if self.EnemyRuntime and self.EnemyRuntime.spawn then
+        self.EnemyRuntime:spawn()
+    end
+
     self.Connection = RunService.Heartbeat:Connect(function(dt)
         self:update(dt)
     end)
 end
 
 function MonsterService:update(dt)
-    if not self.MonsterPositionPart or not self.IsExpeditionActive() then
+    if not self.MonsterPositionPart or not self.IsExpeditionActive() or not self.EnemyRuntime then
         return
     end
 
@@ -434,38 +449,27 @@ function MonsterService:update(dt)
     end
 
     local currentPosition = self:_getCurrentPosition()
-    local targetPlayer = nil
-    if self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.SenseNearestTarget] then
-        targetPlayer = MonsterLogic.pickNearestTarget(
-            currentPosition,
-            playerPositions,
-            self.Definition.SightRange
-        )
-    end
-    local nextPosition
-
-    if targetPlayer and self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.Chase] then
-        nextPosition = MonsterLogic.stepToward(
-            currentPosition,
-            playerPositions[targetPlayer],
-            self.Definition.Speed,
-            dt
-        )
-    elseif
+    local patrolTarget = nil
+    if
         self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.Patrol]
         and #self.PatrolPoints > 0
     then
-        local patrolTarget = self.PatrolPoints[self.PatrolIndex] + self.Definition.SpawnOffset
-        nextPosition = MonsterLogic.stepToward(
-            currentPosition,
-            patrolTarget,
-            self.Definition.Speed * self.Definition.PatrolSpeedMultiplier,
-            dt
-        )
+        patrolTarget = self.PatrolPoints[self.PatrolIndex] + self.Definition.SpawnOffset
+    end
 
-        if (nextPosition - patrolTarget).Magnitude <= 2 then
-            self.PatrolIndex = (self.PatrolIndex % #self.PatrolPoints) + 1
-        end
+    local decision = self.EnemyRuntime:update(dt, {
+        Behaviors = self.Definition.Behaviors,
+        CurrentPosition = currentPosition,
+        PatrolReachDistance = 2,
+        PatrolSpeedMultiplier = self.Definition.PatrolSpeedMultiplier,
+        PatrolTargetPosition = patrolTarget,
+        PlayerPositions = playerPositions,
+        SightRange = self.Definition.SightRange,
+        Speed = self.Definition.Speed,
+    })
+    local nextPosition = decision.NextPosition
+    if decision.ShouldAdvancePatrol and #self.PatrolPoints > 0 then
+        self.PatrolIndex = (self.PatrolIndex % #self.PatrolPoints) + 1
     end
 
     if nextPosition and self.CanTraverse(currentPosition, nextPosition) then
@@ -482,16 +486,8 @@ function MonsterService:update(dt)
             else currentRotation + nextPosition
         self:_applyVisualCFrame(facingCFrame, dt)
 
-        if targetPlayer and self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.Chase] then
-            self:_setAnimationState('Run', 1.15)
-            self:_setChaseLoopSoundPlaying(true)
-        elseif travelOffset.Magnitude > 0 then
-            self:_setAnimationState('Walk', 1)
-            self:_setChaseLoopSoundPlaying(false)
-        else
-            self:_setAnimationState('Idle', 1)
-            self:_setChaseLoopSoundPlaying(false)
-        end
+        self:_setAnimationState(decision.DesiredAnimation, decision.DesiredAnimationSpeed)
+        self:_setChaseLoopSoundPlaying(decision.ShouldPlayChaseLoop)
     else
         self:_setAnimationState('Idle', 1)
         self:_setChaseLoopSoundPlaying(false)

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -8,6 +8,7 @@ local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
 
 local MonsterBehaviorCatalog = Gameplay.Monsters.MonsterBehaviorCatalog
+local MonsterComponentConfig = Gameplay.Monsters.MonsterComponentConfig
 local Enemy = Gameplay.Monsters.Enemy
 local MonsterRuntimeProfile = Gameplay.Monsters.MonsterRuntimeProfile
 
@@ -114,6 +115,7 @@ function MonsterService.new(
         Connection = nil,
         LogicalPosition = nil,
         EnemyRuntime = nil,
+        ComponentConfig = MonsterComponentConfig.fromRuntimeProfile(monsterRuntimeProfile),
         Warn = runtimeOptions.Warn or defaultWarn,
         LoadMonsterModel = runtimeOptions.AssetLoader or defaultLoadMonsterModel,
         LoadAnimationTrack = runtimeOptions.LoadAnimationTrack or defaultLoadAnimationTrack,
@@ -421,7 +423,9 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
         self:_setAnimationState('Idle', 1)
     end
 
-    self.EnemyRuntime = self.EnemyFactory(self.Definition)
+    self.EnemyRuntime = self.EnemyFactory(self.Definition, {
+        ComponentConfig = self.ComponentConfig,
+    })
     if self.EnemyRuntime and self.EnemyRuntime.spawn then
         self.EnemyRuntime:spawn()
     end
@@ -459,6 +463,7 @@ function MonsterService:update(dt)
 
     local decision = self.EnemyRuntime:update(dt, {
         Behaviors = self.Definition.Behaviors,
+        ComponentConfig = self.ComponentConfig,
         CurrentPosition = currentPosition,
         PatrolReachDistance = 2,
         PatrolSpeedMultiplier = self.Definition.PatrolSpeedMultiplier,

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -45,6 +45,10 @@ local DEBUG_DAMAGE_BY_ACTION = {
     RequestDebugLightDamage = Gameplay.PlayerState.DamageKind.Light,
     RequestDebugHeavyDamage = Gameplay.PlayerState.DamageKind.Heavy,
 }
+local DAMAGE_KIND_BY_PIPS = table.freeze({
+    [1] = Gameplay.PlayerState.DamageKind.Light,
+    [2] = Gameplay.PlayerState.DamageKind.Heavy,
+})
 
 local MazeMonsterSpawnPolicy = Gameplay.Monsters.MazeMonsterSpawnPolicy
 
@@ -60,6 +64,10 @@ local function formatDiagnosticValue(value)
     end
 
     return tostring(value)
+end
+
+local function damageKindFromPips(damagePips)
+    return DAMAGE_KIND_BY_PIPS[damagePips]
 end
 
 local function buildDiagnosticFieldString(fields)
@@ -301,6 +309,19 @@ function MazeSessionService:_destroyUgcMonsters()
     table.clear(self.UgcMonsterServices)
 end
 
+function MazeSessionService:_buildMonsterRuntimeOptions()
+    return {
+        OnAttackHit = function(player, damagePips)
+            local damageKind = damageKindFromPips(damagePips)
+            if damageKind == nil then
+                return
+            end
+
+            self:_applyPlayerDamage(player, damageKind)
+        end,
+    }
+end
+
 function MazeSessionService:_spawnQueuedUgcMonsters()
     if #self.PendingUgcMonsterPayloads == 0 then
         return
@@ -367,7 +388,7 @@ function MazeSessionService:_spawnQueuedUgcMonsters()
             end
 
             return self.World.CanTraverseBetweenPositions(fromPosition, toPosition)
-        end)
+        end, self:_buildMonsterRuntimeOptions())
         ugcMonsterService:spawn(patrolPoints, initialPatrolIndex)
 
         table.insert(self.UgcMonsterServices, {
@@ -416,13 +437,15 @@ function MazeSessionService.new(options)
             monsterRuntimeProfile,
             isExpeditionActiveCallback,
             canTargetPlayerCallback,
-            canTraverseCallback
+            canTraverseCallback,
+            monsterRuntimeOptions
         )
             return MonsterService.new(
                 monsterRuntimeProfile,
                 isExpeditionActiveCallback,
                 canTargetPlayerCallback,
-                canTraverseCallback
+                canTraverseCallback,
+                monsterRuntimeOptions
             )
         end
     self.MonsterService = self.MonsterServiceFactory(
@@ -439,7 +462,8 @@ function MazeSessionService.new(options)
             end
 
             return self.World.CanTraverseBetweenPositions(fromPosition, toPosition)
-        end
+        end,
+        self:_buildMonsterRuntimeOptions()
     )
     self.UgcMonsterServices = {}
     self.PendingUgcMonsterPayloads = {}

--- a/tests/src/Shared/MazeSessionServiceMonsterAttack.spec.luau
+++ b/tests/src/Shared/MazeSessionServiceMonsterAttack.spec.luau
@@ -1,0 +1,69 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local mazeModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
+    local MazeSessionService = require(mazeModules:WaitForChild('MazeSessionService'))
+
+    local capturedRuntimeOptions = nil
+    local service = MazeSessionService.new({
+        MonsterServiceFactory = function(_, _, _, _, runtimeOptions)
+            capturedRuntimeOptions = runtimeOptions
+            return {
+                destroy = function() end,
+                spawn = function() end,
+            }
+        end,
+    })
+
+    assert(
+        type(capturedRuntimeOptions) == 'table'
+            and type(capturedRuntimeOptions.OnAttackHit) == 'function',
+        'Maze runtime should wire server-side monster hit callback into MonsterService options'
+    )
+
+    service._setStatus = function(self, status)
+        self.Status = status
+    end
+
+    local function createPlayer(userId, displayName)
+        local character = Instance.new('Model')
+        character.Name = displayName .. 'Character'
+
+        local rootPart = Instance.new('Part')
+        rootPart.Name = 'HumanoidRootPart'
+        rootPart.Anchored = true
+        rootPart.Position = Vector3.new(0, 5, 0)
+        rootPart.Parent = character
+
+        return {
+            UserId = userId,
+            DisplayName = displayName,
+            Character = character,
+        }
+    end
+
+    local activePlayer = createPlayer(101, 'Alpha')
+    service:_addPlayerState(activePlayer)
+    local beforeSummary = service.PlayerStateService:getSummary(activePlayer)
+
+    capturedRuntimeOptions.OnAttackHit(activePlayer, 1)
+    local afterSummary = service.PlayerStateService:getSummary(activePlayer)
+    assert(
+        afterSummary.HealthPips == beforeSummary.HealthPips - 1,
+        'Server attack callback should settle light damage through player state service'
+    )
+
+    capturedRuntimeOptions.OnAttackHit(activePlayer, 3)
+    local invalidSummary = service.PlayerStateService:getSummary(activePlayer)
+    assert(
+        invalidSummary.HealthPips == afterSummary.HealthPips,
+        'Unsupported damage pips should be ignored by the maze attack callback bridge'
+    )
+
+    local inactivePlayer = createPlayer(202, 'Bravo')
+    capturedRuntimeOptions.OnAttackHit(inactivePlayer, 1)
+    local inactiveResult = service.PlayerStateService:get(inactivePlayer)
+    assert(
+        inactiveResult == nil,
+        'Attack callback should not create or mutate state for players outside server tracking'
+    )
+end

--- a/tests/src/Shared/MonsterAttackMarker.spec.luau
+++ b/tests/src/Shared/MonsterAttackMarker.spec.luau
@@ -1,0 +1,228 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local packages = ReplicatedStorage:WaitForChild('Packages')
+    local shared = require(packages:WaitForChild('Shared'))
+
+    local MonsterService = shared.Runtime.MonsterService
+
+    local function buildRuntimeProfile()
+        return {
+            Id = 'attack-marker-spec',
+            Name = 'Attack Marker Spec',
+            Presentation = {
+                ModelAssetId = 4446576906,
+                RigType = 'R6',
+                AnimationMode = 'defaultR6',
+                ChaseLoopSoundAssetId = 9118823108,
+            },
+            AttackRange = 4,
+            AttackCooldownSeconds = 0.05,
+            AttackDamagePips = 2,
+            Speed = 12,
+            SightRange = 36,
+            PatrolSpeedMultiplier = 0.45,
+            SpawnOffset = Vector3.new(0, 4, 0),
+            Behaviors = {
+                SenseNearestTarget = true,
+                Chase = true,
+                Attack = true,
+            },
+            Effects = {},
+            Components = {
+                Attack = {
+                    ArcDegrees = 100,
+                    CooldownSeconds = 0.05,
+                    DamagePips = 2,
+                    HitMarkerName = 'Hit',
+                    Range = 4,
+                },
+            },
+        }
+    end
+
+    local function createMonsterModel()
+        local monsterModel = Instance.new('Model')
+        monsterModel.Name = 'MarkerSpecMonster'
+
+        local rootPart = Instance.new('Part')
+        rootPart.Name = 'HumanoidRootPart'
+        rootPart.Size = Vector3.new(2, 2, 1)
+        rootPart.Parent = monsterModel
+
+        local head = Instance.new('Part')
+        head.Name = 'Head'
+        head.Size = Vector3.new(2, 1, 1)
+        head.Parent = monsterModel
+
+        local humanoid = Instance.new('Humanoid')
+        humanoid.Parent = monsterModel
+
+        return monsterModel
+    end
+
+    local function createPlayer(userId, position)
+        local character = Instance.new('Model')
+        character.Name = string.format('PlayerCharacter%d', userId)
+
+        local rootPart = Instance.new('Part')
+        rootPart.Name = 'HumanoidRootPart'
+        rootPart.Anchored = true
+        rootPart.Position = position
+        rootPart.Parent = character
+
+        return {
+            UserId = userId,
+            Character = character,
+        }
+    end
+
+    local function createTrack(name, withMarkerSupport)
+        local markerEvents = {}
+        local track = {
+            Name = name,
+            IsPlaying = false,
+            Speed = 1,
+            Play = function(self)
+                self.IsPlaying = true
+            end,
+            Stop = function(self)
+                self.IsPlaying = false
+            end,
+            AdjustSpeed = function(self, speed)
+                self.Speed = speed
+            end,
+        }
+
+        if withMarkerSupport then
+            track.GetMarkerReachedSignal = function(_, markerName)
+                if markerEvents[markerName] == nil then
+                    markerEvents[markerName] = Instance.new('BindableEvent')
+                end
+                return markerEvents[markerName].Event
+            end
+            track.FireMarker = function(_, markerName)
+                local markerEvent = markerEvents[markerName]
+                if markerEvent then
+                    markerEvent:Fire()
+                end
+            end
+        end
+
+        return track
+    end
+
+    local activePlayers = {}
+    local hitEvents = {}
+    local loadedTracks = {}
+    local blockedPart = Instance.new('Part')
+    local raycastMode = 'clear'
+    local service = MonsterService.new(
+        buildRuntimeProfile(),
+        function()
+            return true
+        end,
+        nil,
+        nil,
+        {
+            AssetLoader = function()
+                return createMonsterModel()
+            end,
+            GetPlayers = function()
+                return activePlayers
+            end,
+            LoadAnimationTrack = function(_, _, animationName)
+                local supportsMarkers = animationName == 'MonsterAttack'
+                local track = createTrack(animationName, supportsMarkers)
+                loadedTracks[animationName] = track
+                return track
+            end,
+            OnAttackHit = function(player, damagePips, hitContext)
+                table.insert(hitEvents, {
+                    DamagePips = damagePips,
+                    Player = player,
+                    Reason = hitContext.Reason,
+                })
+            end,
+            Raycast = function()
+                if raycastMode == 'blocked' then
+                    return {
+                        Instance = blockedPart,
+                    }
+                end
+                return nil
+            end,
+        }
+    )
+
+    activePlayers = {
+        createPlayer(9001, Vector3.new(3, 4, 0)),
+    }
+
+    service:spawn({ Vector3.new(0, 0, 0) }, 1)
+    assert(
+        service.applyDamage == nil,
+        'Monster runtime should not expose client damage settlement API'
+    )
+    service.MonsterRoot:PivotTo(CFrame.lookAt(Vector3.new(0, 4, 0), Vector3.new(5, 4, 0)))
+    service:update(0.2)
+
+    assert(#hitEvents == 0, 'Attack should not deal damage before the Hit marker is fired')
+
+    loadedTracks.MonsterAttack:FireMarker('Hit')
+    assert(#hitEvents == 1, 'Forward targets within range should be hit when marker fires')
+    assert(hitEvents[1].DamagePips == 2, 'Attack damage should follow runtime AttackDamagePips')
+
+    activePlayers[1].Character.HumanoidRootPart.Position = Vector3.new(-3, 4, 0)
+    service:update(0.2)
+    loadedTracks.MonsterAttack:FireMarker('Hit')
+    assert(#hitEvents == 1, 'Targets behind the monster should fail the 100 degree arc gate')
+
+    local boundaryRadians = math.rad(50)
+    activePlayers[1].Character.HumanoidRootPart.Position =
+        Vector3.new(math.cos(boundaryRadians) * 3, 4, math.sin(boundaryRadians) * 3)
+    service:update(0.2)
+    loadedTracks.MonsterAttack:FireMarker('Hit')
+    assert(#hitEvents == 2, 'Targets on the 50 degree boundary should pass the arc gate')
+
+    activePlayers[1].Character.HumanoidRootPart.Position = Vector3.new(3, 4, 0)
+    raycastMode = 'blocked'
+    service:update(0.2)
+    loadedTracks.MonsterAttack:FireMarker('Hit')
+    assert(#hitEvents == 2, 'Blocked line-of-sight should prevent marker damage')
+
+    service:destroy()
+    blockedPart:Destroy()
+
+    local noMarkerHits = 0
+    local noMarkerService = MonsterService.new(
+        buildRuntimeProfile(),
+        function()
+            return true
+        end,
+        nil,
+        nil,
+        {
+            AssetLoader = function()
+                return createMonsterModel()
+            end,
+            GetPlayers = function()
+                return activePlayers
+            end,
+            LoadAnimationTrack = function(_, _, animationName)
+                local supportsMarkers = animationName ~= 'MonsterAttack'
+                return createTrack(animationName, supportsMarkers)
+            end,
+            OnAttackHit = function()
+                noMarkerHits += 1
+            end,
+        }
+    )
+
+    activePlayers[1].Character.HumanoidRootPart.Position = Vector3.new(3, 4, 0)
+    noMarkerService:spawn({ Vector3.new(0, 0, 0) }, 1)
+    noMarkerService.MonsterRoot:PivotTo(CFrame.lookAt(Vector3.new(0, 4, 0), Vector3.new(5, 4, 0)))
+    noMarkerService:update(0.2)
+    noMarkerService:update(0.2)
+    assert(noMarkerHits == 0, 'Animations without Hit marker support should never settle damage')
+    noMarkerService:destroy()
+end

--- a/tests/src/Shared/MonsterCompiler.spec.luau
+++ b/tests/src/Shared/MonsterCompiler.spec.luau
@@ -51,6 +51,18 @@ return function()
     )
     assert(runtimeProfile.Speed == 14, 'Compiled runtime should expose the configured speed')
     assert(
+        runtimeProfile.AttackRange == 4,
+        'Compiled runtime should expose the configured attack range'
+    )
+    assert(
+        runtimeProfile.AttackCooldownSeconds == 1,
+        'Compiled runtime should expose the configured attack cooldown'
+    )
+    assert(
+        runtimeProfile.AttackDamagePips == 1,
+        'Compiled runtime should expose the configured attack damage pips'
+    )
+    assert(
         runtimeProfile.SightRange == 36,
         'Compiled runtime should expose the configured sight range'
     )
@@ -80,6 +92,18 @@ return function()
         'Component movement spawn offset should map from runtime spawn offset'
     )
     assert(
+        runtimeProfile.Components.Attack.Range == runtimeProfile.AttackRange,
+        'Component attack range should map from runtime attack range'
+    )
+    assert(
+        runtimeProfile.Components.Attack.CooldownSeconds == runtimeProfile.AttackCooldownSeconds,
+        'Component attack cooldown should map from runtime attack cooldown'
+    )
+    assert(
+        runtimeProfile.Components.Attack.DamagePips == runtimeProfile.AttackDamagePips,
+        'Component attack damage should map from runtime attack damage pips'
+    )
+    assert(
         runtimeProfile.Behaviors[behaviorCatalog.Behavior.Patrol] == nil,
         'Disabled patrol intents should not reach the maze runtime profile'
     )
@@ -90,6 +114,10 @@ return function()
     assert(
         runtimeProfile.Behaviors[behaviorCatalog.Behavior.Chase] == true,
         'Chase should stay enabled in the maze runtime profile'
+    )
+    assert(
+        runtimeProfile.Behaviors[behaviorCatalog.Behavior.Attack] == true,
+        'Attack should stay enabled in the maze runtime profile'
     )
     assert(
         runtimeProfile.Behaviors[behaviorCatalog.Behavior.LoseTarget] == nil,

--- a/tests/src/Shared/MonsterCompiler.spec.luau
+++ b/tests/src/Shared/MonsterCompiler.spec.luau
@@ -59,6 +59,27 @@ return function()
         'Compiled runtime should expose the configured patrol speed multiplier'
     )
     assert(
+        runtimeProfile.Components ~= nil and runtimeProfile.Components.Perception ~= nil,
+        'Compiled runtime should include component mapping payload'
+    )
+    assert(
+        runtimeProfile.Components.Perception.SightRange == runtimeProfile.SightRange,
+        'Component perception config should map from runtime sight range'
+    )
+    assert(
+        runtimeProfile.Components.Movement.Speed == runtimeProfile.Speed,
+        'Component movement config should map from runtime speed'
+    )
+    assert(
+        runtimeProfile.Components.Movement.PatrolSpeedMultiplier
+            == runtimeProfile.PatrolSpeedMultiplier,
+        'Component movement config should map patrol speed multiplier'
+    )
+    assert(
+        runtimeProfile.Components.Movement.SpawnOffset == runtimeProfile.SpawnOffset,
+        'Component movement spawn offset should map from runtime spawn offset'
+    )
+    assert(
         runtimeProfile.Behaviors[behaviorCatalog.Behavior.Patrol] == nil,
         'Disabled patrol intents should not reach the maze runtime profile'
     )

--- a/tests/src/Shared/MonsterEnemyPipeline.spec.luau
+++ b/tests/src/Shared/MonsterEnemyPipeline.spec.luau
@@ -1,0 +1,96 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
+
+    local Enemy = gameplay.Monsters.Enemy
+
+    local updateOrder = {}
+    local components = {
+        Perception = {
+            init = function() end,
+            update = function(_, blackboard)
+                table.insert(updateOrder, 'Perception')
+                blackboard.Transient.PerceptionToken = 'seen'
+                blackboard.Transient.HasTarget = true
+                blackboard.Transient.TargetPlayer = 'Target'
+                blackboard.Transient.TargetPosition = Vector3.new(8, 0, 0)
+            end,
+            destroy = function() end,
+        },
+        Movement = {
+            init = function() end,
+            update = function(_, blackboard)
+                table.insert(updateOrder, 'Movement')
+                assert(
+                    blackboard.Transient.PerceptionToken == 'seen',
+                    'Movement should consume target data from blackboard writes'
+                )
+                blackboard.Transient.NextPosition = Vector3.new(4, 0, 0)
+                blackboard.Transient.DesiredAnimation = 'Run'
+                blackboard.Transient.DesiredAnimationSpeed = 1.15
+                blackboard.Transient.ShouldPlayChaseLoop = true
+            end,
+            destroy = function() end,
+        },
+        Attack = {
+            init = function() end,
+            update = function(_, blackboard)
+                table.insert(updateOrder, 'Attack')
+                assert(
+                    blackboard.Transient.PerceptionToken == 'seen',
+                    'Attack should consume perception output via blackboard instead of direct component calls'
+                )
+            end,
+            destroy = function() end,
+        },
+    }
+
+    local stateMachine = {
+        Current = 'Idle',
+        getState = function(self)
+            return self.Current
+        end,
+        update = function(self, blackboard)
+            table.insert(updateOrder, 'FSM')
+            assert(
+                blackboard.Transient.PerceptionToken == 'seen',
+                'FSM should read from blackboard after perception stage'
+            )
+            self.Current = 'Alert'
+            blackboard:setState(self.Current)
+        end,
+    }
+
+    local enemy = Enemy.new({
+        Id = 'spec-enemy',
+        Name = 'Spec Enemy',
+    }, {
+        Components = components,
+        StateMachine = stateMachine,
+    })
+
+    enemy:spawn()
+    local decision = enemy:update(0.1, {
+        Behaviors = {},
+        CurrentPosition = Vector3.new(0, 0, 0),
+        PatrolSpeedMultiplier = 1,
+        PlayerPositions = {},
+        SightRange = 10,
+        Speed = 10,
+    })
+
+    assert(
+        table.concat(updateOrder, ' -> ') == 'Perception -> FSM -> Movement -> Attack',
+        'Enemy runtime should execute the fixed pipeline order'
+    )
+    assert(decision.State == 'Alert', 'FSM stage should drive state output')
+    assert(decision.TargetPlayer == 'Target', 'Perception output should flow into decision payload')
+    assert(decision.DesiredAnimation == 'Run', 'Movement output should flow into decision payload')
+    assert(decision.ShouldPlayChaseLoop == true, 'Movement output should control chase loop intent')
+    assert(
+        table.concat(Enemy.UpdateOrder, ' -> ') == 'Perception -> FSM -> Movement -> Attack',
+        'Enemy runtime should expose the canonical update order'
+    )
+
+    enemy:destroy()
+end

--- a/tests/src/Shared/MonsterRuntimeProfile.spec.luau
+++ b/tests/src/Shared/MonsterRuntimeProfile.spec.luau
@@ -1,0 +1,62 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
+
+    local runtimeProfileModule = gameplay.Monsters.MonsterRuntimeProfile
+    local presentationCatalog = gameplay.Monsters.MonsterPresentationCatalog
+
+    local componentOnlyProfile = {
+        Id = 'component-only-spec',
+        Name = 'Component Only Spec',
+        Presentation = {
+            ModelAssetId = 4446576906,
+            RigType = presentationCatalog.RigType.R6,
+            AnimationMode = presentationCatalog.AnimationMode.DefaultR6,
+            ChaseLoopSoundAssetId = 9118823108,
+        },
+        Behaviors = {
+            SenseNearestTarget = true,
+            Chase = true,
+        },
+        Effects = {},
+        Components = {
+            Perception = {
+                SightRange = 28,
+            },
+            Movement = {
+                Speed = 12,
+                PatrolSpeedMultiplier = 0.4,
+                PatrolReachDistance = 2,
+                SpawnOffset = Vector3.new(0, 4, 0),
+            },
+            Attack = {
+                Range = 4,
+                CooldownSeconds = 1,
+            },
+        },
+    }
+
+    local validComponentOnly, componentOnlyReason =
+        runtimeProfileModule.validate(componentOnlyProfile)
+    assert(
+        validComponentOnly == true,
+        string.format(
+            'Component-only runtime payload should stay valid, got %s',
+            tostring(componentOnlyReason)
+        )
+    )
+
+    local invalidMovementProfile = table.clone(componentOnlyProfile)
+    invalidMovementProfile.Components = table.clone(componentOnlyProfile.Components)
+    invalidMovementProfile.Components.Movement =
+        table.clone(componentOnlyProfile.Components.Movement)
+    invalidMovementProfile.Components.Movement.Speed = 0
+
+    local invalidMovementOk, invalidMovementReason =
+        runtimeProfileModule.validate(invalidMovementProfile)
+    assert(invalidMovementOk == false, 'Invalid movement component speed should fail validation')
+    assert(
+        invalidMovementReason == 'InvalidRuntimeComponentMovementSpeed',
+        'Invalid movement component speed should surface a dedicated reason'
+    )
+end

--- a/tests/src/Shared/MonsterRuntimeProfile.spec.luau
+++ b/tests/src/Shared/MonsterRuntimeProfile.spec.luau
@@ -32,6 +32,7 @@ return function()
             Attack = {
                 Range = 4,
                 CooldownSeconds = 1,
+                DamagePips = 1,
             },
         },
     }
@@ -58,5 +59,19 @@ return function()
     assert(
         invalidMovementReason == 'InvalidRuntimeComponentMovementSpeed',
         'Invalid movement component speed should surface a dedicated reason'
+    )
+
+    local invalidAttackDamageProfile = table.clone(componentOnlyProfile)
+    invalidAttackDamageProfile.Components = table.clone(componentOnlyProfile.Components)
+    invalidAttackDamageProfile.Components.Attack =
+        table.clone(componentOnlyProfile.Components.Attack)
+    invalidAttackDamageProfile.Components.Attack.DamagePips = 3
+
+    local invalidDamageOk, invalidDamageReason =
+        runtimeProfileModule.validate(invalidAttackDamageProfile)
+    assert(invalidDamageOk == false, 'Attack damage pips outside 1/2 should fail validation')
+    assert(
+        invalidDamageReason == 'InvalidRuntimeComponentAttackDamagePips',
+        'Invalid attack damage pips should expose a dedicated reason'
     )
 end

--- a/tests/src/Shared/MonsterUgcPipeline.spec.luau
+++ b/tests/src/Shared/MonsterUgcPipeline.spec.luau
@@ -104,6 +104,16 @@ return function()
         'Out-of-range speed should be clamped into allowed tuning range'
     )
     assert(
+        generationResult.RuntimeProfile.Components.Movement.Speed
+            == generationResult.RuntimeProfile.Speed,
+        'UGC runtime output should map movement speed into component config'
+    )
+    assert(
+        generationResult.RuntimeProfile.Components.Perception.SightRange
+            == generationResult.RuntimeProfile.SightRange,
+        'UGC runtime output should map perception sight range into component config'
+    )
+    assert(
         generationResult.Diagnostics.SkippedBehaviorIds[1] == behaviorCatalog.Behavior.LoseTarget,
         'Known but non-maze behaviors should appear in compile skipped diagnostics'
     )


### PR DESCRIPTION
## 关联
- Closes #179
- Parent: #175
- Related: #166

## 本次实现
- 攻击由服务端动画 marker（`Hit`）触发命中结算。
- 命中门禁固定为：Range + 100° Arc + LOS（Raycast）。
- 增加运行时字段与校验：`AttackRange`、`AttackCooldownSeconds`、`AttackDamagePips`（仅 1/2）。
- 伤害通过 Maze 服务端玩家状态链路结算（`OnAttackHit -> _applyPlayerDamage`），客户端不参与权威结算。
- 默认怪物配置补齐攻击参数与 Attack 行为。

## 测试
- `stylua --check .`
- `selene .`
- `rojo build tests/default.project.json -o /tmp/roblox_experience-tests.rbxlx`
- `run-in-roblox --place /tmp/roblox_experience-tests.rbxlx --script tests/run-in-roblox.lua`
- 新增：
  - `tests/src/Shared/MonsterAttackMarker.spec.luau`（Range/Arc/LOS + marker 门禁）
  - `tests/src/Shared/MazeSessionServiceMonsterAttack.spec.luau`（服务端伤害桥接）
  - `tests/src/Shared/MonsterRuntimeProfile.spec.luau`（AttackDamagePips 1/2 校验）
