### PR TITLE
feat(monster): switch default model asset to 9492320977

### DIFF
--- a/packages/gameplay/src/Config/Monsters.luau
+++ b/packages/gameplay/src/Config/Monsters.luau
@@ -1,5 +1,6 @@
 local MonsterBehaviorCatalog = require(script.Parent.Parent.Monsters.MonsterBehaviorCatalog)
 local MonsterEffectCatalog = require(script.Parent.Parent.Monsters.MonsterEffectCatalog)
+local MonsterAssetIds = require(script.Parent.Parent.Monsters.MonsterAssetIds)
 local MonsterPresentationCatalog = require(script.Parent.Parent.Monsters.MonsterPresentationCatalog)
 
 return {
@@ -29,10 +30,10 @@ return {
         },
         Executable = {
             Presentation = {
-                ModelAssetId = 9492320977,
+                ModelAssetId = MonsterAssetIds.DefaultModelAssetId,
                 RigType = MonsterPresentationCatalog.RigType.R6,
                 AnimationMode = MonsterPresentationCatalog.AnimationMode.DefaultR6,
-                ChaseLoopSoundAssetId = 9118823108,
+                ChaseLoopSoundAssetId = MonsterAssetIds.DefaultChaseLoopSoundAssetId,
             },
             BehaviorIntents = {
                 {

--- a/packages/gameplay/src/Config/Monsters.luau
+++ b/packages/gameplay/src/Config/Monsters.luau
@@ -29,7 +29,7 @@ return {
         },
         Executable = {
             Presentation = {
-                ModelAssetId = 4446576906,
+                ModelAssetId = 9492320977,
                 RigType = MonsterPresentationCatalog.RigType.R6,
                 AnimationMode = MonsterPresentationCatalog.AnimationMode.DefaultR6,
                 ChaseLoopSoundAssetId = 9118823108,

--- a/packages/gameplay/src/Monsters/MonsterAssetIds.luau
+++ b/packages/gameplay/src/Monsters/MonsterAssetIds.luau
@@ -1,0 +1,6 @@
+local MonsterAssetIds = table.freeze({
+    DefaultModelAssetId = 9492320977,
+    DefaultChaseLoopSoundAssetId = 9118823108,
+})
+
+return MonsterAssetIds

--- a/packages/gameplay/src/Monsters/MonsterUgcPipeline.luau
+++ b/packages/gameplay/src/Monsters/MonsterUgcPipeline.luau
@@ -1,6 +1,7 @@
 local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
 local MonsterCompiler = require(script.Parent.MonsterCompiler)
 local MonsterEffectCatalog = require(script.Parent.MonsterEffectCatalog)
+local MonsterAssetIds = require(script.Parent.MonsterAssetIds)
 local MonsterPresentationCatalog = require(script.Parent.MonsterPresentationCatalog)
 
 local MonsterUgcPipeline = {}
@@ -29,8 +30,8 @@ MonsterUgcPipeline.TuningRange = table.freeze({
 })
 
 local DEFAULT_ASSET_IDS = table.freeze({
-    ModelAssetId = 9492320977,
-    ChaseLoopSoundAssetId = 9118823108,
+    ModelAssetId = MonsterAssetIds.DefaultModelAssetId,
+    ChaseLoopSoundAssetId = MonsterAssetIds.DefaultChaseLoopSoundAssetId,
 })
 
 local DEFAULT_PREFAB_ID = 'stalker-hunt'

--- a/packages/gameplay/src/Monsters/MonsterUgcPipeline.luau
+++ b/packages/gameplay/src/Monsters/MonsterUgcPipeline.luau
@@ -29,7 +29,7 @@ MonsterUgcPipeline.TuningRange = table.freeze({
 })
 
 local DEFAULT_ASSET_IDS = table.freeze({
-    ModelAssetId = 4446576906,
+    ModelAssetId = 9492320977,
     ChaseLoopSoundAssetId = 9118823108,
 })
 

--- a/packages/gameplay/src/Monsters/init.luau
+++ b/packages/gameplay/src/Monsters/init.luau
@@ -6,6 +6,7 @@ return {
     EnemyBlackboard = require(script.EnemyBlackboard),
     EnemyStateMachine = require(script.EnemyStateMachine),
     MonsterAuthorProfile = require(script.MonsterAuthorProfile),
+    MonsterAssetIds = require(script.MonsterAssetIds),
     MonsterBehaviorCatalog = require(script.MonsterBehaviorCatalog),
     MonsterCompiler = MonsterCompiler,
     MonsterEffectCatalog = require(script.MonsterEffectCatalog),

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -48,6 +48,7 @@ local UGC_STATUS = table.freeze({
     Ready = 'Ready',
     Rejected = 'Rejected',
 })
+local MONSTER_ASSET_IDS = Gameplay.Monsters.MonsterAssetIds
 
 local ITEM_DEFINITION_BY_ID = {}
 for _, itemDef in ipairs(Gameplay.Config.Items) do
@@ -350,11 +351,11 @@ end
 function RunSessionService:_buildAssetValidator()
     return function(assetId, assetKind)
         if assetKind == 'ModelAssetId' then
-            return assetId == 9492320977, 'OnlyOfficialModelAssetAllowedInV1'
+            return assetId == MONSTER_ASSET_IDS.DefaultModelAssetId, 'OnlyOfficialModelAssetAllowedInV1'
         end
 
         if assetKind == 'ChaseLoopSoundAssetId' then
-            return assetId == 9118823108, 'OnlyOfficialSoundAssetAllowedInV1'
+            return assetId == MONSTER_ASSET_IDS.DefaultChaseLoopSoundAssetId, 'OnlyOfficialSoundAssetAllowedInV1'
         end
 
         return false, 'UnsupportedAssetKind'

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -350,7 +350,7 @@ end
 function RunSessionService:_buildAssetValidator()
     return function(assetId, assetKind)
         if assetKind == 'ModelAssetId' then
-            return assetId == 4446576906, 'OnlyOfficialModelAssetAllowedInV1'
+            return assetId == 9492320977, 'OnlyOfficialModelAssetAllowedInV1'
         end
 
         if assetKind == 'ChaseLoopSoundAssetId' then

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -351,11 +351,13 @@ end
 function RunSessionService:_buildAssetValidator()
     return function(assetId, assetKind)
         if assetKind == 'ModelAssetId' then
-            return assetId == MONSTER_ASSET_IDS.DefaultModelAssetId, 'OnlyOfficialModelAssetAllowedInV1'
+            return assetId == MONSTER_ASSET_IDS.DefaultModelAssetId,
+                'OnlyOfficialModelAssetAllowedInV1'
         end
 
         if assetKind == 'ChaseLoopSoundAssetId' then
-            return assetId == MONSTER_ASSET_IDS.DefaultChaseLoopSoundAssetId, 'OnlyOfficialSoundAssetAllowedInV1'
+            return assetId == MONSTER_ASSET_IDS.DefaultChaseLoopSoundAssetId,
+                'OnlyOfficialSoundAssetAllowedInV1'
         end
 
         return false, 'UnsupportedAssetKind'

--- a/tests/src/Shared/CampMazeSessionContract.spec.luau
+++ b/tests/src/Shared/CampMazeSessionContract.spec.luau
@@ -1,7 +1,9 @@
 return function()
     local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
     local shared = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared'))
     local contract = shared.Session.CampMazeSessionContract
+    local monsterAssetIds = gameplay.Monsters.MonsterAssetIds
 
     local campSession = contract.newCampSession({
         SessionId = 'camp-session-1',
@@ -82,10 +84,10 @@ return function()
                 Id = 'ugc-42-100',
                 Name = 'Scrap Whisper',
                 Presentation = {
-                    ModelAssetId = 9492320977,
+                    ModelAssetId = monsterAssetIds.DefaultModelAssetId,
                     RigType = 'R6',
                     AnimationMode = 'defaultR6',
-                    ChaseLoopSoundAssetId = 9118823108,
+                    ChaseLoopSoundAssetId = monsterAssetIds.DefaultChaseLoopSoundAssetId,
                 },
                 Speed = 14,
                 SightRange = 36,
@@ -129,7 +131,8 @@ return function()
     )
     assert(
         pendingUgcPayload.RuntimeProfile ~= nil
-            and pendingUgcPayload.RuntimeProfile.Presentation.ModelAssetId == 9492320977,
+            and pendingUgcPayload.RuntimeProfile.Presentation.ModelAssetId
+                == monsterAssetIds.DefaultModelAssetId,
         'Pending UGC payload should preserve runtime monster presentation data'
     )
 

--- a/tests/src/Shared/CampMazeSessionContract.spec.luau
+++ b/tests/src/Shared/CampMazeSessionContract.spec.luau
@@ -82,7 +82,7 @@ return function()
                 Id = 'ugc-42-100',
                 Name = 'Scrap Whisper',
                 Presentation = {
-                    ModelAssetId = 4446576906,
+                    ModelAssetId = 9492320977,
                     RigType = 'R6',
                     AnimationMode = 'defaultR6',
                     ChaseLoopSoundAssetId = 9118823108,
@@ -129,7 +129,7 @@ return function()
     )
     assert(
         pendingUgcPayload.RuntimeProfile ~= nil
-            and pendingUgcPayload.RuntimeProfile.Presentation.ModelAssetId == 4446576906,
+            and pendingUgcPayload.RuntimeProfile.Presentation.ModelAssetId == 9492320977,
         'Pending UGC payload should preserve runtime monster presentation data'
     )
 

--- a/tests/src/Shared/MazeSessionServiceUgcSpawn.spec.luau
+++ b/tests/src/Shared/MazeSessionServiceUgcSpawn.spec.luau
@@ -75,7 +75,7 @@ return function()
                 Id = string.format('ugc-%d', index),
                 Name = string.format('UGC-%d', index),
                 Presentation = {
-                    ModelAssetId = 4446576906,
+                    ModelAssetId = 9492320977,
                     RigType = 'R6',
                     AnimationMode = 'defaultR6',
                     ChaseLoopSoundAssetId = 9118823108,

--- a/tests/src/Shared/MazeSessionServiceUgcSpawn.spec.luau
+++ b/tests/src/Shared/MazeSessionServiceUgcSpawn.spec.luau
@@ -1,7 +1,9 @@
 return function()
     local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
     local mazeModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
     local MazeSessionService = require(mazeModules:WaitForChild('MazeSessionService'))
+    local monsterAssetIds = gameplay.Monsters.MonsterAssetIds
 
     local spawnedRecords = {}
     local monsterServiceFactory = function(runtimeProfile)
@@ -75,10 +77,10 @@ return function()
                 Id = string.format('ugc-%d', index),
                 Name = string.format('UGC-%d', index),
                 Presentation = {
-                    ModelAssetId = 9492320977,
+                    ModelAssetId = monsterAssetIds.DefaultModelAssetId,
                     RigType = 'R6',
                     AnimationMode = 'defaultR6',
-                    ChaseLoopSoundAssetId = 9118823108,
+                    ChaseLoopSoundAssetId = monsterAssetIds.DefaultChaseLoopSoundAssetId,
                 },
                 Speed = 14,
                 SightRange = 36,

--- a/tests/src/Shared/MonsterCompiler.spec.luau
+++ b/tests/src/Shared/MonsterCompiler.spec.luau
@@ -5,6 +5,7 @@ return function()
     local compiler = gameplay.Monsters.compileMonsterForMaze
     local behaviorCatalog = gameplay.Monsters.MonsterBehaviorCatalog
     local effectCatalog = gameplay.Monsters.MonsterEffectCatalog
+    local monsterAssetIds = gameplay.Monsters.MonsterAssetIds
     local authorProfileModule = gameplay.Monsters.MonsterAuthorProfile
     local presentationCatalog = gameplay.Monsters.MonsterPresentationCatalog
     local runtimeProfileModule = gameplay.Monsters.MonsterRuntimeProfile
@@ -34,7 +35,7 @@ return function()
     assert(runtimeProfile.Id == 'scrap-wisp', 'Compiled runtime should preserve the monster id')
     assert(runtimeProfile.Name == 'Scrap Wisp', 'Compiled runtime should preserve the monster name')
     assert(
-        runtimeProfile.Presentation.ModelAssetId == 9492320977,
+        runtimeProfile.Presentation.ModelAssetId == monsterAssetIds.DefaultModelAssetId,
         'Compiled runtime should expose the configured model asset id'
     )
     assert(
@@ -46,7 +47,8 @@ return function()
         'Compiled runtime should preserve the configured animation mode'
     )
     assert(
-        runtimeProfile.Presentation.ChaseLoopSoundAssetId == 9118823108,
+        runtimeProfile.Presentation.ChaseLoopSoundAssetId
+            == monsterAssetIds.DefaultChaseLoopSoundAssetId,
         'Compiled runtime should expose the configured chase loop sound asset id'
     )
     assert(runtimeProfile.Speed == 14, 'Compiled runtime should expose the configured speed')

--- a/tests/src/Shared/MonsterCompiler.spec.luau
+++ b/tests/src/Shared/MonsterCompiler.spec.luau
@@ -34,7 +34,7 @@ return function()
     assert(runtimeProfile.Id == 'scrap-wisp', 'Compiled runtime should preserve the monster id')
     assert(runtimeProfile.Name == 'Scrap Wisp', 'Compiled runtime should preserve the monster name')
     assert(
-        runtimeProfile.Presentation.ModelAssetId == 4446576906,
+        runtimeProfile.Presentation.ModelAssetId == 9492320977,
         'Compiled runtime should expose the configured model asset id'
     )
     assert(

--- a/tests/src/Shared/MonsterService.spec.luau
+++ b/tests/src/Shared/MonsterService.spec.luau
@@ -61,7 +61,7 @@ return function()
         {
             AssetLoader = function(assetId)
                 assert(
-                    assetId == 4446576906,
+                    assetId == 9492320977,
                     'Monster service should request the configured model asset'
                 )
 

--- a/tests/src/Shared/MonsterService.spec.luau
+++ b/tests/src/Shared/MonsterService.spec.luau
@@ -3,6 +3,7 @@ return function()
     local packages = ReplicatedStorage:WaitForChild('Packages')
     local gameplay = require(packages:WaitForChild('Gameplay'))
     local shared = require(packages:WaitForChild('Shared'))
+    local monsterAssetIds = gameplay.Monsters.MonsterAssetIds
 
     local monsterServiceModule = shared.Runtime.MonsterService
     local compileMonsterForMaze = gameplay.Monsters.compileMonsterForMaze
@@ -61,7 +62,7 @@ return function()
         {
             AssetLoader = function(assetId)
                 assert(
-                    assetId == 9492320977,
+                    assetId == monsterAssetIds.DefaultModelAssetId,
                     'Monster service should request the configured model asset'
                 )
 
@@ -132,7 +133,10 @@ return function()
     assert(loadedTracks.MonsterRun ~= nil, 'Monster should create a run animation track')
     assert(#warnings == 0, 'Successful model loads should not emit fallback warnings')
     assert(#sounds == 1, 'Configured chase audio should create one looped sound')
-    assert(sounds[1].AssetId == 9118823108, 'Monster should use the configured chase loop asset id')
+    assert(
+        sounds[1].AssetId == monsterAssetIds.DefaultChaseLoopSoundAssetId,
+        'Monster should use the configured chase loop asset id'
+    )
 
     local spawnPosition = service.MonsterPositionPart.Position
     service:update(0.5)

--- a/tests/src/Shared/MonsterUgcPipeline.spec.luau
+++ b/tests/src/Shared/MonsterUgcPipeline.spec.luau
@@ -46,7 +46,7 @@ return function()
         },
         Preferences = {
             Name = 'Scrap Whisper',
-            ModelAssetId = 4446576906,
+            ModelAssetId = 9492320977,
             ChaseLoopSoundAssetId = 9118823108,
             Tuning = {
                 Speed = 100,

--- a/tests/src/Shared/MonsterUgcPipeline.spec.luau
+++ b/tests/src/Shared/MonsterUgcPipeline.spec.luau
@@ -6,6 +6,7 @@ return function()
     local ugcPipeline = monsters.MonsterUgcPipeline
     local behaviorCatalog = monsters.MonsterBehaviorCatalog
     local effectCatalog = monsters.MonsterEffectCatalog
+    local monsterAssetIds = monsters.MonsterAssetIds
 
     local briefOk, waitingState = ugcPipeline.evaluateBrief({
         Goal = '',
@@ -46,8 +47,8 @@ return function()
         },
         Preferences = {
             Name = 'Scrap Whisper',
-            ModelAssetId = 9492320977,
-            ChaseLoopSoundAssetId = 9118823108,
+            ModelAssetId = monsterAssetIds.DefaultModelAssetId,
+            ChaseLoopSoundAssetId = monsterAssetIds.DefaultChaseLoopSoundAssetId,
             Tuning = {
                 Speed = 100,
                 SightRange = 34,


### PR DESCRIPTION
## Summary
- switch default monster model asset to `9492320977`
- update run-side model asset validator to keep UGC policy aligned
- update deterministic tests that assert configured model id

## Validation
- `selene` (targeted files)
- `rojo build places/run/default.project.json -o .\\tmp\\run.rbxlx`
- `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`