### PR TITLE
探索道具表现层：图标占位、3D 模板槽、药水与契约字段

### DIFF
--- a/packages/gameplay/src/Config/ItemPresentation.luau
+++ b/packages/gameplay/src/Config/ItemPresentation.luau
@@ -1,0 +1,24 @@
+-- Shared presentation hints for items (2D icons, 3D template names).
+-- Icon PNGs are recommended square; upload to Roblox, then paste the numeric id into IconAssetId.
+
+local ItemPresentation = {}
+
+ItemPresentation.ICON_RECOMMENDED_PIXELS = 256
+
+ItemPresentation.REPLICATED_STORAGE_ASSETS_FOLDER = 'Assets'
+ItemPresentation.TOOL_TEMPLATES_FOLDER = 'ToolTemplates'
+
+function ItemPresentation.formatIconContentId(contentId: string?): string
+    if contentId == nil or contentId == '' then
+        return ''
+    end
+    if string.sub(contentId, 1, 13) == 'rbxassetid://' then
+        return contentId
+    end
+    if string.sub(contentId, 1, 11) == 'rbxasset://' then
+        return contentId
+    end
+    return 'rbxassetid://' .. contentId
+end
+
+return ItemPresentation

--- a/packages/gameplay/src/Config/ToolItems.luau
+++ b/packages/gameplay/src/Config/ToolItems.luau
@@ -1,4 +1,6 @@
 -- ExplorationToolItems Config v0.1
+-- IconAssetId: Roblox image asset id only, or full rbxassetid:// URI; empty = UI uses Color fallback.
+-- ToolTemplateName: optional Model/Tool name under ReplicatedStorage.Assets.ToolTemplates (see place default.project.json).
 local ToolItems = {
     -- 手电筒：照明消耗电量
     ['tool-flashlight'] = {
@@ -10,6 +12,8 @@ local ToolItems = {
         Value = 0,
         Color = Color3.fromRGB(148, 163, 184),
         IsEquipable = true,
+        IconAssetId = '',
+        ToolTemplateName = 'ToolFlashlight',
         -- 状态属性
         StateModel = 'Battery',
         InitialState = 100,
@@ -27,6 +31,8 @@ local ToolItems = {
         Value = 0,
         Color = Color3.fromRGB(200, 200, 200),
         IsEquipable = true,
+        IconAssetId = '',
+        ToolTemplateName = 'ToolCrowbar',
         -- 状态属性
         StateModel = 'Durability',
         InitialState = 10,
@@ -37,6 +43,24 @@ local ToolItems = {
         SwingArcDegrees = 70,
         KnockbackStrength = 15,
         MeleeDamage = 1,
+    },
+
+    -- 药水：迷宫内饮用，消耗次数并回复生命 pip（占位数值）
+    ['tool-potion'] = {
+        Id = 'tool-potion',
+        Name = 'Potion',
+        Description = '饮用消耗一次剂量并回复少量生命；仅在迷宫远征中作为工具使用。',
+        ToolCategory = 'Potion',
+        Weight = 1,
+        Value = 0,
+        Color = Color3.fromRGB(236, 72, 153),
+        IsEquipable = true,
+        IconAssetId = '',
+        ToolTemplateName = 'ToolPotion',
+        StateModel = 'Charges',
+        InitialState = 3,
+        ConsumePerUse = 1,
+        CooldownSeconds = 1,
     },
 }
 

--- a/packages/gameplay/src/Config/ToolItems.luau
+++ b/packages/gameplay/src/Config/ToolItems.luau
@@ -61,6 +61,8 @@ local ToolItems = {
         InitialState = 3,
         ConsumePerUse = 1,
         CooldownSeconds = 1,
+        -- 每次成功饮用回复的生命 pip（迷宫 RequestUseTool）
+        HealHealthPips = 1,
     },
 }
 

--- a/packages/gameplay/src/Config/init.luau
+++ b/packages/gameplay/src/Config/init.luau
@@ -1,5 +1,6 @@
 return {
     Items = require(script.Items),
+    ItemPresentation = require(script.ItemPresentation),
     Monsters = require(script.Monsters),
     Roles = require(script.Roles),
 }

--- a/packages/gameplay/src/Inventory.luau
+++ b/packages/gameplay/src/Inventory.luau
@@ -38,6 +38,7 @@ local function cloneItemEntry(itemEntry)
         SwingArcDegrees = itemEntry.SwingArcDegrees,
         KnockbackStrength = itemEntry.KnockbackStrength,
         MeleeDamage = itemEntry.MeleeDamage,
+        HealHealthPips = itemEntry.HealHealthPips,
     }
 end
 
@@ -93,6 +94,7 @@ function Inventory:_buildItemEntry(itemDef)
         SwingArcDegrees = itemDef.SwingArcDegrees,
         KnockbackStrength = itemDef.KnockbackStrength,
         MeleeDamage = itemDef.MeleeDamage,
+        HealHealthPips = itemDef.HealHealthPips,
     }
 
     self.NextItemInstanceId += 1
@@ -129,6 +131,7 @@ local function normalizeItemEntry(rawItemEntry)
         SwingArcDegrees = rawItemEntry.SwingArcDegrees,
         KnockbackStrength = rawItemEntry.KnockbackStrength,
         MeleeDamage = rawItemEntry.MeleeDamage,
+        HealHealthPips = rawItemEntry.HealHealthPips,
     }
 end
 

--- a/packages/gameplay/src/Inventory.luau
+++ b/packages/gameplay/src/Inventory.luau
@@ -22,6 +22,9 @@ local function cloneItemEntry(itemEntry)
         Value = itemEntry.Value,
         Color = itemEntry.Color,
         Light = cloneLightConfig(itemEntry.Light),
+        Description = itemEntry.Description,
+        IconAssetId = itemEntry.IconAssetId,
+        ToolTemplateName = itemEntry.ToolTemplateName,
 
         -- === 新增：探索道具扩展字段 ===
         ToolCategory = itemEntry.ToolCategory,
@@ -74,6 +77,9 @@ function Inventory:_buildItemEntry(itemDef)
         Value = itemDef.Value,
         Color = itemDef.Color,
         Light = cloneLightConfig(itemDef.Light),
+        Description = itemDef.Description,
+        IconAssetId = itemDef.IconAssetId,
+        ToolTemplateName = itemDef.ToolTemplateName,
 
         -- === 新增：探索道具扩展字段 ===
         ToolCategory = itemDef.ToolCategory,
@@ -107,6 +113,9 @@ local function normalizeItemEntry(rawItemEntry)
         Value = rawItemEntry.Value or 0,
         Color = rawItemEntry.Color,
         Light = cloneLightConfig(rawItemEntry.Light),
+        Description = rawItemEntry.Description,
+        IconAssetId = rawItemEntry.IconAssetId,
+        ToolTemplateName = rawItemEntry.ToolTemplateName,
 
         -- === 新增：探索道具扩展字段 ===
         ToolCategory = rawItemEntry.ToolCategory,

--- a/packages/gameplay/src/Player/Components/HealthComponent.luau
+++ b/packages/gameplay/src/Player/Components/HealthComponent.luau
@@ -36,6 +36,21 @@ function HealthComponent:applyDamage(_blackboard, damageKind)
     return true, self.CurrentHealthPips
 end
 
+function HealthComponent:healPips(blackboard, amount)
+    if self.IsDead then
+        return false, 'Dead'
+    end
+
+    local delta = math.floor(tonumber(amount) or 0)
+    if delta < 1 then
+        return false, 'InvalidAmount'
+    end
+
+    self.CurrentHealthPips = math.min(self.MaxHealthPips, self.CurrentHealthPips + delta)
+    self:update(blackboard, 0)
+    return true, self.CurrentHealthPips
+end
+
 function HealthComponent:update(blackboard, _dt)
     blackboard.Transient.CurrentHealthPips = self.CurrentHealthPips
     blackboard.Transient.MaxHealthPips = self.MaxHealthPips

--- a/packages/shared/src/Client/HeldItemController.luau
+++ b/packages/shared/src/Client/HeldItemController.luau
@@ -1,3 +1,5 @@
+local HeldToolVisual = require(script.Parent.HeldToolVisual)
+
 local HeldItemController = {}
 HeldItemController.__index = HeldItemController
 
@@ -29,8 +31,9 @@ function HeldItemController.new(player)
     )
     table.insert(
         self.Connections,
-        player.CharacterRemoving:Connect(function()
+        player.CharacterRemoving:Connect(function(character)
             self:_clearLight()
+            HeldToolVisual.clear(character)
         end)
     )
 
@@ -53,14 +56,23 @@ function HeldItemController:_clearLight()
 end
 
 function HeldItemController:_refresh()
+    local character = self.Player.Character
     local heldItem = self.Inventory and self.Inventory.HeldItem
+
+    if character then
+        HeldToolVisual.sync(character, heldItem)
+    end
+
     local lightConfig = heldItem and heldItem.Light
     if type(lightConfig) ~= 'table' then
         self:_clearLight()
         return
     end
 
-    local character = self.Player.Character
+    if not character then
+        return
+    end
+
     local lightParent = getLightParent(character)
     if not lightParent then
         return
@@ -98,6 +110,7 @@ function HeldItemController:destroy()
 
     self.Connections = {}
     self:_clearLight()
+    HeldToolVisual.clear(self.Player.Character)
 end
 
 return HeldItemController

--- a/packages/shared/src/Client/HeldToolVisual.luau
+++ b/packages/shared/src/Client/HeldToolVisual.luau
@@ -27,23 +27,85 @@ function HeldToolVisual.clear(character: Model?)
     end
 end
 
-local function tryWeldToHand(hand: BasePart, root: Instance)
-    local handle = root:FindFirstChild('Handle', true)
-    if handle and handle:IsA('BasePart') then
-        for _, inst in root:GetDescendants() do
-            if inst:IsA('BasePart') then
-                inst.Anchored = false
-                inst.CanCollide = false
-                inst.Massless = true
+local function addRigidEdge(adj: { [BasePart]: { BasePart } }, partA: BasePart, partB: BasePart)
+    adj[partA] = adj[partA] or {}
+    adj[partB] = adj[partB] or {}
+    table.insert(adj[partA], partB)
+    table.insert(adj[partB], partA)
+end
+
+-- Parts already rigidly linked to `handle` through WeldConstraint / Motor6D inside `root`.
+local function partsRigidlyConnectedToHandle(
+    root: Instance,
+    handle: BasePart
+): { [BasePart]: boolean }
+    local adj: { [BasePart]: { BasePart } } = {}
+    for _, inst in root:GetDescendants() do
+        if inst:IsA('WeldConstraint') or inst:IsA('Motor6D') then
+            local p0, p1 = inst.Part0, inst.Part1
+            if p0 and p1 and p0:IsA('BasePart') and p1:IsA('BasePart') then
+                addRigidEdge(adj, p0, p1)
             end
         end
-
-        handle.CFrame = hand.CFrame
-        local weld = Instance.new('WeldConstraint')
-        weld.Part0 = hand
-        weld.Part1 = handle
-        weld.Parent = handle
     end
+
+    local seen: { [BasePart]: boolean } = { [handle] = true }
+    local queue = { handle }
+    local index = 1
+    while index <= #queue do
+        local current = queue[index]
+        index += 1
+        for _, neighbor in adj[current] or {} do
+            if not seen[neighbor] then
+                seen[neighbor] = true
+                table.insert(queue, neighbor)
+            end
+        end
+    end
+
+    return seen
+end
+
+local function tryWeldToHand(hand: BasePart, root: Instance)
+    local handle = root:FindFirstChild('Handle', true)
+    if not (handle and handle:IsA('BasePart')) then
+        return
+    end
+
+    for _, inst in root:GetDescendants() do
+        if inst:IsA('BasePart') then
+            inst.Anchored = false
+            inst.CanCollide = false
+            inst.Massless = true
+        end
+    end
+
+    if root:IsA('Model') then
+        local model = root :: Model
+        if model.PrimaryPart ~= nil then
+            model:PivotTo(hand.CFrame)
+        else
+            handle.CFrame = hand.CFrame
+        end
+    else
+        handle.CFrame = hand.CFrame
+    end
+
+    local connected = partsRigidlyConnectedToHandle(root, handle)
+    for _, inst in root:GetDescendants() do
+        if inst:IsA('BasePart') and inst ~= handle and not connected[inst] then
+            local w = Instance.new('WeldConstraint')
+            w.Part0 = handle
+            w.Part1 = inst
+            w.Parent = inst
+            connected[inst] = true
+        end
+    end
+
+    local handWeld = Instance.new('WeldConstraint')
+    handWeld.Part0 = hand
+    handWeld.Part1 = handle
+    handWeld.Parent = handle
 end
 
 function HeldToolVisual.sync(character: Model?, heldItem: any?)
@@ -89,9 +151,9 @@ function HeldToolVisual.sync(character: Model?, heldItem: any?)
 
     if clone:IsA('Model') then
         if clone.PrimaryPart == nil then
-            local handle = clone:FindFirstChild('Handle')
-            if handle and handle:IsA('BasePart') then
-                clone.PrimaryPart = handle
+            local h = clone:FindFirstChild('Handle')
+            if h and h:IsA('BasePart') then
+                clone.PrimaryPart = h
             end
         end
         tryWeldToHand(hand, clone)

--- a/packages/shared/src/Client/HeldToolVisual.luau
+++ b/packages/shared/src/Client/HeldToolVisual.luau
@@ -1,0 +1,103 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+local ItemPresentation = Gameplay.Config.ItemPresentation
+
+local CLONE_NAME = 'HeldToolVisualClone'
+
+local HeldToolVisual = {}
+
+local function getHandPart(character: Model): BasePart?
+    local hand = character:FindFirstChild('RightHand') or character:FindFirstChild('Right Arm')
+    return hand and hand:IsA('BasePart') and hand or nil
+end
+
+function HeldToolVisual.clear(character: Model?)
+    if not character then
+        return
+    end
+
+    local hand = getHandPart(character)
+    if hand then
+        local existing = hand:FindFirstChild(CLONE_NAME)
+        if existing then
+            existing:Destroy()
+        end
+    end
+end
+
+local function tryWeldToHand(hand: BasePart, root: Instance)
+    local handle = root:FindFirstChild('Handle', true)
+    if handle and handle:IsA('BasePart') then
+        for _, inst in root:GetDescendants() do
+            if inst:IsA('BasePart') then
+                inst.Anchored = false
+                inst.CanCollide = false
+                inst.Massless = true
+            end
+        end
+
+        handle.CFrame = hand.CFrame
+        local weld = Instance.new('WeldConstraint')
+        weld.Part0 = hand
+        weld.Part1 = handle
+        weld.Parent = handle
+    end
+end
+
+function HeldToolVisual.sync(character: Model?, heldItem: any?)
+    if not character then
+        return
+    end
+
+    HeldToolVisual.clear(character)
+
+    if type(heldItem) ~= 'table' then
+        return
+    end
+
+    local templateName = heldItem.ToolTemplateName
+    if type(templateName) ~= 'string' or templateName == '' then
+        return
+    end
+
+    local assetsFolder =
+        ReplicatedStorage:FindFirstChild(ItemPresentation.REPLICATED_STORAGE_ASSETS_FOLDER)
+    if not assetsFolder then
+        return
+    end
+
+    local templatesFolder = assetsFolder:FindFirstChild(ItemPresentation.TOOL_TEMPLATES_FOLDER)
+    if not templatesFolder then
+        return
+    end
+
+    local template = templatesFolder:FindFirstChild(templateName)
+    if not template or (not template:IsA('Model') and not template:IsA('Tool')) then
+        return
+    end
+
+    local hand = getHandPart(character)
+    if not hand then
+        return
+    end
+
+    local clone = template:Clone()
+    clone.Name = CLONE_NAME
+    clone.Parent = hand
+
+    if clone:IsA('Model') then
+        if clone.PrimaryPart == nil then
+            local handle = clone:FindFirstChild('Handle')
+            if handle and handle:IsA('BasePart') then
+                clone.PrimaryPart = handle
+            end
+        end
+        tryWeldToHand(hand, clone)
+    elseif clone:IsA('Tool') then
+        tryWeldToHand(hand, clone)
+    end
+end
+
+return HeldToolVisual

--- a/packages/shared/src/Runtime/PlayerService.luau
+++ b/packages/shared/src/Runtime/PlayerService.luau
@@ -66,6 +66,16 @@ function PlayerService:applyDamage(player, damageKind)
     return health:applyDamage(p.Blackboard, damageKind)
 end
 
+function PlayerService:healHealthPips(player, amount)
+    local p = self:get(player)
+    if not p then
+        return false, 'MissingPlayer'
+    end
+
+    local health = p.Components.Health
+    return health:healPips(p.Blackboard, amount)
+end
+
 function PlayerService:setSprinting(player, isSprinting)
     local p = self:get(player)
     if not p then

--- a/packages/shared/src/Session/CampMazeSessionContract.luau
+++ b/packages/shared/src/Session/CampMazeSessionContract.luau
@@ -45,6 +45,20 @@ local function cloneInventoryItem(itemEntry)
         Value = itemEntry.Value,
         Color = itemEntry.Color,
         Light = cloneLightConfig(itemEntry.Light),
+        Description = itemEntry.Description,
+        IconAssetId = itemEntry.IconAssetId,
+        ToolTemplateName = itemEntry.ToolTemplateName,
+        ToolCategory = itemEntry.ToolCategory,
+        StateModel = itemEntry.StateModel,
+        InitialState = itemEntry.InitialState,
+        CurrentState = itemEntry.CurrentState,
+        ConsumePerUse = itemEntry.ConsumePerUse,
+        CooldownSeconds = itemEntry.CooldownSeconds,
+        LastUsedAt = itemEntry.LastUsedAt,
+        SwingRange = itemEntry.SwingRange,
+        SwingArcDegrees = itemEntry.SwingArcDegrees,
+        KnockbackStrength = itemEntry.KnockbackStrength,
+        MeleeDamage = itemEntry.MeleeDamage,
     }
 end
 

--- a/packages/shared/src/Session/CampMazeSessionContract.luau
+++ b/packages/shared/src/Session/CampMazeSessionContract.luau
@@ -59,6 +59,7 @@ local function cloneInventoryItem(itemEntry)
         SwingArcDegrees = itemEntry.SwingArcDegrees,
         KnockbackStrength = itemEntry.KnockbackStrength,
         MeleeDamage = itemEntry.MeleeDamage,
+        HealHealthPips = itemEntry.HealHealthPips,
     }
 end
 

--- a/places/maze/default.project.json
+++ b/places/maze/default.project.json
@@ -15,6 +15,12 @@
         "UI": {
           "$path": "../../packages/ui/src"
         }
+      },
+      "Assets": {
+        "$className": "Folder",
+        "ToolTemplates": {
+          "$className": "Folder"
+        }
       }
     },
     "Workspace": {

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -1187,6 +1187,12 @@ function MazeSessionService:_handleUseTool(player)
     elseif updatedHeldItem.ToolCategory == 'Potion' then
         actionWord = 'drank'
         local healPips = 1
+        if
+            type(updatedHeldItem.HealHealthPips) == 'number'
+            and updatedHeldItem.HealHealthPips >= 1
+        then
+            healPips = math.floor(updatedHeldItem.HealHealthPips)
+        end
         local healOk, healResult = self.PlayerService:healHealthPips(player, healPips)
         if healOk then
             effectText = string.format('The brew steadies you — health pips: %d.', healResult)

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -1184,6 +1184,15 @@ function MazeSessionService:_handleUseTool(player)
                 )
             end
         end
+    elseif updatedHeldItem.ToolCategory == 'Potion' then
+        actionWord = 'drank'
+        local healPips = 1
+        local healOk, healResult = self.PlayerService:healHealthPips(player, healPips)
+        if healOk then
+            effectText = string.format('The brew steadies you — health pips: %d.', healResult)
+        else
+            effectText = string.format('The brew has no effect (%s).', tostring(healResult))
+        end
     end
 
     self:_setStatus(

--- a/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
+++ b/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
@@ -7,8 +7,10 @@ local localPlayer = Players.LocalPlayer
 local playerGui = localPlayer:WaitForChild('PlayerGui')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
 local Shared = require(Packages:WaitForChild('Shared'))
 local UI = require(Packages:WaitForChild('UI'))
+local ItemPresentation = Gameplay.Config.ItemPresentation
 
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
 local heldItemController = Shared.Client.HeldItemController.new(localPlayer)
@@ -28,6 +30,17 @@ local visibleBackpackItems = {}
 local didReceiveInitialSnapshot = false
 local lastToolUseRequestAt = -math.huge
 local heldToolCooldownSeconds = 0.2
+
+local function presentationIconSuffix(itemEntry: { [string]: any }?)
+    if type(itemEntry) ~= 'table' then
+        return ''
+    end
+    local uri = ItemPresentation.formatIconContentId(itemEntry.IconAssetId)
+    if uri ~= '' then
+        return ' | 2D icon'
+    end
+    return ''
+end
 
 local function readBootstrapDiagnostic()
     local failed = ReplicatedStorage:GetAttribute('MazeBootstrapFailed')
@@ -301,11 +314,12 @@ local function connectMazeRemotes(remotes)
 
         local detailLines = {
             heldItem and string.format(
-                'Held: %s | %d KG | %d value%s',
+                'Held: %s | %d KG | %d value%s%s',
                 heldItem.Name,
                 heldItem.Weight,
                 heldItem.Value,
-                heldItem.Light and ' | Glow active' or ''
+                heldItem.Light and ' | Glow active' or '',
+                presentationIconSuffix(heldItem)
             ) or 'Held: Empty hands',
             'Backpack:',
         }
@@ -318,11 +332,12 @@ local function connectMazeRemotes(remotes)
                 table.insert(
                     detailLines,
                     string.format(
-                        '- [%d] %s | %d KG | %d value',
+                        '- [%d] %s | %d KG | %d value%s',
                         itemIndex,
                         itemEntry.Name,
                         itemEntry.Weight,
-                        itemEntry.Value
+                        itemEntry.Value,
+                        presentationIconSuffix(itemEntry)
                     )
                 )
             end

--- a/places/run/default.project.json
+++ b/places/run/default.project.json
@@ -15,6 +15,12 @@
         "UI": {
           "$path": "../../packages/ui/src"
         }
+      },
+      "Assets": {
+        "$className": "Folder",
+        "ToolTemplates": {
+          "$className": "Folder"
+        }
       }
     },
     "Workspace": {

--- a/places/run/src/ServerScriptService/Run/ItemService.luau
+++ b/places/run/src/ServerScriptService/Run/ItemService.luau
@@ -11,6 +11,8 @@ export type ItemData = {
     Description: string,
     IsEquipped: boolean,
     IsActive: boolean,
+    IconAssetId: string?,
+    Color: Color3?,
 }
 
 --#endregion
@@ -42,6 +44,8 @@ ItemService.Items = {
         Description = '点燃倒塌的灯塔',
         IsEquipped = false,
         IsActive = false,
+        IconAssetId = '',
+        Color = Color3.fromRGB(255, 140, 60),
     },
     Flashlight = {
         Name = '手电筒',
@@ -49,6 +53,8 @@ ItemService.Items = {
         Description = '照亮黑暗区域',
         IsEquipped = false,
         IsActive = false,
+        IconAssetId = '',
+        Color = Color3.fromRGB(148, 163, 184),
     },
     Rope = {
         Name = '绳索',
@@ -56,6 +62,8 @@ ItemService.Items = {
         Description = '攀爬高处、跨越断层、固定怪物',
         IsEquipped = false,
         IsActive = false,
+        IconAssetId = '',
+        Color = Color3.fromRGB(180, 160, 120),
     },
     Crowbar = {
         Name = '撬棍',
@@ -63,6 +71,17 @@ ItemService.Items = {
         Description = '撬开锁住的箱子/门',
         IsEquipped = false,
         IsActive = false,
+        IconAssetId = '',
+        Color = Color3.fromRGB(200, 200, 200),
+    },
+    Potion = {
+        Name = '药水',
+        Type = 'Tool',
+        Description = '迷宫远征中饮用可回复生命（Run 侧为展示占位）',
+        IsEquipped = false,
+        IsActive = false,
+        IconAssetId = '',
+        Color = Color3.fromRGB(236, 72, 153),
     },
 }
 

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/BackpackUI.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/BackpackUI.luau
@@ -10,7 +10,9 @@ local ReplicatedStorage = game:GetService('ReplicatedStorage')
 --#region Requires
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
 local Shared = require(Packages:WaitForChild('Shared'))
+local ItemPresentation = Gameplay.Config.ItemPresentation
 local Remotes = Shared.Network.Remotes.waitForScope(Shared.Network.Remotes.Scope.Run)
 
 --#endregion
@@ -25,6 +27,7 @@ local ItemDescriptions = {
     Flashlight = '照亮黑暗区域（按F键开关）',
     Rope = '攀爬高处、跨越断层、固定怪物',
     Crowbar = '撬开锁住的箱子/门',
+    Potion = '迷宫内饮用可回复生命（本背包为展示）',
 }
 
 -- 创建背包 UI
@@ -111,14 +114,24 @@ function BackpackUI.createItemCard(itemName: string, itemData: { [string]: any }
     card.BorderSizePixel = 0
     card.Parent = BackpackUI.ItemContainer
 
-    -- 道具图标（占位）
+    -- 道具图标：有 IconAssetId 时用图；否则用道具 Color 作为色块占位
     local icon = Instance.new('Frame')
     icon.Name = 'Icon'
     icon.Size = UDim2.new(0, 60, 0, 60)
     icon.Position = UDim2.new(0, 10, 0.5, -30)
-    icon.BackgroundColor3 = Color3.fromRGB(60, 60, 70)
+    icon.BackgroundColor3 = (itemData.Color :: Color3?) or Color3.fromRGB(60, 60, 70)
     icon.BorderSizePixel = 0
     icon.Parent = card
+
+    local iconUri = ItemPresentation.formatIconContentId(itemData.IconAssetId)
+    local iconImage = Instance.new('ImageLabel')
+    iconImage.Name = 'IconImage'
+    iconImage.BackgroundTransparency = 1
+    iconImage.Size = UDim2.new(1, 0, 1, 0)
+    iconImage.ScaleType = Enum.ScaleType.Fit
+    iconImage.Image = iconUri
+    iconImage.Visible = iconUri ~= ''
+    iconImage.Parent = icon
 
     -- 道具名称
     local nameLabel = Instance.new('TextLabel')

--- a/tests/default.project.json
+++ b/tests/default.project.json
@@ -16,6 +16,12 @@
           "$path": "../packages/ui/src"
         }
       },
+      "Assets": {
+        "$className": "Folder",
+        "ToolTemplates": {
+          "$className": "Folder"
+        }
+      },
       "PlaceModules": {
         "$className": "Folder",
         "Lobby": {

--- a/tests/src/Shared/CampMazeSessionContract.spec.luau
+++ b/tests/src/Shared/CampMazeSessionContract.spec.luau
@@ -152,7 +152,7 @@ return function()
         EntryReason = 'maze_gate',
         PlayerInventory = {
             Capacity = 8,
-            Weight = 3,
+            Weight = 1,
             Count = 1,
             BackpackCount = 0,
             HeldCount = 1,
@@ -160,36 +160,37 @@ return function()
             BackpackItems = {},
             HeldItem = {
                 InstanceId = 10,
-                Id = 'tool-crowbar',
-                Name = 'Crowbar',
-                Weight = 3,
+                Id = 'tool-potion',
+                Name = 'Potion',
+                Weight = 1,
                 Value = 0,
-                Color = Color3.fromRGB(200, 200, 200),
-                ToolCategory = 'Crowbar',
-                StateModel = 'Durability',
-                InitialState = 10,
-                CurrentState = 10,
-                ConsumePerUse = 0,
-                CooldownSeconds = 0.5,
+                Color = Color3.fromRGB(236, 72, 153),
+                ToolCategory = 'Potion',
+                StateModel = 'Charges',
+                InitialState = 3,
+                CurrentState = 3,
+                ConsumePerUse = 1,
+                CooldownSeconds = 1,
                 IconAssetId = '',
-                ToolTemplateName = 'ToolCrowbar',
-                Description = 'Contract tool row',
-                SwingRange = 6,
-                SwingArcDegrees = 70,
-                KnockbackStrength = 15,
-                MeleeDamage = 1,
+                ToolTemplateName = 'ToolPotion',
+                Description = 'Contract potion row',
+                HealHealthPips = 2,
             },
         },
         PendingUgcMonsterPayload = nil,
     })
     local toolHoldInventory = contract.findPlayerInventory(toolHoldTeleport, 42)
     assert(
-        toolHoldInventory.HeldItem.ToolCategory == 'Crowbar',
+        toolHoldInventory.HeldItem.ToolCategory == 'Potion',
         'Run -> maze inventory clone should preserve ToolCategory for tools'
     )
     assert(
-        toolHoldInventory.HeldItem.ToolTemplateName == 'ToolCrowbar',
+        toolHoldInventory.HeldItem.ToolTemplateName == 'ToolPotion',
         'Run -> maze inventory clone should preserve ToolTemplateName for presentation'
+    )
+    assert(
+        toolHoldInventory.HeldItem.HealHealthPips == 2,
+        'Run -> maze inventory clone should preserve HealHealthPips for potion tools'
     )
 
     local earlyReturn = contract.buildReturnSummary({

--- a/tests/src/Shared/CampMazeSessionContract.spec.luau
+++ b/tests/src/Shared/CampMazeSessionContract.spec.luau
@@ -137,6 +137,61 @@ return function()
         'Pending UGC payload should preserve runtime monster presentation data'
     )
 
+    local toolHoldTeleport = contract.buildRunToMazeTeleportData({
+        SessionConfig = {
+            Seed = 12345,
+            Quota = 120,
+            RunDurationSeconds = 180,
+            InventoryCapacity = 8,
+        },
+        CampSession = entered,
+        EnteringPlayer = {
+            UserId = 42,
+            Name = 'Scout',
+        },
+        EntryReason = 'maze_gate',
+        PlayerInventory = {
+            Capacity = 8,
+            Weight = 3,
+            Count = 1,
+            BackpackCount = 0,
+            HeldCount = 1,
+            Value = 0,
+            BackpackItems = {},
+            HeldItem = {
+                InstanceId = 10,
+                Id = 'tool-crowbar',
+                Name = 'Crowbar',
+                Weight = 3,
+                Value = 0,
+                Color = Color3.fromRGB(200, 200, 200),
+                ToolCategory = 'Crowbar',
+                StateModel = 'Durability',
+                InitialState = 10,
+                CurrentState = 10,
+                ConsumePerUse = 0,
+                CooldownSeconds = 0.5,
+                IconAssetId = '',
+                ToolTemplateName = 'ToolCrowbar',
+                Description = 'Contract tool row',
+                SwingRange = 6,
+                SwingArcDegrees = 70,
+                KnockbackStrength = 15,
+                MeleeDamage = 1,
+            },
+        },
+        PendingUgcMonsterPayload = nil,
+    })
+    local toolHoldInventory = contract.findPlayerInventory(toolHoldTeleport, 42)
+    assert(
+        toolHoldInventory.HeldItem.ToolCategory == 'Crowbar',
+        'Run -> maze inventory clone should preserve ToolCategory for tools'
+    )
+    assert(
+        toolHoldInventory.HeldItem.ToolTemplateName == 'ToolCrowbar',
+        'Run -> maze inventory clone should preserve ToolTemplateName for presentation'
+    )
+
     local earlyReturn = contract.buildReturnSummary({
         UserId = 42,
         Name = 'Scout',

--- a/tests/src/Shared/Inventory.spec.luau
+++ b/tests/src/Shared/Inventory.spec.luau
@@ -22,6 +22,9 @@ return function()
         Weight = 3,
         Value = 0,
         Color = Color3.fromRGB(200, 200, 200),
+        Description = 'Spec crowbar',
+        IconAssetId = '',
+        ToolTemplateName = 'ToolCrowbar',
         ToolCategory = 'Crowbar',
         StateModel = 'Durability',
         InitialState = 10,
@@ -162,6 +165,20 @@ return function()
     assert(
         toolSummary.HeldItem.CurrentState == 10,
         'Tool state should persist unchanged when ConsumePerUse is 0'
+    )
+    assert(
+        toolSummary.HeldItem.ToolTemplateName == 'ToolCrowbar',
+        'Tool presentation template name should round-trip through summaries'
+    )
+
+    local toolRoundTrip = gameplay.Inventory.new(7)
+    assert(
+        toolRoundTrip:loadSummary(toolSummary) == true,
+        'Tool summaries should hydrate inventory'
+    )
+    assert(
+        toolRoundTrip:getSummary().HeldItem.ToolTemplateName == 'ToolCrowbar',
+        'Hydrated inventory should preserve ToolTemplateName'
     )
 
     local cooldownToolPlayer = {

--- a/tests/src/Shared/Inventory.spec.luau
+++ b/tests/src/Shared/Inventory.spec.luau
@@ -181,6 +181,34 @@ return function()
         'Hydrated inventory should preserve ToolTemplateName'
     )
 
+    local potionPlayer = {
+        UserId = 204,
+    }
+    inventoryService:addPlayer(potionPlayer)
+    local potionDef = {
+        Id = 'tool-potion',
+        Name = 'Potion',
+        Weight = 1,
+        Value = 0,
+        Color = Color3.fromRGB(236, 72, 153),
+        ToolCategory = 'Potion',
+        StateModel = 'Charges',
+        InitialState = 2,
+        CurrentState = 2,
+        ConsumePerUse = 1,
+        CooldownSeconds = 0,
+        HealHealthPips = 2,
+    }
+    local pickupPotionSuccess, potionEntry = inventoryService:pickup(potionPlayer, potionDef)
+    assert(pickupPotionSuccess == true, 'Runtime inventory should pick up potion tool defs')
+    local equipPotionSuccess = inventoryService:equip(potionPlayer, potionEntry.InstanceId)
+    assert(equipPotionSuccess == true, 'Runtime inventory should equip potion tools')
+    local potionSummary = inventoryService:getSummary(potionPlayer)
+    assert(
+        potionSummary.HeldItem.HealHealthPips == 2,
+        'HealHealthPips should round-trip on held potion summaries'
+    )
+
     local cooldownToolPlayer = {
         UserId = 203,
     }


### PR DESCRIPTION
ToolItems: IconAssetId、ToolTemplateName；新增药水配置
Inventory + CampMazeSessionContract: 传送/摘要带上展示字段
Run BackpackUI / ItemService: 色块 + 可选图片
HeldToolVisual + default.project.json: ReplicatedStorage/Assets/ToolTemplates 迷宫：MazeSession 药水治疗、MazeClient 与 ItemPresentation 对齐 测试：Inventory / CampMazeSessionContract spec 更新 未上传真实图标/模型、仅占位

## Summary

- What changed?
- Why is this change needed?
- Any prototype-only exceptions or follow-up work?

## Roblox Integration Checklist

- [ ] The change updates the active runtime source under `packages/**`, or I explained why another source path had to change.
- [ ] If Studio tree structure changed, I updated the relevant `default.project.json` in the same PR.
- [ ] If I changed Remote names, replicated schema, or visibility behavior, I updated all linked producers/consumers/tests in the same PR.
- [ ] If I changed non-trivial shared/gameplay behavior, I added or updated deterministic coverage under `tests/src/Shared`, or I explained why no test change was needed.
- [ ] If I touched `SessionConfig.PlaceIds` or any other real-environment configuration, I documented the required rollout or environment follow-up.
- [ ] If this PR includes `.rbxl`, generated output, or other non-source artifacts, I explained why they are required.

## Validation

- [ ] `stylua --check .`
- [ ] `selene .`
- [ ] Additional verification steps are listed below if this PR needs more than static checks.

## Notes

- Manual test notes:
- Risks / follow-ups:
