### PR TITLE
chore: ignore local tmp artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@ DevPackages
 *.rbxl.lock
 *.project.user.json
 *.sourcemap.json
+tmp/
+tmp_pr*
+tmp_*_latest_luau.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ DevPackages
 tmp/
 tmp_pr*
 tmp_*_latest_luau.log
+.aftman/
 


### PR DESCRIPTION
## Summary
- ignore local build/test tmp outputs under 	mp/
- ignore local PR review scratch files (	mp_pr*)
- ignore local luau log scratch files (	mp_*_latest_luau.log)

## Notes
- This PR only updates .gitignore.
