### PR TITLE
迷宫：手电撬棍不消耗 + 撬棍近战主怪

### DIFF
--- a/packages/gameplay/src/Combat/PlayerMonsterMelee.luau
+++ b/packages/gameplay/src/Combat/PlayerMonsterMelee.luau
@@ -1,0 +1,70 @@
+-- Pure geometry for player crowbar / melee vs a monster anchor position (tests + runtime).
+
+local EPS = 1e-4
+
+local PlayerMonsterMelee = {}
+
+function PlayerMonsterMelee.horizontalUnit(vector3)
+    if typeof(vector3) ~= 'Vector3' then
+        return nil
+    end
+
+    local horizontal = Vector3.new(vector3.X, 0, vector3.Z)
+    if horizontal.Magnitude <= EPS then
+        return nil
+    end
+
+    return horizontal.Unit
+end
+
+function PlayerMonsterMelee.evaluateSwing(
+    playerPosition,
+    playerLookVector,
+    monsterPosition,
+    swingRange,
+    swingArcDegrees
+)
+    if typeof(playerPosition) ~= 'Vector3' then
+        return false, 'InvalidPlayerPosition'
+    end
+    if typeof(monsterPosition) ~= 'Vector3' then
+        return false, 'InvalidMonsterPosition'
+    end
+
+    local range = swingRange
+    if type(range) ~= 'number' or range <= 0 then
+        return false, 'InvalidSwingRange'
+    end
+
+    local arc = swingArcDegrees
+    if type(arc) ~= 'number' or arc <= 0 then
+        return false, 'InvalidSwingArc'
+    end
+
+    local offset = monsterPosition - playerPosition
+    local distance = offset.Magnitude
+    if distance > range + EPS then
+        return false, 'OutOfRange'
+    end
+
+    local facing = PlayerMonsterMelee.horizontalUnit(playerLookVector)
+    if facing == nil then
+        return false, 'InvalidFacing'
+    end
+
+    local toMonster = PlayerMonsterMelee.horizontalUnit(offset)
+    if toMonster == nil then
+        return true, 'HitGeometryOk'
+    end
+
+    local halfArcRad = math.rad(arc * 0.5)
+    local minDot = math.cos(halfArcRad)
+    local dot = facing:Dot(toMonster)
+    if dot + EPS < minDot then
+        return false, 'OutOfSwingArc'
+    end
+
+    return true, 'HitGeometryOk'
+end
+
+return PlayerMonsterMelee

--- a/packages/gameplay/src/Combat/init.luau
+++ b/packages/gameplay/src/Combat/init.luau
@@ -1,0 +1,3 @@
+return {
+    PlayerMonsterMelee = require(script.PlayerMonsterMelee),
+}

--- a/packages/gameplay/src/Config/Monsters.luau
+++ b/packages/gameplay/src/Config/Monsters.luau
@@ -23,6 +23,7 @@ return {
             AttackCooldownSeconds = 1,
             AttackDamagePips = 1,
             AttackRange = 4,
+            CombatHitPoints = 3,
             Speed = 14,
             SightRange = 36,
             PatrolSpeedMultiplier = 0.45,

--- a/packages/gameplay/src/Config/ToolItems.luau
+++ b/packages/gameplay/src/Config/ToolItems.luau
@@ -4,7 +4,7 @@ local ToolItems = {
     ['tool-flashlight'] = {
         Id = 'tool-flashlight',
         Name = 'Flashlight',
-        Description = '在黑暗中照亮路径。电量耗尽后无法使用。',
+        Description = '在黑暗中照亮路径。本配置下使用不消耗电量。',
         ToolCategory = 'Flashlight',
         Weight = 1,
         Value = 0,
@@ -13,7 +13,7 @@ local ToolItems = {
         -- 状态属性
         StateModel = 'Battery',
         InitialState = 100,
-        ConsumePerUse = 1,
+        ConsumePerUse = 0,
         CooldownSeconds = 0,
     },
 
@@ -21,7 +21,7 @@ local ToolItems = {
     ['tool-crowbar'] = {
         Id = 'tool-crowbar',
         Name = 'Crowbar',
-        Description = '近战挥舞可击退前方怪物。',
+        Description = '近战挥舞可对前方怪物造成伤害。本配置下使用不消耗耐久。',
         ToolCategory = 'Crowbar',
         Weight = 3,
         Value = 0,
@@ -30,12 +30,13 @@ local ToolItems = {
         -- 状态属性
         StateModel = 'Durability',
         InitialState = 10,
-        ConsumePerUse = 1,
+        ConsumePerUse = 0,
         CooldownSeconds = 0.5,
         -- 战斗参数
         SwingRange = 6,
         SwingArcDegrees = 70,
         KnockbackStrength = 15,
+        MeleeDamage = 1,
     },
 }
 

--- a/packages/gameplay/src/Inventory.luau
+++ b/packages/gameplay/src/Inventory.luau
@@ -22,12 +22,18 @@ local function cloneItemEntry(itemEntry)
         Value = itemEntry.Value,
         Color = itemEntry.Color,
         Light = cloneLightConfig(itemEntry.Light),
+
+        -- === 新增：探索道具扩展字段 ===
         ToolCategory = itemEntry.ToolCategory,
         StateModel = itemEntry.StateModel,
-        CurrentState = itemEntry.CurrentState,
+        InitialState = itemEntry.InitialState,
+        CurrentState = itemEntry.CurrentState, -- 记录当前电量/耐久
         ConsumePerUse = itemEntry.ConsumePerUse,
         CooldownSeconds = itemEntry.CooldownSeconds,
-        LastUsedAt = itemEntry.LastUsedAt,
+        SwingRange = itemEntry.SwingRange,
+        SwingArcDegrees = itemEntry.SwingArcDegrees,
+        KnockbackStrength = itemEntry.KnockbackStrength,
+        MeleeDamage = itemEntry.MeleeDamage,
     }
 end
 
@@ -67,12 +73,18 @@ function Inventory:_buildItemEntry(itemDef)
         Value = itemDef.Value,
         Color = itemDef.Color,
         Light = cloneLightConfig(itemDef.Light),
+
+        -- === 新增：探索道具扩展字段 ===
         ToolCategory = itemDef.ToolCategory,
         StateModel = itemDef.StateModel,
-        CurrentState = itemDef.InitialState,
+        InitialState = itemDef.InitialState,
+        CurrentState = itemDef.InitialState, -- 刚放进背包时，当前状态等于初始状态 (满电/满耐久)
         ConsumePerUse = itemDef.ConsumePerUse,
         CooldownSeconds = itemDef.CooldownSeconds,
-        LastUsedAt = itemDef.LastUsedAt,
+        SwingRange = itemDef.SwingRange,
+        SwingArcDegrees = itemDef.SwingArcDegrees,
+        KnockbackStrength = itemDef.KnockbackStrength,
+        MeleeDamage = itemDef.MeleeDamage,
     }
 
     self.NextItemInstanceId += 1
@@ -93,12 +105,18 @@ local function normalizeItemEntry(rawItemEntry)
         Value = rawItemEntry.Value or 0,
         Color = rawItemEntry.Color,
         Light = cloneLightConfig(rawItemEntry.Light),
+
+        -- === 新增：探索道具扩展字段 ===
         ToolCategory = rawItemEntry.ToolCategory,
         StateModel = rawItemEntry.StateModel,
+        InitialState = rawItemEntry.InitialState,
         CurrentState = rawItemEntry.CurrentState,
         ConsumePerUse = rawItemEntry.ConsumePerUse,
         CooldownSeconds = rawItemEntry.CooldownSeconds,
-        LastUsedAt = rawItemEntry.LastUsedAt,
+        SwingRange = rawItemEntry.SwingRange,
+        SwingArcDegrees = rawItemEntry.SwingArcDegrees,
+        KnockbackStrength = rawItemEntry.KnockbackStrength,
+        MeleeDamage = rawItemEntry.MeleeDamage,
     }
 end
 
@@ -149,34 +167,6 @@ function Inventory:unequip()
     self.HeldItem = nil
 
     return true, cloneItemEntry(previousHeldItem)
-end
-
-function Inventory:consumeHeldItemState(nowSeconds)
-    local heldItem = self.HeldItem
-    if heldItem == nil then
-        return false, 'NothingHeld'
-    end
-
-    if type(heldItem.CurrentState) ~= 'number' or type(heldItem.ConsumePerUse) ~= 'number' then
-        return false, 'NotConsumable'
-    end
-
-    if heldItem.CurrentState < heldItem.ConsumePerUse then
-        return false, 'Depleted'
-    end
-
-    local now = type(nowSeconds) == 'number' and nowSeconds or os.clock()
-    local cooldownSeconds = heldItem.CooldownSeconds
-    if type(cooldownSeconds) == 'number' and cooldownSeconds > 0 then
-        local lastUsedAt = heldItem.LastUsedAt
-        if type(lastUsedAt) == 'number' and now - lastUsedAt < cooldownSeconds then
-            return false, 'Cooldown', cooldownSeconds - (now - lastUsedAt)
-        end
-    end
-
-    heldItem.CurrentState -= heldItem.ConsumePerUse
-    heldItem.LastUsedAt = now
-    return true, cloneItemEntry(heldItem)
 end
 
 function Inventory:getTotalValue()
@@ -249,48 +239,6 @@ function Inventory:clear()
     self.Weight = 0
     table.clear(self.BackpackItems)
     self.HeldItem = nil
-end
-
-function Inventory:countById(itemId)
-    if type(itemId) ~= 'string' or itemId == '' then
-        return 0
-    end
-
-    local count = 0
-    for _, itemEntry in ipairs(self.BackpackItems) do
-        if itemEntry.Id == itemId then
-            count += 1
-        end
-    end
-
-    if self.HeldItem and self.HeldItem.Id == itemId then
-        count += 1
-    end
-
-    return count
-end
-
-function Inventory:consumeById(itemId)
-    if type(itemId) ~= 'string' or itemId == '' then
-        return false, 'MissingItemId'
-    end
-
-    for index, itemEntry in ipairs(self.BackpackItems) do
-        if itemEntry.Id == itemId then
-            local consumed = table.remove(self.BackpackItems, index)
-            self.Weight -= consumed.Weight
-            return true, cloneItemEntry(consumed)
-        end
-    end
-
-    if self.HeldItem and self.HeldItem.Id == itemId then
-        local consumed = self.HeldItem
-        self.HeldItem = nil
-        self.Weight -= consumed.Weight
-        return true, cloneItemEntry(consumed)
-    end
-
-    return false, 'ItemNotFound'
 end
 
 return Inventory

--- a/packages/gameplay/src/Inventory.luau
+++ b/packages/gameplay/src/Inventory.luau
@@ -30,6 +30,7 @@ local function cloneItemEntry(itemEntry)
         CurrentState = itemEntry.CurrentState, -- 记录当前电量/耐久
         ConsumePerUse = itemEntry.ConsumePerUse,
         CooldownSeconds = itemEntry.CooldownSeconds,
+        LastUsedAt = itemEntry.LastUsedAt,
         SwingRange = itemEntry.SwingRange,
         SwingArcDegrees = itemEntry.SwingArcDegrees,
         KnockbackStrength = itemEntry.KnockbackStrength,
@@ -81,6 +82,7 @@ function Inventory:_buildItemEntry(itemDef)
         CurrentState = itemDef.InitialState, -- 刚放进背包时，当前状态等于初始状态 (满电/满耐久)
         ConsumePerUse = itemDef.ConsumePerUse,
         CooldownSeconds = itemDef.CooldownSeconds,
+        LastUsedAt = itemDef.LastUsedAt,
         SwingRange = itemDef.SwingRange,
         SwingArcDegrees = itemDef.SwingArcDegrees,
         KnockbackStrength = itemDef.KnockbackStrength,
@@ -113,6 +115,7 @@ local function normalizeItemEntry(rawItemEntry)
         CurrentState = rawItemEntry.CurrentState,
         ConsumePerUse = rawItemEntry.ConsumePerUse,
         CooldownSeconds = rawItemEntry.CooldownSeconds,
+        LastUsedAt = rawItemEntry.LastUsedAt,
         SwingRange = rawItemEntry.SwingRange,
         SwingArcDegrees = rawItemEntry.SwingArcDegrees,
         KnockbackStrength = rawItemEntry.KnockbackStrength,
@@ -167,6 +170,36 @@ function Inventory:unequip()
     self.HeldItem = nil
 
     return true, cloneItemEntry(previousHeldItem)
+end
+
+function Inventory:consumeHeldItemState(nowSeconds)
+    local heldItem = self.HeldItem
+    if heldItem == nil then
+        return false, 'NothingHeld'
+    end
+
+    if type(heldItem.CurrentState) ~= 'number' or type(heldItem.ConsumePerUse) ~= 'number' then
+        return false, 'NotConsumable'
+    end
+
+    if type(heldItem.ConsumePerUse) == 'number' and heldItem.ConsumePerUse > 0 then
+        if heldItem.CurrentState < heldItem.ConsumePerUse then
+            return false, 'Depleted'
+        end
+    end
+
+    local now = type(nowSeconds) == 'number' and nowSeconds or os.clock()
+    local cooldownSeconds = heldItem.CooldownSeconds
+    if type(cooldownSeconds) == 'number' and cooldownSeconds > 0 then
+        local lastUsedAt = heldItem.LastUsedAt
+        if type(lastUsedAt) == 'number' and now - lastUsedAt < cooldownSeconds then
+            return false, 'Cooldown', cooldownSeconds - (now - lastUsedAt)
+        end
+    end
+
+    heldItem.CurrentState -= heldItem.ConsumePerUse
+    heldItem.LastUsedAt = now
+    return true, cloneItemEntry(heldItem)
 end
 
 function Inventory:getTotalValue()
@@ -239,6 +272,48 @@ function Inventory:clear()
     self.Weight = 0
     table.clear(self.BackpackItems)
     self.HeldItem = nil
+end
+
+function Inventory:countById(itemId)
+    if type(itemId) ~= 'string' or itemId == '' then
+        return 0
+    end
+
+    local count = 0
+    for _, itemEntry in ipairs(self.BackpackItems) do
+        if itemEntry.Id == itemId then
+            count += 1
+        end
+    end
+
+    if self.HeldItem and self.HeldItem.Id == itemId then
+        count += 1
+    end
+
+    return count
+end
+
+function Inventory:consumeById(itemId)
+    if type(itemId) ~= 'string' or itemId == '' then
+        return false, 'MissingItemId'
+    end
+
+    for index, itemEntry in ipairs(self.BackpackItems) do
+        if itemEntry.Id == itemId then
+            local consumed = table.remove(self.BackpackItems, index)
+            self.Weight -= consumed.Weight
+            return true, cloneItemEntry(consumed)
+        end
+    end
+
+    if self.HeldItem and self.HeldItem.Id == itemId then
+        local consumed = self.HeldItem
+        self.HeldItem = nil
+        self.Weight -= consumed.Weight
+        return true, cloneItemEntry(consumed)
+    end
+
+    return false, 'ItemNotFound'
 end
 
 return Inventory

--- a/packages/gameplay/src/Inventory.luau
+++ b/packages/gameplay/src/Inventory.luau
@@ -186,19 +186,20 @@ function Inventory:consumeHeldItemState(nowSeconds)
         if heldItem.CurrentState < heldItem.ConsumePerUse then
             return false, 'Depleted'
         end
-    end
 
-    local now = type(nowSeconds) == 'number' and nowSeconds or os.clock()
-    local cooldownSeconds = heldItem.CooldownSeconds
-    if type(cooldownSeconds) == 'number' and cooldownSeconds > 0 then
-        local lastUsedAt = heldItem.LastUsedAt
-        if type(lastUsedAt) == 'number' and now - lastUsedAt < cooldownSeconds then
-            return false, 'Cooldown', cooldownSeconds - (now - lastUsedAt)
+        local now = type(nowSeconds) == 'number' and nowSeconds or os.clock()
+        local cooldownSeconds = heldItem.CooldownSeconds
+        if type(cooldownSeconds) == 'number' and cooldownSeconds > 0 then
+            local lastUsedAt = heldItem.LastUsedAt
+            if type(lastUsedAt) == 'number' and now - lastUsedAt < cooldownSeconds then
+                return false, 'Cooldown', cooldownSeconds - (now - lastUsedAt)
+            end
         end
+
+        heldItem.CurrentState -= heldItem.ConsumePerUse
+        heldItem.LastUsedAt = now
     end
 
-    heldItem.CurrentState -= heldItem.ConsumePerUse
-    heldItem.LastUsedAt = now
     return true, cloneItemEntry(heldItem)
 end
 

--- a/packages/gameplay/src/Monsters/MonsterAuthorProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterAuthorProfile.luau
@@ -256,6 +256,16 @@ function MonsterAuthorProfile.validate(profile)
         return false, 'InvalidSpawnOffset'
     end
 
+    if tuning.CombatHitPoints ~= nil then
+        if
+            type(tuning.CombatHitPoints) ~= 'number'
+            or tuning.CombatHitPoints < 1
+            or math.floor(tuning.CombatHitPoints) ~= tuning.CombatHitPoints
+        then
+            return false, 'InvalidCombatHitPoints'
+        end
+    end
+
     if type(executable.BehaviorIntents) ~= 'table' or #executable.BehaviorIntents == 0 then
         return false, 'MissingBehaviorIntents'
     end

--- a/packages/gameplay/src/Monsters/MonsterCompiler.luau
+++ b/packages/gameplay/src/Monsters/MonsterCompiler.luau
@@ -8,6 +8,7 @@ local DEFAULT_SPAWN_OFFSET = Vector3.new(0, 4, 0)
 local DEFAULT_ATTACK_COOLDOWN_SECONDS = 1
 local DEFAULT_ATTACK_DAMAGE_PIPS = 1
 local DEFAULT_ATTACK_RANGE = 4
+local DEFAULT_COMBAT_HIT_POINTS = 1
 
 local MonsterCompiler = {}
 
@@ -71,6 +72,15 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
         end
     end
 
+    local combatHitPoints = normalizedProfile.Tuning.CombatHitPoints
+    if
+        type(combatHitPoints) ~= 'number'
+        or combatHitPoints < 1
+        or math.floor(combatHitPoints) ~= combatHitPoints
+    then
+        combatHitPoints = DEFAULT_COMBAT_HIT_POINTS
+    end
+
     local runtimeProfile = {
         Id = normalizedProfile.Id,
         Name = normalizedProfile.Name,
@@ -83,6 +93,7 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
         SightRange = normalizedProfile.Tuning.SightRange,
         PatrolSpeedMultiplier = normalizedProfile.Tuning.PatrolSpeedMultiplier,
         SpawnOffset = normalizedProfile.Tuning.SpawnOffset or DEFAULT_SPAWN_OFFSET,
+        CombatHitPoints = combatHitPoints,
         Behaviors = table.freeze(behaviors),
         Effects = table.freeze(runtimeEffects),
     }

--- a/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
@@ -207,6 +207,15 @@ function MonsterRuntimeProfile.validate(profile)
         return false, 'MissingRuntimeEffects'
     end
 
+    local combatHitPoints = profile.CombatHitPoints
+    if
+        type(combatHitPoints) ~= 'number'
+        or combatHitPoints < 1
+        or math.floor(combatHitPoints) ~= combatHitPoints
+    then
+        return false, 'InvalidRuntimeCombatHitPoints'
+    end
+
     return true
 end
 

--- a/packages/gameplay/src/init.luau
+++ b/packages/gameplay/src/init.luau
@@ -1,4 +1,5 @@
 return {
+    Combat = require(script.Combat),
     Config = require(script.Config),
     ControlState = require(script.ControlState),
     Inventory = require(script.Inventory),

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -181,6 +181,8 @@ function MonsterService.new(
         RandomSeed = randomSeed,
         RandomSource = runtimeOptions.RandomSource
             or if randomSeed ~= nil then Random.new(randomSeed) else Random.new(),
+        CombatMaxHealth = 1,
+        CombatCurrentHealth = 1,
     }, MonsterService)
 
     service.EnemyRuntime = EnemyRuntime.new({
@@ -219,6 +221,15 @@ function MonsterService.new(
             CooldownSeconds = monsterRuntimeProfile.AttackCooldownSeconds,
         },
     })
+
+    local combatHp = monsterRuntimeProfile.CombatHitPoints
+    if type(combatHp) ~= 'number' or combatHp < 1 or math.floor(combatHp) ~= combatHp then
+        combatHp = 1
+    else
+        combatHp = math.floor(combatHp)
+    end
+    service.CombatMaxHealth = combatHp
+    service.CombatCurrentHealth = combatHp
 
     return service
 end
@@ -867,6 +878,133 @@ function MonsterService:_onAttackMarkerReached(markerName)
 
     self.OnAttackHit(pendingAttack.TargetPlayer, pendingAttack.DamagePips, hitContext)
 end
+
+function MonsterService:_isWithinPlayerMeleeArc(
+    playerPosition,
+    playerLookUnit,
+    monsterPosition,
+    arcDegrees
+)
+    local toMonster = monsterPosition - playerPosition
+    local horizontalToMonster = Vector3.new(toMonster.X, 0, toMonster.Z)
+    if horizontalToMonster.Magnitude <= 1e-4 then
+        return true
+    end
+
+    local facingHorizontal = Vector3.new(playerLookUnit.X, 0, playerLookUnit.Z)
+    if facingHorizontal.Magnitude <= 1e-4 then
+        return true
+    end
+    facingHorizontal = facingHorizontal.Unit
+
+    local targetDirection = horizontalToMonster.Unit
+    local arc = arcDegrees or DEFAULT_ATTACK_ARC_DEGREES
+    local halfArcCosine = math.cos(math.rad(arc * 0.5))
+    return facingHorizontal:Dot(targetDirection) + 1e-6 >= halfArcCosine
+end
+
+function MonsterService:_hasClearShotFromPlayerToMonster(player, originPosition, monsterPosition)
+    local character = player and player.Character
+    if character == nil then
+        return false
+    end
+
+    local delta = monsterPosition - originPosition
+    local distance = delta.Magnitude
+    if distance <= 1e-3 then
+        return true
+    end
+
+    local raycastParams = RaycastParams.new()
+    raycastParams.FilterType = Enum.RaycastFilterType.Exclude
+    raycastParams.IgnoreWater = true
+    raycastParams.FilterDescendantsInstances = { character }
+
+    local raycastResult = self.Raycast(originPosition, delta, raycastParams)
+    if raycastResult == nil then
+        return true
+    end
+
+    if
+        self.MonsterRoot
+        and raycastResult.Instance
+        and raycastResult.Instance:IsDescendantOf(self.MonsterRoot)
+    then
+        return true
+    end
+
+    return false
+end
+
+-- Player crowbar (maze): optional CombatHitPoints on runtime profile; UGC services out of scope for this path.
+function MonsterService:tryApplyPlayerMeleeHit(
+    player,
+    rootPosition,
+    lookVector,
+    swingRange,
+    swingArcDegrees,
+    damageAmount
+)
+    if not self.IsExpeditionActive() then
+        return false, 'NotActive'
+    end
+
+    if typeof(rootPosition) ~= 'Vector3' or typeof(lookVector) ~= 'Vector3' then
+        return false, 'InvalidPlayerTransform'
+    end
+
+    if self.CombatCurrentHealth == nil or self.CombatCurrentHealth <= 0 then
+        return true, { Hit = false, Reason = 'AlreadyDead' }
+    end
+
+    if not self.MonsterPositionPart or self:_getCurrentPosition() == nil then
+        return true, { Hit = false, Reason = 'NoMonster' }
+    end
+
+    local monsterPosition = self:_getCurrentPosition()
+
+    local dmg = type(damageAmount) == 'number' and damageAmount or 1
+    if dmg < 1 then
+        dmg = 1
+    end
+
+    local rangeLimit = type(swingRange) == 'number' and swingRange > 0 and swingRange or 6
+    local arcDeg = type(swingArcDegrees) == 'number' and swingArcDegrees > 0 and swingArcDegrees
+        or DEFAULT_ATTACK_ARC_DEGREES
+
+    local horizontalDistance = Vector3.new(
+        monsterPosition.X - rootPosition.X,
+        0,
+        monsterPosition.Z - rootPosition.Z
+    ).Magnitude
+    if horizontalDistance > rangeLimit then
+        return true, { Hit = false, Reason = 'OutOfRange' }
+    end
+
+    if not self:_isWithinPlayerMeleeArc(rootPosition, lookVector, monsterPosition, arcDeg) then
+        return true, { Hit = false, Reason = 'OutOfArc' }
+    end
+
+    if not self.CanTraverse(monsterPosition, rootPosition) then
+        return true, { Hit = false, Reason = 'BlockedPath' }
+    end
+
+    local rayOrigin = rootPosition + Vector3.new(0, 1.5, 0)
+    if not self:_hasClearShotFromPlayerToMonster(player, rayOrigin, monsterPosition) then
+        return true, { Hit = false, Reason = 'BlockedLineOfSight' }
+    end
+
+    local nextHealth = self.CombatCurrentHealth - dmg
+    self.CombatCurrentHealth = math.max(0, nextHealth)
+    local killed = self.CombatCurrentHealth <= 0
+    if killed then
+        self:destroy()
+        return true, { Hit = true, Killed = true, RemainingHealth = 0 }
+    end
+
+    return true, { Hit = true, Killed = false, RemainingHealth = self.CombatCurrentHealth }
+end
+
 function MonsterService:spawn(patrolPoints, initialPatrolIndex)
     self:destroy()
     self.PatrolPoints = patrolPoints
@@ -881,6 +1019,15 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
     if #patrolPoints == 0 then
         return
     end
+
+    local maxHp = self.Definition.CombatHitPoints
+    if type(maxHp) ~= 'number' or maxHp < 1 or math.floor(maxHp) ~= maxHp then
+        maxHp = 1
+    else
+        maxHp = math.floor(maxHp)
+    end
+    self.CombatMaxHealth = maxHp
+    self.CombatCurrentHealth = maxHp
 
     self.PatrolIndex = math.clamp(initialPatrolIndex or 1, 1, #patrolPoints)
     self.EnemyRuntime:reset(self.PatrolPoints, self.PatrolIndex)

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -12,6 +12,7 @@ local MonsterComponentConfig = Gameplay.Monsters.MonsterComponentConfig
 local MonsterLogic = Gameplay.Monsters.MonsterLogic
 local Enemy = Gameplay.Monsters.Enemy
 local MonsterRuntimeProfile = Gameplay.Monsters.MonsterRuntimeProfile
+local PlayerMonsterMelee = Gameplay.Combat.PlayerMonsterMelee
 local EnemyRuntime = require(script.Parent.MonsterRuntime.EnemyRuntime)
 
 local MonsterService = {}
@@ -181,8 +182,7 @@ function MonsterService.new(
         RandomSeed = randomSeed,
         RandomSource = runtimeOptions.RandomSource
             or if randomSeed ~= nil then Random.new(randomSeed) else Random.new(),
-        CombatMaxHealth = 1,
-        CombatCurrentHealth = 1,
+        CombatHitPointsRemaining = nil,
     }, MonsterService)
 
     service.EnemyRuntime = EnemyRuntime.new({
@@ -263,6 +263,7 @@ function MonsterService:destroy()
     self.PendingAttack = nil
     self.ActiveAnimation = nil
     self.MonsterHumanoid = nil
+    self.CombatHitPointsRemaining = nil
     self.MonsterPositionPart = nil
     self.LogicalPosition = nil
     self.LogicAccumulator = 0
@@ -449,9 +450,33 @@ function MonsterService:_spawnModel(spawnPosition)
     self.MonsterRoot = preparedModel
     self.MonsterPositionPart = rootPart
     self.LogicalPosition = spawnPosition
+    if self.MonsterHumanoid == nil then
+        self.MonsterHumanoid = humanoid
+    end
     self:_attachChaseLoopSound(rootPart)
 
     return true
+end
+
+function MonsterService:_applyDefinitionCombatHealth()
+    local maxPips = self.Definition.CombatHitPoints
+    if type(maxPips) ~= 'number' or maxPips < 1 or math.floor(maxPips) ~= maxPips then
+        maxPips = 1
+    end
+
+    self.CombatMaxHealth = maxPips
+
+    local humanoid = self.MonsterHumanoid
+    if humanoid then
+        humanoid.MaxHealth = maxPips
+        humanoid.Health = maxPips
+        self.CombatCurrentHealth = maxPips
+        self.CombatHitPointsRemaining = nil
+        return
+    end
+
+    self.CombatHitPointsRemaining = maxPips
+    self.CombatCurrentHealth = maxPips
 end
 
 function MonsterService:_setAnimationState(animationName, speedMultiplier)
@@ -879,56 +904,31 @@ function MonsterService:_onAttackMarkerReached(markerName)
     self.OnAttackHit(pendingAttack.TargetPlayer, pendingAttack.DamagePips, hitContext)
 end
 
-function MonsterService:_isWithinPlayerMeleeArc(
-    playerPosition,
-    playerLookUnit,
-    monsterPosition,
-    arcDegrees
-)
-    local toMonster = monsterPosition - playerPosition
-    local horizontalToMonster = Vector3.new(toMonster.X, 0, toMonster.Z)
-    if horizontalToMonster.Magnitude <= 1e-4 then
-        return true
-    end
-
-    local facingHorizontal = Vector3.new(playerLookUnit.X, 0, playerLookUnit.Z)
-    if facingHorizontal.Magnitude <= 1e-4 then
-        return true
-    end
-    facingHorizontal = facingHorizontal.Unit
-
-    local targetDirection = horizontalToMonster.Unit
-    local arc = arcDegrees or DEFAULT_ATTACK_ARC_DEGREES
-    local halfArcCosine = math.cos(math.rad(arc * 0.5))
-    return facingHorizontal:Dot(targetDirection) + 1e-6 >= halfArcCosine
-end
-
-function MonsterService:_hasClearShotFromPlayerToMonster(player, originPosition, monsterPosition)
-    local character = player and player.Character
-    if character == nil then
-        return false
-    end
-
-    local delta = monsterPosition - originPosition
-    local distance = delta.Magnitude
+function MonsterService:_playerMeleeLineOfSightClear(player, playerPosition, monsterPosition)
+    local offset = monsterPosition - playerPosition
+    local distance = offset.Magnitude
     if distance <= 1e-3 then
         return true
     end
 
+    local character = player and player.Character
     local raycastParams = RaycastParams.new()
     raycastParams.FilterType = Enum.RaycastFilterType.Exclude
     raycastParams.IgnoreWater = true
-    raycastParams.FilterDescendantsInstances = { character }
+    if character then
+        raycastParams.FilterDescendantsInstances = { character }
+    end
 
-    local raycastResult = self.Raycast(originPosition, delta, raycastParams)
-    if raycastResult == nil then
+    local direction = offset.Unit * (distance + 0.25)
+    local result = self.Raycast(playerPosition, direction, raycastParams)
+    if result == nil then
         return true
     end
 
     if
         self.MonsterRoot
-        and raycastResult.Instance
-        and raycastResult.Instance:IsDescendantOf(self.MonsterRoot)
+        and result.Instance
+        and result.Instance:IsDescendantOf(self.MonsterRoot)
     then
         return true
     end
@@ -936,73 +936,113 @@ function MonsterService:_hasClearShotFromPlayerToMonster(player, originPosition,
     return false
 end
 
--- Player crowbar (maze): optional CombatHitPoints on runtime profile; UGC services out of scope for this path.
-function MonsterService:tryApplyPlayerMeleeHit(
-    player,
-    rootPosition,
-    lookVector,
-    swingRange,
-    swingArcDegrees,
-    damageAmount
-)
+function MonsterService:tryApplyPlayerMeleeHit(player, meleeOptions)
     if not self.IsExpeditionActive() then
-        return false, 'NotActive'
+        return false, 'ExpeditionInactive'
     end
 
-    if typeof(rootPosition) ~= 'Vector3' or typeof(lookVector) ~= 'Vector3' then
-        return false, 'InvalidPlayerTransform'
+    if self.MonsterRoot == nil then
+        return false, 'NoMonster'
     end
 
-    if self.CombatCurrentHealth == nil or self.CombatCurrentHealth <= 0 then
-        return true, { Hit = false, Reason = 'AlreadyDead' }
+    local isPlayerInstance = typeof(player) == 'Instance' and player:IsA('Player')
+    local isTestStub = type(player) == 'table' and type(player.UserId) == 'number'
+    if not isPlayerInstance and not isTestStub then
+        return false, 'InvalidPlayer'
     end
 
-    if not self.MonsterPositionPart or self:_getCurrentPosition() == nil then
-        return true, { Hit = false, Reason = 'NoMonster' }
+    local character = player.Character
+    if character == nil then
+        return false, 'NoCharacter'
     end
+
+    local humanoidRoot = character:FindFirstChild('HumanoidRootPart')
+    if humanoidRoot == nil or not humanoidRoot:IsA('BasePart') then
+        return false, 'MissingHumanoidRoot'
+    end
+
+    local options = meleeOptions or {}
+    local swingRange = options.SwingRange
+    if type(swingRange) ~= 'number' or swingRange <= 0 then
+        swingRange = 6
+    end
+
+    local swingArcDegrees = options.SwingArcDegrees
+    if type(swingArcDegrees) ~= 'number' or swingArcDegrees <= 0 then
+        swingArcDegrees = 70
+    end
+
+    local damagePips = options.DamagePips
+    if type(damagePips) ~= 'number' or damagePips < 1 then
+        damagePips = 1
+    end
+    damagePips = math.floor(damagePips)
 
     local monsterPosition = self:_getCurrentPosition()
-
-    local dmg = type(damageAmount) == 'number' and damageAmount or 1
-    if dmg < 1 then
-        dmg = 1
+    if typeof(monsterPosition) ~= 'Vector3' then
+        return false, 'MissingMonsterPosition'
     end
 
-    local rangeLimit = type(swingRange) == 'number' and swingRange > 0 and swingRange or 6
-    local arcDeg = type(swingArcDegrees) == 'number' and swingArcDegrees > 0 and swingArcDegrees
-        or DEFAULT_ATTACK_ARC_DEGREES
+    local playerPosition = humanoidRoot.Position
+    local playerLook = humanoidRoot.CFrame.LookVector
 
-    local horizontalDistance = Vector3.new(
-        monsterPosition.X - rootPosition.X,
-        0,
-        monsterPosition.Z - rootPosition.Z
-    ).Magnitude
-    if horizontalDistance > rangeLimit then
-        return true, { Hit = false, Reason = 'OutOfRange' }
+    local geometryOk, geometryReason = PlayerMonsterMelee.evaluateSwing(
+        playerPosition,
+        playerLook,
+        monsterPosition,
+        swingRange,
+        swingArcDegrees
+    )
+    if geometryOk ~= true then
+        return false, geometryReason
     end
 
-    if not self:_isWithinPlayerMeleeArc(rootPosition, lookVector, monsterPosition, arcDeg) then
-        return true, { Hit = false, Reason = 'OutOfArc' }
+    if not self.CanTraverse(playerPosition, monsterPosition) then
+        return false, 'PathBlocked'
     end
 
-    if not self.CanTraverse(monsterPosition, rootPosition) then
-        return true, { Hit = false, Reason = 'BlockedPath' }
+    if not self:_playerMeleeLineOfSightClear(player, playerPosition, monsterPosition) then
+        return false, 'BlockedLineOfSight'
     end
 
-    local rayOrigin = rootPosition + Vector3.new(0, 1.5, 0)
-    if not self:_hasClearShotFromPlayerToMonster(player, rayOrigin, monsterPosition) then
-        return true, { Hit = false, Reason = 'BlockedLineOfSight' }
+    local monsterHumanoid = self.MonsterHumanoid
+    local killed = false
+    local remainingHitPoints
+
+    if monsterHumanoid then
+        local nextHealth = math.max(0, monsterHumanoid.Health - damagePips)
+        monsterHumanoid.Health = nextHealth
+        remainingHitPoints = math.ceil(nextHealth)
+        self.CombatCurrentHealth = remainingHitPoints
+        if nextHealth <= 0 then
+            killed = true
+        end
+    elseif type(self.CombatHitPointsRemaining) == 'number' then
+        self.CombatHitPointsRemaining -= damagePips
+        remainingHitPoints = math.max(0, self.CombatHitPointsRemaining)
+        self.CombatCurrentHealth = remainingHitPoints
+        if remainingHitPoints <= 0 then
+            killed = true
+        end
+    else
+        return false, 'MonsterCombatStateMissing'
     end
 
-    local nextHealth = self.CombatCurrentHealth - dmg
-    self.CombatCurrentHealth = math.max(0, nextHealth)
-    local killed = self.CombatCurrentHealth <= 0
+    self:_recordDecisionEvent('PlayerMeleeHit', {
+        DamagePips = damagePips,
+        Killed = killed,
+        RemainingHitPoints = remainingHitPoints,
+        TargetUserId = player.UserId,
+    })
+
     if killed then
         self:destroy()
-        return true, { Hit = true, Killed = true, RemainingHealth = 0 }
     end
 
-    return true, { Hit = true, Killed = false, RemainingHealth = self.CombatCurrentHealth }
+    return true, {
+        Killed = killed,
+        RemainingHitPoints = remainingHitPoints,
+    }
 end
 
 function MonsterService:spawn(patrolPoints, initialPatrolIndex)
@@ -1020,15 +1060,6 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
         return
     end
 
-    local maxHp = self.Definition.CombatHitPoints
-    if type(maxHp) ~= 'number' or maxHp < 1 or math.floor(maxHp) ~= maxHp then
-        maxHp = 1
-    else
-        maxHp = math.floor(maxHp)
-    end
-    self.CombatMaxHealth = maxHp
-    self.CombatCurrentHealth = maxHp
-
     self.PatrolIndex = math.clamp(initialPatrolIndex or 1, 1, #patrolPoints)
     self.EnemyRuntime:reset(self.PatrolPoints, self.PatrolIndex)
     local spawnPosition = patrolPoints[self.PatrolIndex] + self.Definition.SpawnOffset
@@ -1039,6 +1070,8 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
     else
         self:_setAnimationState('Idle', 1)
     end
+
+    self:_applyDefinitionCombatHealth()
 
     self.EnemyRuntime = self.EnemyFactory(self.Definition, {
         ComponentConfig = self.ComponentConfig,

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -1101,8 +1101,8 @@ function MazeSessionService:_handleUseTool(player)
         return
     end
 
-    -- 2. 检查这东西有没有“状态/耐久”
-    if not heldItem.CurrentState or not heldItem.ConsumePerUse then
+    -- 2. 检查这东西有没有“状态/耐久”（ConsumePerUse 允许为 0，表示使用不扣数值）
+    if type(heldItem.CurrentState) ~= 'number' or type(heldItem.ConsumePerUse) ~= 'number' then
         self:_setStatus(
             string.format(
                 '%s cannot actively "use" %s (it is not a tool).',
@@ -1163,6 +1163,26 @@ function MazeSessionService:_handleUseTool(player)
     elseif updatedHeldItem.ToolCategory == 'Crowbar' then
         actionWord = 'swung'
         effectText = 'A satisfying swoosh cuts the air!'
+
+        local character = player.Character
+        local humanoidRoot = character and character:FindFirstChild('HumanoidRootPart')
+        if humanoidRoot then
+            local meleeOk, meleeResult = self.MonsterService:tryApplyPlayerMeleeHit(
+                player,
+                humanoidRoot.Position,
+                humanoidRoot.CFrame.LookVector,
+                updatedHeldItem.SwingRange,
+                updatedHeldItem.SwingArcDegrees,
+                updatedHeldItem.MeleeDamage
+            )
+            if meleeOk == true and type(meleeResult) == 'table' and meleeResult.Hit == true then
+                if meleeResult.Killed == true then
+                    effectText = 'You land a crushing blow. The threat falls silent.'
+                else
+                    effectText = 'Metal bites true. The creature falters.'
+                end
+            end
+        end
     end
 
     self:_setStatus(

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -1101,7 +1101,7 @@ function MazeSessionService:_handleUseTool(player)
         return
     end
 
-    -- 2. 检查这东西有没有“状态/耐久”（ConsumePerUse 允许为 0，表示使用不扣数值）
+    -- 2. 检查这东西有没有“状态/耐久”（ConsumePerUse 允许为 0 表示不消耗型工具）
     if type(heldItem.CurrentState) ~= 'number' or type(heldItem.ConsumePerUse) ~= 'number' then
         self:_setStatus(
             string.format(
@@ -1113,8 +1113,8 @@ function MazeSessionService:_handleUseTool(player)
         return
     end
 
-    -- 3. 检查有没有没电/报废
-    if heldItem.CurrentState < heldItem.ConsumePerUse then
+    -- 3. 检查有没有没电/报废（仅当每次使用会扣耐久时）
+    if heldItem.ConsumePerUse > 0 and heldItem.CurrentState < heldItem.ConsumePerUse then
         self:_setStatus(
             string.format(
                 '%s tried to use %s, but it has no %s left.',
@@ -1164,23 +1164,24 @@ function MazeSessionService:_handleUseTool(player)
         actionWord = 'swung'
         effectText = 'A satisfying swoosh cuts the air!'
 
-        local character = player.Character
-        local humanoidRoot = character and character:FindFirstChild('HumanoidRootPart')
-        if humanoidRoot then
-            local meleeOk, meleeResult = self.MonsterService:tryApplyPlayerMeleeHit(
-                player,
-                humanoidRoot.Position,
-                humanoidRoot.CFrame.LookVector,
-                updatedHeldItem.SwingRange,
-                updatedHeldItem.SwingArcDegrees,
-                updatedHeldItem.MeleeDamage
-            )
-            if meleeOk == true and type(meleeResult) == 'table' and meleeResult.Hit == true then
-                if meleeResult.Killed == true then
-                    effectText = 'You land a crushing blow. The threat falls silent.'
-                else
-                    effectText = 'Metal bites true. The creature falters.'
-                end
+        local damagePips = 1
+        if type(updatedHeldItem.MeleeDamage) == 'number' and updatedHeldItem.MeleeDamage >= 1 then
+            damagePips = math.floor(updatedHeldItem.MeleeDamage)
+        end
+
+        local meleeOk, meleeResult = self.MonsterService:tryApplyPlayerMeleeHit(player, {
+            DamagePips = damagePips,
+            SwingArcDegrees = updatedHeldItem.SwingArcDegrees,
+            SwingRange = updatedHeldItem.SwingRange,
+        })
+        if meleeOk then
+            if meleeResult and meleeResult.Killed then
+                effectText = 'The crowbar connects — the threat goes down!'
+            elseif meleeResult and type(meleeResult.RemainingHitPoints) == 'number' then
+                effectText = string.format(
+                    'The crowbar connects! Foe stamina: ~%d.',
+                    meleeResult.RemainingHitPoints
+                )
             end
         end
     end

--- a/references/maze-player-melee-hit.md
+++ b/references/maze-player-melee-hit.md
@@ -1,0 +1,17 @@
+# Maze player melee (`MonsterService:tryApplyPlayerMeleeHit`)
+
+Paste the table below into PR descriptions when changing melee rules.
+
+| Stage | Rule | Failure reason string |
+| --- | --- | --- |
+| Session | Expedition must be active (`IsExpeditionActive`). | `ExpeditionInactive` |
+| Monster | Main maze monster instance must exist (`MonsterRoot`). | `NoMonster` |
+| Player | Valid `Player` with `Character` and `HumanoidRootPart`. | `InvalidPlayer`, `NoCharacter`, `MissingHumanoidRoot` |
+| Geometry | Horizontal distance from player root to monster logical position ≤ `SwingRange` (default `6`). | `OutOfRange` |
+| Geometry | Monster lies inside horizontal swing cone: half-angle = `SwingArcDegrees / 2` (default `70°`) around player look. | `OutOfSwingArc`, `InvalidFacing`, … |
+| Path | `CanTraverse(playerPosition, monsterPosition)` must be true (same callback used for monster movement / maze grid). | `PathBlocked` |
+| LOS | Ray from player root toward monster: first hit must be on `MonsterRoot` (or clear ray). Player character excluded. | `BlockedLineOfSight` |
+| Damage | Subtracts `DamagePips` (default `1`) from `Humanoid.Health` or internal fallback HP. | `MonsterCombatStateMissing` |
+| Kill | At ≤ 0 HP, calls `destroy()` on the service. | _(success payload `Killed = true`)_ |
+
+Tool stats come from inventory item entry: `SwingRange`, `SwingArcDegrees` (from `ToolItems` config), passed through `MazeSessionService` after a successful `consumeHeldItemState` for the crowbar.

--- a/tests/src/Shared/CampMazeSessionContract.spec.luau
+++ b/tests/src/Shared/CampMazeSessionContract.spec.luau
@@ -93,6 +93,7 @@ return function()
                 SightRange = 36,
                 PatrolSpeedMultiplier = 0.45,
                 SpawnOffset = Vector3.new(0, 4, 0),
+                CombatHitPoints = 2,
                 Behaviors = {
                     SenseNearestTarget = true,
                     Chase = true,

--- a/tests/src/Shared/Inventory.spec.luau
+++ b/tests/src/Shared/Inventory.spec.luau
@@ -25,7 +25,7 @@ return function()
         ToolCategory = 'Crowbar',
         StateModel = 'Durability',
         InitialState = 10,
-        ConsumePerUse = 1,
+        ConsumePerUse = 0,
         CooldownSeconds = 0.5,
     }
 
@@ -154,14 +154,14 @@ return function()
     local consumeToolSuccess, consumedHeldTool = inventoryService:consumeHeldItemState(toolPlayer)
     assert(consumeToolSuccess == true, 'Runtime inventory should consume held tool state')
     assert(
-        consumedHeldTool.CurrentState == 9,
-        'Consuming a held tool should decrement current state on persisted inventory data'
+        consumedHeldTool.CurrentState == 10,
+        'Crowbar with ConsumePerUse 0 should not decrement current state'
     )
 
     local toolSummary = inventoryService:getSummary(toolPlayer)
     assert(
-        toolSummary.HeldItem.CurrentState == 9,
-        'Consumed tool state should persist in subsequent inventory snapshots'
+        toolSummary.HeldItem.CurrentState == 10,
+        'Tool state should persist unchanged when ConsumePerUse is 0'
     )
 
     local cooldownToolPlayer = {

--- a/tests/src/Shared/MazeSessionServiceMonsterDeterminism.spec.luau
+++ b/tests/src/Shared/MazeSessionServiceMonsterDeterminism.spec.luau
@@ -99,6 +99,7 @@ return function()
             SightRange = 36,
             SpawnOffset = Vector3.new(0, 4, 0),
             Speed = 14,
+            CombatHitPoints = 2,
         },
     })
     service:_spawnQueuedUgcMonsters()

--- a/tests/src/Shared/MazeSessionServiceUgcSpawn.spec.luau
+++ b/tests/src/Shared/MazeSessionServiceUgcSpawn.spec.luau
@@ -86,6 +86,7 @@ return function()
                 SightRange = 36,
                 PatrolSpeedMultiplier = 0.45,
                 SpawnOffset = Vector3.new(0, 4, 0),
+                CombatHitPoints = 2,
                 Behaviors = {
                     SenseNearestTarget = true,
                     Chase = true,

--- a/tests/src/Shared/MonsterAttackMarker.spec.luau
+++ b/tests/src/Shared/MonsterAttackMarker.spec.luau
@@ -22,6 +22,7 @@ return function()
             SightRange = 36,
             PatrolSpeedMultiplier = 0.45,
             SpawnOffset = Vector3.new(0, 4, 0),
+            CombatHitPoints = 4,
             Behaviors = {
                 SenseNearestTarget = true,
                 Chase = true,

--- a/tests/src/Shared/MonsterCompiler.spec.luau
+++ b/tests/src/Shared/MonsterCompiler.spec.luau
@@ -65,6 +65,10 @@ return function()
         'Compiled runtime should expose the configured attack damage pips'
     )
     assert(
+        runtimeProfile.CombatHitPoints == 3,
+        'Compiled runtime should expose configured combat hit points'
+    )
+    assert(
         runtimeProfile.SightRange == 36,
         'Compiled runtime should expose the configured sight range'
     )
@@ -155,6 +159,21 @@ return function()
             and compileReport.SkippedEffectIds[1] == effectCatalog.Effect.SprintSuppressed,
         'Compiler should report maze-skipped effect intents'
     )
+
+    local noCombatHitPointsProfile = table.clone(scrapWisp)
+    noCombatHitPointsProfile.Tuning = table.clone(scrapWisp.Tuning)
+    noCombatHitPointsProfile.Tuning.CombatHitPoints = nil
+
+    local defaultHpOk, defaultHpRuntime, defaultHpReport = compiler(noCombatHitPointsProfile)
+    assert(
+        defaultHpOk == true,
+        string.format('Expected compiler success, got %s', tostring(defaultHpRuntime))
+    )
+    assert(
+        defaultHpRuntime.CombatHitPoints == 1,
+        'Compiler should default CombatHitPoints when tuning omits the field'
+    )
+    assert(defaultHpReport ~= nil, 'Default combat HP compile should return a report')
 
     local legacyProfile = {
         Id = scrapWisp.Id,

--- a/tests/src/Shared/MonsterRuntimeProfile.spec.luau
+++ b/tests/src/Shared/MonsterRuntimeProfile.spec.luau
@@ -19,6 +19,7 @@ return function()
             Chase = true,
         },
         Effects = {},
+        CombatHitPoints = 2,
         Components = {
             Perception = {
                 SightRange = 28,

--- a/tests/src/Shared/MonsterServiceMelee.spec.luau
+++ b/tests/src/Shared/MonsterServiceMelee.spec.luau
@@ -102,17 +102,23 @@ return function()
     assert(hrp ~= nil, 'Fake player should expose HumanoidRootPart')
     hrp.CFrame = CFrame.lookAt(Vector3.new(4, 0, 0), Vector3.new(0, 4, 0))
 
-    local ok1, r1 =
-        service:tryApplyPlayerMeleeHit(fakePlayer, hrp.Position, hrp.CFrame.LookVector, 8, 90, 1)
+    local ok1, r1 = service:tryApplyPlayerMeleeHit(fakePlayer, {
+        DamagePips = 1,
+        SwingArcDegrees = 90,
+        SwingRange = 8,
+    })
     assert(
-        ok1 == true and r1.Hit == true and r1.Killed == false and r1.RemainingHealth == 1,
+        ok1 == true and r1.Killed == false and r1.RemainingHitPoints == 1,
         'first melee hit should reduce remaining health without killing'
     )
 
-    local ok2, r2 =
-        service:tryApplyPlayerMeleeHit(fakePlayer, hrp.Position, hrp.CFrame.LookVector, 8, 90, 1)
+    local ok2, r2 = service:tryApplyPlayerMeleeHit(fakePlayer, {
+        DamagePips = 1,
+        SwingArcDegrees = 90,
+        SwingRange = 8,
+    })
     assert(
-        ok2 == true and r2.Hit == true and r2.Killed == true and r2.RemainingHealth == 0,
+        ok2 == true and r2.Killed == true and r2.RemainingHitPoints == 0,
         'second melee hit should kill and report zero remaining health'
     )
 

--- a/tests/src/Shared/MonsterServiceMelee.spec.luau
+++ b/tests/src/Shared/MonsterServiceMelee.spec.luau
@@ -1,0 +1,122 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local packages = ReplicatedStorage:WaitForChild('Packages')
+    local gameplay = require(packages:WaitForChild('Gameplay'))
+    local shared = require(packages:WaitForChild('Shared'))
+
+    local compileMonsterForMaze = gameplay.Monsters.compileMonsterForMaze
+    local monsterServiceModule = shared.Runtime.MonsterService
+    local monsterAssetIds = gameplay.Monsters.MonsterAssetIds
+
+    local compileOk, runtimeProfile = compileMonsterForMaze(gameplay.Config.Monsters[1])
+    assert(compileOk == true, 'Expected maze monster runtime profile')
+
+    runtimeProfile.CombatHitPoints = 2
+
+    local function createCharacter(position)
+        local character = Instance.new('Model')
+        character.Name = 'MeleeSpecCharacter'
+
+        local rootPart = Instance.new('Part')
+        rootPart.Name = 'HumanoidRootPart'
+        rootPart.Anchored = true
+        rootPart.Position = position
+        rootPart.Parent = character
+
+        return character
+    end
+
+    local fakePlayer = {
+        UserId = 501,
+        Character = createCharacter(Vector3.new(4, 0, 0)),
+    }
+
+    local service = monsterServiceModule.new(
+        runtimeProfile,
+        function()
+            return true
+        end,
+        nil,
+        function()
+            return true
+        end,
+        {
+            AssetLoader = function(assetId)
+                assert(
+                    assetId == monsterAssetIds.DefaultModelAssetId,
+                    'Melee spec should request the configured model asset id'
+                )
+
+                local monsterModel = Instance.new('Model')
+                monsterModel.Name = 'Noob'
+
+                local rootPart = Instance.new('Part')
+                rootPart.Name = 'HumanoidRootPart'
+                rootPart.Size = Vector3.new(2, 2, 1)
+                rootPart.Parent = monsterModel
+
+                local head = Instance.new('Part')
+                head.Name = 'Head'
+                head.Size = Vector3.new(2, 1, 1)
+                head.Parent = monsterModel
+
+                local humanoid = Instance.new('Humanoid')
+                humanoid.Parent = monsterModel
+
+                return monsterModel
+            end,
+            LoadAnimationTrack = function()
+                return {
+                    Looped = false,
+                    Play = function() end,
+                    Stop = function() end,
+                    AdjustSpeed = function() end,
+                    GetMarkerReachedSignal = function()
+                        return nil
+                    end,
+                }
+            end,
+            CreateLoopSound = function()
+                return {
+                    Play = function() end,
+                    Stop = function() end,
+                }
+            end,
+            GetPlayers = function()
+                return {}
+            end,
+            Raycast = function()
+                return nil
+            end,
+            VisualSmoothingSpeed = 1,
+        }
+    )
+
+    service:spawn({ Vector3.new(0, 0, 0) }, 1)
+    assert(
+        service.CombatMaxHealth == 2 and service.CombatCurrentHealth == 2,
+        'spawn should initialize combat hit points from CombatHitPoints'
+    )
+
+    local hrp = fakePlayer.Character:FindFirstChild('HumanoidRootPart')
+    assert(hrp ~= nil, 'Fake player should expose HumanoidRootPart')
+    hrp.CFrame = CFrame.lookAt(Vector3.new(4, 0, 0), Vector3.new(0, 4, 0))
+
+    local ok1, r1 =
+        service:tryApplyPlayerMeleeHit(fakePlayer, hrp.Position, hrp.CFrame.LookVector, 8, 90, 1)
+    assert(
+        ok1 == true and r1.Hit == true and r1.Killed == false and r1.RemainingHealth == 1,
+        'first melee hit should reduce remaining health without killing'
+    )
+
+    local ok2, r2 =
+        service:tryApplyPlayerMeleeHit(fakePlayer, hrp.Position, hrp.CFrame.LookVector, 8, 90, 1)
+    assert(
+        ok2 == true and r2.Hit == true and r2.Killed == true and r2.RemainingHealth == 0,
+        'second melee hit should kill and report zero remaining health'
+    )
+
+    assert(service.MonsterRoot == nil, 'lethal melee should destroy the monster instance')
+
+    fakePlayer.Character:Destroy()
+end

--- a/tests/src/Shared/PlayerMonsterMelee.spec.luau
+++ b/tests/src/Shared/PlayerMonsterMelee.spec.luau
@@ -1,0 +1,35 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
+
+    local melee = gameplay.Combat.PlayerMonsterMelee
+
+    local playerPos = Vector3.new(0, 0, 0)
+    local monsterPos = Vector3.new(0, 0, 5)
+    local look = Vector3.new(0, 0, 1)
+
+    local ok, reason = melee.evaluateSwing(playerPos, look, monsterPos, 6, 70)
+    assert(
+        ok == true and reason == 'HitGeometryOk',
+        'Forward swing within range should pass geometry'
+    )
+
+    local farPos = Vector3.new(0, 0, 12)
+    local farOk, farReason = melee.evaluateSwing(playerPos, look, farPos, 6, 70)
+    assert(farOk == false and farReason == 'OutOfRange', 'Distant targets should fail range')
+
+    local sidePos = Vector3.new(8, 0, 0)
+    local sideOk, sideReason = melee.evaluateSwing(playerPos, look, sidePos, 12, 45)
+    assert(
+        sideOk == false and sideReason == 'OutOfSwingArc',
+        'Wide off-axis targets should fail arc gate'
+    )
+
+    local boundaryRad = math.rad(35)
+    local boundaryPos = Vector3.new(math.sin(boundaryRad) * 4, 0, math.cos(boundaryRad) * 4)
+    local boundaryOk, boundaryReason = melee.evaluateSwing(playerPos, look, boundaryPos, 8, 70)
+    assert(
+        boundaryOk == true and boundaryReason == 'HitGeometryOk',
+        'Targets near the swing arc boundary should pass'
+    )
+end


### PR DESCRIPTION
本 PR：撬棍近战、CombatHitPoints、手电/撬棍不消耗（ConsumePerUse=0）、相关文档与冲突解决；不包含 UGC 刷怪。UGC 怪物接入不在本 PR，后续单独跟；可选 CombatHitPoints 调血量。

## Summary

- What changed?
- Why is this change needed?
- Any prototype-only exceptions or follow-up work?

## Roblox Integration Checklist

- [ ] The change updates the active runtime source under `packages/**`, or I explained why another source path had to change.
- [ ] If Studio tree structure changed, I updated the relevant `default.project.json` in the same PR.
- [ ] If I changed Remote names, replicated schema, or visibility behavior, I updated all linked producers/consumers/tests in the same PR.
- [ ] If I changed non-trivial shared/gameplay behavior, I added or updated deterministic coverage under `tests/src/Shared`, or I explained why no test change was needed.
- [ ] If I touched `SessionConfig.PlaceIds` or any other real-environment configuration, I documented the required rollout or environment follow-up.
- [ ] If this PR includes `.rbxl`, generated output, or other non-source artifacts, I explained why they are required.

## Validation

- [ ] `stylua --check .`
- [ ] `selene .`
- [ ] Additional verification steps are listed below if this PR needs more than static checks.

## Notes

- Manual test notes:
- Risks / follow-ups:
