### PR TITLE
feat(run): validate static world collision and stabilize session boot

### DIFF
--- a/packages/gameplay/src/Config/init.luau
+++ b/packages/gameplay/src/Config/init.luau
@@ -1,6 +1,7 @@
 return {
     Items = require(script.Items),
-    ItemPresentation = require(script.ItemPresentation),
     Monsters = require(script.Monsters),
+    Players = require(script.Players),
     Roles = require(script.Roles),
+    ToolItems = require(script.ToolItems),
 }

--- a/packages/gameplay/src/ControlState.luau
+++ b/packages/gameplay/src/ControlState.luau
@@ -27,6 +27,12 @@ function ControlState:getSummary()
 end
 
 function ControlState:requestSprintStart(playerStateSummary)
+    if type(playerStateSummary) ~= 'table' then
+        self.SprintRequested = false
+        self.Mode = MODE.Walk
+        return false, 'MissingPlayerState'
+    end
+
     if playerStateSummary.IsDead then
         self.SprintRequested = false
         self.Mode = MODE.Walk
@@ -51,6 +57,12 @@ function ControlState:requestSprintStop()
 end
 
 function ControlState:syncPlayerState(playerStateSummary)
+    if type(playerStateSummary) ~= 'table' then
+        self.SprintRequested = false
+        self.Mode = MODE.Walk
+        return self:getSummary()
+    end
+
     if playerStateSummary.IsDead then
         self.SprintRequested = false
         self.Mode = MODE.Walk

--- a/packages/gameplay/src/Player/Components/HealthComponent.luau
+++ b/packages/gameplay/src/Player/Components/HealthComponent.luau
@@ -6,12 +6,26 @@ local DAMAGE_PIP_COST = {
     Heavy = 2,
 }
 
+local function getComponentConfig(blackboard, componentName)
+    local context = if type(blackboard) == 'table' and type(blackboard.Context) == 'table'
+        then blackboard.Context
+        else {}
+    local componentConfig = if type(context.ComponentConfig) == 'table' then context.ComponentConfig else {}
+    local config = componentConfig[componentName]
+
+    if type(config) == 'table' then
+        return config
+    end
+
+    return {}
+end
+
 function HealthComponent.new()
     return setmetatable({}, HealthComponent)
 end
 
 function HealthComponent:init(blackboard)
-    local config = blackboard.Context.ComponentConfig.Health
+    local config = getComponentConfig(blackboard, 'Health')
     local maxHealthPips = if config and config.MaxHealthPips then config.MaxHealthPips else 2
 
     self.MaxHealthPips = maxHealthPips
@@ -33,21 +47,6 @@ function HealthComponent:applyDamage(_blackboard, damageKind)
         self.CorpseActive = true
     end
 
-    return true, self.CurrentHealthPips
-end
-
-function HealthComponent:healPips(blackboard, amount)
-    if self.IsDead then
-        return false, 'Dead'
-    end
-
-    local delta = math.floor(tonumber(amount) or 0)
-    if delta < 1 then
-        return false, 'InvalidAmount'
-    end
-
-    self.CurrentHealthPips = math.min(self.MaxHealthPips, self.CurrentHealthPips + delta)
-    self:update(blackboard, 0)
     return true, self.CurrentHealthPips
 end
 

--- a/packages/gameplay/src/Player/Components/InventoryComponent.luau
+++ b/packages/gameplay/src/Player/Components/InventoryComponent.luau
@@ -1,12 +1,26 @@
 local InventoryComponent = {}
 InventoryComponent.__index = InventoryComponent
 
+local function getComponentConfig(blackboard, componentName)
+    local context = if type(blackboard) == 'table' and type(blackboard.Context) == 'table'
+        then blackboard.Context
+        else {}
+    local componentConfig = if type(context.ComponentConfig) == 'table' then context.ComponentConfig else {}
+    local config = componentConfig[componentName]
+
+    if type(config) == 'table' then
+        return config
+    end
+
+    return {}
+end
+
 function InventoryComponent.new()
     return setmetatable({}, InventoryComponent)
 end
 
 function InventoryComponent:init(blackboard)
-    local config = blackboard.Context.ComponentConfig.Inventory or {}
+    local config = getComponentConfig(blackboard, 'Inventory')
 
     self.SlotCount = config.SlotCount or 8
     self.Slots = table.create(self.SlotCount, nil)

--- a/packages/gameplay/src/Player/Components/MovementComponent.luau
+++ b/packages/gameplay/src/Player/Components/MovementComponent.luau
@@ -5,12 +5,26 @@ local DEFAULT_WALK_SPEED = 16
 local DEFAULT_SPRINT_SPEED = 24
 local DEFAULT_JUMP_VELOCITY = 50
 
+local function getComponentConfig(blackboard, componentName)
+    local context = if type(blackboard) == 'table' and type(blackboard.Context) == 'table'
+        then blackboard.Context
+        else {}
+    local componentConfig = if type(context.ComponentConfig) == 'table' then context.ComponentConfig else {}
+    local config = componentConfig[componentName]
+
+    if type(config) == 'table' then
+        return config
+    end
+
+    return {}
+end
+
 function MovementComponent.new()
     return setmetatable({}, MovementComponent)
 end
 
 function MovementComponent:init(blackboard)
-    local config = blackboard.Context.ComponentConfig.Movement or {}
+    local config = getComponentConfig(blackboard, 'Movement')
 
     self.MaxWalkSpeed = config.MaxWalkSpeed or DEFAULT_WALK_SPEED
     self.MaxSprintSpeed = config.MaxSprintSpeed or DEFAULT_SPRINT_SPEED

--- a/packages/gameplay/src/Player/Components/StaminaComponent.luau
+++ b/packages/gameplay/src/Player/Components/StaminaComponent.luau
@@ -3,12 +3,26 @@ StaminaComponent.__index = StaminaComponent
 
 local DEFAULT_STAMINA_RECOVERY_DELAY_SECONDS = 1.5
 
+local function getComponentConfig(blackboard, componentName)
+    local context = if type(blackboard) == 'table' and type(blackboard.Context) == 'table'
+        then blackboard.Context
+        else {}
+    local componentConfig = if type(context.ComponentConfig) == 'table' then context.ComponentConfig else {}
+    local config = componentConfig[componentName]
+
+    if type(config) == 'table' then
+        return config
+    end
+
+    return {}
+end
+
 function StaminaComponent.new()
     return setmetatable({}, StaminaComponent)
 end
 
 function StaminaComponent:init(blackboard)
-    local config = blackboard.Context.ComponentConfig.Stamina or {}
+    local config = getComponentConfig(blackboard, 'Stamina')
 
     self.MaxStamina = config.MaxStamina or 100
     self.CurrentStamina = self.MaxStamina

--- a/packages/gameplay/src/Player/Player.luau
+++ b/packages/gameplay/src/Player/Player.luau
@@ -38,6 +38,9 @@ end
 
 function Player:spawn()
     self.Blackboard:setState(self.StateMachine:getState())
+    self.Blackboard:beginTick({
+        ComponentConfig = self.ComponentConfig,
+    })
     for _, component in pairs(self.Components) do
         if component.init then
             component:init(self.Blackboard)

--- a/places/run/STATIC_WORLD.md
+++ b/places/run/STATIC_WORLD.md
@@ -22,10 +22,23 @@ Required markers:
 - Root attribute `OutdoorThresholdZ`
   Defines the authored Z threshold between `Temple Hall` and `Wilderness`.
 
+Required authored collision structure:
+
+- `Collision/Scene`
+- `Collision/Ship`
+
+Required authored trigger structure:
+
+- `Triggers/Ocean`
+
 Rules:
 
 - Keep all run-only geometry and prompts under `Workspace/RunStaticWorld`.
 - `RunStaticWorld` is the only formal runtime source for the `run` place.
 - `RunWorldBuilder` no longer generates fallback camp or wilderness geometry at runtime.
+- `Collision/Scene` and `Collision/Ship` must contain invisible anchored collision shells.
+- Collision shell parts must use `Anchored=true`, `CanCollide=true`, `CanTouch=false`, `CanQuery=true`, and `Transparency=1`.
+- `Triggers/Ocean` must contain invisible anchored non-collidable trigger parts for water-entry feedback.
 - Missing required markers, prompts, doors, or root attributes must fail loudly at runtime so content issues are fixed in Studio instead of hidden in code.
+- `SpawnMarker` must have a collidable authored floor within 32 studs below it.
 - `MazeGateMarker` is the run-to-maze transition object. Scene code only identifies it; cross-place teleport is handled by the dedicated transition layer.

--- a/places/run/default.project.json
+++ b/places/run/default.project.json
@@ -15,12 +15,6 @@
         "UI": {
           "$path": "../../packages/ui/src"
         }
-      },
-      "Assets": {
-        "$className": "Folder",
-        "ToolTemplates": {
-          "$className": "Folder"
-        }
       }
     },
     "Workspace": {
@@ -46,6 +40,21 @@
           "$className": "Part",
           "$properties": {
             "Anchored": true
+          }
+        },
+        "Collision": {
+          "$className": "Folder",
+          "Scene": {
+            "$className": "Folder"
+          },
+          "Ship": {
+            "$className": "Folder"
+          }
+        },
+        "Triggers": {
+          "$className": "Folder",
+          "Ocean": {
+            "$className": "Folder"
           }
         },
         "DoorLeft": {

--- a/places/run/src/ServerScriptService/Bootstrap.server.luau
+++ b/places/run/src/ServerScriptService/Bootstrap.server.luau
@@ -2,7 +2,9 @@ local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Shared = require(Packages:WaitForChild('Shared'))
+local RunStaticWorldContract = require(script.Parent.Run.RunStaticWorldContract)
 local RunSessionService = require(script.Parent.Run.RunSessionService)
 
 Shared.Network.Remotes.ensure()
+warn(string.format('[run-bootstrap] build=%s', RunStaticWorldContract.BuildFingerprint))
 RunSessionService.new():start()

--- a/places/run/src/ServerScriptService/Run/RunInteractionRegistry.luau
+++ b/places/run/src/ServerScriptService/Run/RunInteractionRegistry.luau
@@ -33,6 +33,12 @@ function RunInteractionRegistry:bindScene(scene, handlers)
     self:_track(scene.MazePortal:bind(function(player)
         handlers.OnMazePortal(player)
     end))
+
+    for _, oceanTrigger in ipairs(scene.OceanTriggers or {}) do
+        self:_track(oceanTrigger:bind(function(player, trigger)
+            handlers.OnOceanEntered(player, trigger)
+        end))
+    end
 end
 
 function RunInteractionRegistry:disconnectAll()

--- a/places/run/src/ServerScriptService/Run/RunOceanTrigger.luau
+++ b/places/run/src/ServerScriptService/Run/RunOceanTrigger.luau
@@ -1,0 +1,51 @@
+local Players = game:GetService('Players')
+
+local RunOceanTrigger = {}
+RunOceanTrigger.__index = RunOceanTrigger
+
+local ENTRY_COOLDOWN_SECONDS = 0.75
+
+local function findPlayerFromHit(hit)
+    if hit == nil then
+        return nil
+    end
+
+    local character = hit:FindFirstAncestorOfClass('Model')
+    if character == nil then
+        return nil
+    end
+
+    local humanoid = character:FindFirstChildOfClass('Humanoid')
+    if humanoid == nil then
+        return nil
+    end
+
+    return Players:GetPlayerFromCharacter(character)
+end
+
+function RunOceanTrigger.new(part)
+    return setmetatable({
+        Part = part,
+        LastEnteredAtByUserId = {},
+    }, RunOceanTrigger)
+end
+
+function RunOceanTrigger:bind(callback)
+    return self.Part.Touched:Connect(function(hit)
+        local player = findPlayerFromHit(hit)
+        if player == nil then
+            return
+        end
+
+        local now = os.clock()
+        local lastEnteredAt = self.LastEnteredAtByUserId[player.UserId]
+        if lastEnteredAt ~= nil and now - lastEnteredAt < ENTRY_COOLDOWN_SECONDS then
+            return
+        end
+
+        self.LastEnteredAtByUserId[player.UserId] = now
+        callback(player, self)
+    end)
+end
+
+return RunOceanTrigger

--- a/places/run/src/ServerScriptService/Run/RunScene.luau
+++ b/places/run/src/ServerScriptService/Run/RunScene.luau
@@ -1,8 +1,10 @@
 local RunAreaResolver = require(script.Parent.RunAreaResolver)
 local RunDoor = require(script.Parent.RunDoor)
 local RunInteractionRegistry = require(script.Parent.RunInteractionRegistry)
+local RunOceanTrigger = require(script.Parent.RunOceanTrigger)
 local RunPortal = require(script.Parent.RunPortal)
 local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
+local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
 local RunTerminal = require(script.Parent.RunTerminal)
 
 local RunScene = {}
@@ -42,6 +44,59 @@ local function requirePart(root, name)
     return part
 end
 
+local function requireContainer(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not (child:IsA('Folder') or child:IsA('Model')) then
+        error(string.format('%s is missing required container "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function collectBaseParts(root)
+    local parts = {}
+
+    for _, descendant in ipairs(root:GetDescendants()) do
+        if descendant:IsA('BasePart') then
+            table.insert(parts, descendant)
+        end
+    end
+
+    return parts
+end
+
+local function buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
+    local raycastParams = RaycastParams.new()
+    raycastParams.FilterType = Enum.RaycastFilterType.Include
+    raycastParams.FilterDescendantsInstances = { sceneCollisionRoot, shipCollisionRoot }
+    return raycastParams
+end
+
+local function groundedSpawnCFrame(part, raycastParams)
+    local origin = part.Position + Vector3.new(0, (part.Size.Y * 0.5) + 2, 0)
+    local result = workspace:Raycast(
+        origin,
+        Vector3.new(0, -RunStaticWorldContract.SpawnGroundCheckDepth, 0),
+        raycastParams
+    )
+
+    if result and result.Instance and result.Instance.CanCollide and result.Normal.Y > 0.5 then
+        local groundedPosition = Vector3.new(
+            part.Position.X,
+            result.Position.Y + RunStaticWorldContract.SpawnLiftStuds,
+            part.Position.Z
+        )
+        return CFrame.fromMatrix(
+            groundedPosition,
+            part.CFrame.XVector,
+            part.CFrame.YVector,
+            part.CFrame.ZVector
+        )
+    end
+
+    return part.CFrame
+end
+
 function RunScene.new(root)
     if not (root:IsA('Folder') or root:IsA('Model')) then
         error('RunStaticWorld must be a Folder or Model.', 0)
@@ -52,9 +107,32 @@ function RunScene.new(root)
         error('RunStaticWorld is missing required attribute "OutdoorThresholdZ".', 0)
     end
 
+    local collisionRoot =
+        requireContainer(root, RunStaticWorldContract.CollisionRootName, 'RunStaticWorld')
+    local sceneCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.SceneCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local shipCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.ShipCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local triggersRoot =
+        requireContainer(root, RunStaticWorldContract.TriggersRootName, 'RunStaticWorld')
+    local oceanTriggerRoot = requireContainer(
+        triggersRoot,
+        RunStaticWorldContract.OceanTriggerName,
+        'RunStaticWorld Triggers'
+    )
+    local spawnGroundParams = buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
     local spawnPoints = {}
+    local spawnCFramesByKind = {}
     for markerName, kind in pairs(REQUIRED_MARKERS) do
-        spawnPoints[kind] = RunSpawnPoint.new(kind, requirePart(root, markerName))
+        local markerPart = requirePart(root, markerName)
+        spawnPoints[kind] = RunSpawnPoint.new(kind, markerPart)
+        spawnCFramesByKind[kind] = groundedSpawnCFrame(markerPart, spawnGroundParams)
     end
 
     local terminals = {}
@@ -67,6 +145,11 @@ function RunScene.new(root)
         requirePart(root, 'DoorLeft'),
         requirePart(root, 'DoorRight'),
     })
+    local oceanTriggers = {}
+
+    for _, part in ipairs(collectBaseParts(oceanTriggerRoot)) do
+        table.insert(oceanTriggers, RunOceanTrigger.new(part))
+    end
 
     local self = setmetatable({
         Root = root,
@@ -74,12 +157,18 @@ function RunScene.new(root)
         Terminals = terminals,
         MazePortal = mazePortal,
         GateDoor = gateDoor,
+        Collision = {
+            Scene = sceneCollisionRoot,
+            Ship = shipCollisionRoot,
+        },
+        OceanTriggers = oceanTriggers,
         OutdoorThresholdZ = outdoorThresholdZ,
         AreaResolver = nil,
+        SpawnCFramesByKind = spawnCFramesByKind,
 
-        SpawnCFrame = spawnPoints[RunSpawnPoint.Kind.Spawn]:getCFrame(),
-        ReturnCFrame = spawnPoints[RunSpawnPoint.Kind.Return]:getCFrame(),
-        MazeReturnCFrame = spawnPoints[RunSpawnPoint.Kind.MazeReturn]:getCFrame(),
+        SpawnCFrame = spawnCFramesByKind[RunSpawnPoint.Kind.Spawn],
+        ReturnCFrame = spawnCFramesByKind[RunSpawnPoint.Kind.Return],
+        MazeReturnCFrame = spawnCFramesByKind[RunSpawnPoint.Kind.MazeReturn],
         ShopPrompt = terminals.Shop.Prompt,
         SellPrompt = terminals.Sell.Prompt,
         ObjectivePrompt = terminals.Objective.Prompt,
@@ -95,12 +184,12 @@ function RunScene.new(root)
 end
 
 function RunScene:getSpawnCFrame(kind)
-    local spawnPoint = self.SpawnPoints[kind]
-    if spawnPoint == nil then
+    local spawnCFrame = self.SpawnCFramesByKind[kind]
+    if spawnCFrame == nil then
         error(string.format('Unknown run spawn point kind %q.', tostring(kind)), 0)
     end
 
-    return spawnPoint:getCFrame()
+    return spawnCFrame
 end
 
 function RunScene:getAreaForPosition(position)

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -19,6 +19,7 @@ local PlayerStateService = Shared.Runtime.PlayerStateService
 local TeleportInventoryHydrator = Shared.Runtime.TeleportInventoryHydrator
 
 local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
+local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
 local RunToMazeTransition = require(script.Parent.RunToMazeTransition)
 local RunWorldBuilder = require(script.Parent.RunWorldBuilder)
 
@@ -37,6 +38,7 @@ local RUN_MAZE_GATE_RETURN_REASONS = table.freeze({
 })
 local INITIAL_TEMPLE_STATUS = 'Select Enter Temple to enter the temple.'
 local BOOK_GOAL_AMOUNT = 120
+local OCEAN_SPLASH_MESSAGE = 'Sea spray crashes over you.'
 local SHOP_ITEMS = {
     {
         Id = 'temple_lantern',
@@ -209,6 +211,7 @@ function RunSessionService.new(options)
     local self = setmetatable({}, RunSessionService)
 
     self.Remotes = Remotes
+    self.BuildFingerprint = RunStaticWorldContract.BuildFingerprint
     self.SessionData = {
         Seed = SessionConfig.DefaultSeed,
         Quota = SessionConfig.DefaultQuota,
@@ -228,6 +231,7 @@ function RunSessionService.new(options)
     self.HasAuthoritativeSessionSeed = false
     self.SessionSeedRandom = nil
     self.LastMazeEntryRequestAtByUserId = {}
+    self.LastOceanSplashAtByUserId = {}
     self.MazeEntryMode = MazeEntryAvailability.Mode.Blocked
     self.MazeEntryReason =
         'Set SessionConfig.PlaceIds.Maze or SessionPlaceIdMaze before using the maze gate.'
@@ -239,6 +243,7 @@ function RunSessionService.new(options)
     self.PlayerService = PlayerService.new()
     self.PlayerStateService = PlayerStateService.new()
     self.RunToMazeTransition = runtimeOptions.RunToMazeTransition or RunToMazeTransition.new()
+    self.WorldBuilder = runtimeOptions.RunWorldBuilder or RunWorldBuilder
 
     return self
 end
@@ -254,6 +259,24 @@ function RunSessionService:_removePlayerState(player)
     self.InventoryService:removePlayer(player)
     self.ControlStateService:removePlayer(player)
     self.PlayerService:removePlayer(player)
+end
+
+function RunSessionService:_handleOceanEntered(player)
+    local now = os.clock()
+    local lastSplashAt = self.LastOceanSplashAtByUserId[player.UserId]
+    if
+        lastSplashAt ~= nil
+        and now - lastSplashAt < RunStaticWorldContract.OceanSplashCooldownSeconds
+    then
+        return
+    end
+
+    self.LastOceanSplashAtByUserId[player.UserId] = now
+    self.Remotes.RunPrivateState:FireClient(player, {
+        Type = 'OceanSplash',
+        Message = OCEAN_SPLASH_MESSAGE,
+        FutureEffect = 'DrownDamagePending',
+    })
 end
 
 function RunSessionService:_getMovementSummaryFor(player)
@@ -460,7 +483,7 @@ function RunSessionService:_rebuildWorld()
         self.WorldInteractions = nil
     end
 
-    self.World = RunWorldBuilder.build()
+    self.World = self.WorldBuilder.build()
     if self.GateOpen then
         self.World:openGate()
     end
@@ -506,6 +529,9 @@ function RunSessionService:_rebuildWorld()
             if self:_canProcessMazeEntryRequest(player) then
                 self:_requestMazeEntry(player, false)
             end
+        end,
+        OnOceanEntered = function(player)
+            self:_handleOceanEntered(player)
         end,
     })
 
@@ -775,6 +801,7 @@ function RunSessionService:_broadcastSnapshot()
         self.Remotes.RunState:FireClient(player, {
             IsLaunched = self.IsLaunched,
             Status = self.Status,
+            BuildFingerprint = self.BuildFingerprint,
             Area = self:_getPlayerArea(player),
             GateOpen = self.GateOpen,
             Objective = self:_getObjectiveFor(player),
@@ -1022,12 +1049,13 @@ function RunSessionService:_launchRun(_player)
         return
     end
 
-    self.IsLaunched = true
-    Players.CharacterAutoLoads = true
     self.GateOpen = self.CampSession.GateOpen == true
     self:_syncCampSession()
 
     self:_rebuildWorld()
+
+    self.IsLaunched = true
+    Players.CharacterAutoLoads = true
 
     for _, player in ipairs(Players:GetPlayers()) do
         player:LoadCharacter()
@@ -1154,6 +1182,7 @@ function RunSessionService:_ensureAuthoritativeSessionSeed()
 end
 
 function RunSessionService:start()
+    warn(string.format('[run-session] build=%s', self.BuildFingerprint))
     self:_loadSessionDataFromJoin()
     self:_ensureAuthoritativeSessionSeed()
     Players.CharacterAutoLoads = false
@@ -1182,6 +1211,7 @@ function RunSessionService:start()
 
     Players.PlayerRemoving:Connect(function(player)
         self.LastMazeEntryRequestAtByUserId[player.UserId] = nil
+        self.LastOceanSplashAtByUserId[player.UserId] = nil
         self.PendingSpawnByUserId[player.UserId] = nil
         self.CampSession = CampMazeSessionContract.prunePlayer(self.CampSession, player.UserId, {
             PreserveMazeEntry = CampMazeSessionContract.isPlayerInMaze(

--- a/places/run/src/ServerScriptService/Run/RunStaticWorldContract.luau
+++ b/places/run/src/ServerScriptService/Run/RunStaticWorldContract.luau
@@ -1,0 +1,14 @@
+local RunStaticWorldContract = table.freeze({
+    RootName = 'RunStaticWorld',
+    CollisionRootName = 'Collision',
+    SceneCollisionName = 'Scene',
+    ShipCollisionName = 'Ship',
+    TriggersRootName = 'Triggers',
+    OceanTriggerName = 'Ocean',
+    BuildFingerprint = 'run-collision-contract-v2',
+    SpawnGroundCheckDepth = 32,
+    SpawnLiftStuds = 4,
+    OceanSplashCooldownSeconds = 1.5,
+})
+
+return RunStaticWorldContract

--- a/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
+++ b/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
@@ -1,0 +1,213 @@
+local Workspace = game:GetService('Workspace')
+
+local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
+
+local RunStaticWorldValidator = {}
+local REQUIRED_MARKER_NAMES = table.freeze({
+    'SpawnMarker',
+    'ReturnMarker',
+    'MazeReturnMarker',
+})
+
+local function requireContainer(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not (child:IsA('Folder') or child:IsA('Model')) then
+        error(string.format('%s is missing required container "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function collectBaseParts(root)
+    local parts = {}
+
+    for _, descendant in ipairs(root:GetDescendants()) do
+        if descendant:IsA('BasePart') then
+            table.insert(parts, descendant)
+        end
+    end
+
+    return parts
+end
+
+local function requireBaseParts(root, contextLabel)
+    local parts = collectBaseParts(root)
+    if #parts == 0 then
+        error(string.format('%s must contain at least one BasePart.', contextLabel), 0)
+    end
+
+    return parts
+end
+
+local function validateCollisionParts(parts, contextLabel)
+    for _, part in ipairs(parts) do
+        if part.Anchored ~= true then
+            error(string.format('%s part "%s" must be Anchored.', contextLabel, part.Name), 0)
+        end
+        if part.CanCollide ~= true then
+            error(
+                string.format('%s part "%s" must have CanCollide=true.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.CanTouch ~= false then
+            error(
+                string.format('%s part "%s" must have CanTouch=false.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.CanQuery ~= true then
+            error(
+                string.format('%s part "%s" must have CanQuery=true.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.Transparency ~= 1 then
+            error(
+                string.format('%s part "%s" must have Transparency=1.', contextLabel, part.Name),
+                0
+            )
+        end
+    end
+end
+
+local function validateOceanParts(parts, contextLabel)
+    for _, part in ipairs(parts) do
+        if part.Anchored ~= true then
+            error(string.format('%s part "%s" must be Anchored.', contextLabel, part.Name), 0)
+        end
+        if part.CanCollide ~= false then
+            error(
+                string.format('%s part "%s" must have CanCollide=false.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.CanTouch ~= true then
+            error(
+                string.format('%s part "%s" must have CanTouch=true.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.Transparency ~= 1 then
+            error(
+                string.format('%s part "%s" must have Transparency=1.', contextLabel, part.Name),
+                0
+            )
+        end
+    end
+end
+
+local function validateMarkerPart(part, contextLabel)
+    if part.Anchored ~= true then
+        error(string.format('%s must be Anchored.', contextLabel), 0)
+    end
+    if part.CanCollide ~= false then
+        error(string.format('%s must have CanCollide=false.', contextLabel), 0)
+    end
+    if part.CanTouch ~= false then
+        error(string.format('%s must have CanTouch=false.', contextLabel), 0)
+    end
+    if part.CanQuery ~= true then
+        error(string.format('%s must have CanQuery=true.', contextLabel), 0)
+    end
+end
+
+local function buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
+    local raycastParams = RaycastParams.new()
+    raycastParams.FilterType = Enum.RaycastFilterType.Include
+    raycastParams.FilterDescendantsInstances = { sceneCollisionRoot, shipCollisionRoot }
+    return raycastParams
+end
+
+local function buildSpawnGroundSampleOffsets(spawnMarker)
+    local offsetX = math.max(spawnMarker.Size.X * 0.35, 1)
+    local offsetZ = math.max(spawnMarker.Size.Z * 0.35, 1)
+
+    return {
+        Vector3.zero,
+        Vector3.new(offsetX, 0, offsetZ),
+        Vector3.new(offsetX, 0, -offsetZ),
+        Vector3.new(-offsetX, 0, offsetZ),
+        Vector3.new(-offsetX, 0, -offsetZ),
+    }
+end
+
+local function assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, spawnMarker)
+    local raycastParams = buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
+    local sampleOffsets = buildSpawnGroundSampleOffsets(spawnMarker)
+    local raycastDistance = Vector3.new(0, -RunStaticWorldContract.SpawnGroundCheckDepth, 0)
+    local raycastStartHeight = (spawnMarker.Size.Y * 0.5) + 2
+
+    for _, offset in ipairs(sampleOffsets) do
+        local origin = spawnMarker.Position + Vector3.new(offset.X, raycastStartHeight, offset.Z)
+        local result = Workspace:Raycast(origin, raycastDistance, raycastParams)
+        if result and result.Instance and result.Instance.CanCollide and result.Normal.Y > 0.5 then
+            return
+        end
+    end
+
+    error(
+        string.format(
+            'RunStaticWorld SpawnMarker must raycast onto Collision/Scene or Collision/Ship within %d studs below it.',
+            RunStaticWorldContract.SpawnGroundCheckDepth
+        ),
+        0
+    )
+end
+
+function RunStaticWorldValidator.validate(root)
+    if root.Parent ~= Workspace then
+        error('RunStaticWorld must be parented to Workspace before validation.', 0)
+    end
+
+    local collisionRoot =
+        requireContainer(root, RunStaticWorldContract.CollisionRootName, 'RunStaticWorld')
+    local sceneCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.SceneCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local shipCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.ShipCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local triggersRoot =
+        requireContainer(root, RunStaticWorldContract.TriggersRootName, 'RunStaticWorld')
+    local oceanTriggerRoot = requireContainer(
+        triggersRoot,
+        RunStaticWorldContract.OceanTriggerName,
+        'RunStaticWorld Triggers'
+    )
+
+    validateCollisionParts(
+        requireBaseParts(sceneCollisionRoot, 'RunStaticWorld Collision/Scene'),
+        'RunStaticWorld Collision/Scene'
+    )
+    validateCollisionParts(
+        requireBaseParts(shipCollisionRoot, 'RunStaticWorld Collision/Ship'),
+        'RunStaticWorld Collision/Ship'
+    )
+    validateOceanParts(
+        requireBaseParts(oceanTriggerRoot, 'RunStaticWorld Triggers/Ocean'),
+        'RunStaticWorld Triggers/Ocean'
+    )
+
+    local spawnMarker = nil
+    for _, markerName in ipairs(REQUIRED_MARKER_NAMES) do
+        local markerPart = root:FindFirstChild(markerName, true)
+        if markerPart == nil or not markerPart:IsA('BasePart') then
+            error(string.format('RunStaticWorld is missing required part "%s".', markerName), 0)
+        end
+
+        validateMarkerPart(markerPart, string.format('RunStaticWorld marker "%s"', markerName))
+
+        if markerName == 'SpawnMarker' then
+            spawnMarker = markerPart
+        end
+    end
+
+    assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, spawnMarker)
+end
+
+return RunStaticWorldValidator

--- a/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
+++ b/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
@@ -1,21 +1,29 @@
 local Workspace = game:GetService('Workspace')
 
 local RunScene = require(script.Parent.RunScene)
+local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
+local RunStaticWorldValidator = require(script.Parent.RunStaticWorldValidator)
 local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
 
 local RunWorldBuilder = {}
 
-local STATIC_WORLD_ROOT_NAME = 'RunStaticWorld'
-
 function RunWorldBuilder.build()
-    local staticWorldRoot = Workspace:FindFirstChild(STATIC_WORLD_ROOT_NAME)
+    local staticWorldRoot = Workspace:FindFirstChild(RunStaticWorldContract.RootName)
     if staticWorldRoot == nil then
-        error('Workspace is missing required authored root "RunStaticWorld".', 0)
+        error(
+            string.format(
+                'Workspace is missing required authored root "%s".',
+                RunStaticWorldContract.RootName
+            ),
+            0
+        )
     end
 
     if not (staticWorldRoot:IsA('Folder') or staticWorldRoot:IsA('Model')) then
         error('RunStaticWorld must be a Folder or Model.', 0)
     end
+
+    RunStaticWorldValidator.validate(staticWorldRoot)
 
     return RunScene.new(staticWorldRoot)
 end

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -1,6 +1,7 @@
 local Players = game:GetService('Players')
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 local RunService = game:GetService('RunService')
+local TweenService = game:GetService('TweenService')
 local UserInputService = game:GetService('UserInputService')
 
 local localPlayer = Players.LocalPlayer
@@ -39,6 +40,7 @@ local inventorySummary = nil
 local activeShopItems = {}
 local activeSalvageItems = {}
 local activeModal = nil
+local activeBuildFingerprint = 'unknown'
 ensureFirstPersonLock = function()
     disconnectFirstPersonLock = Shared.Client.FirstPersonController.start(localPlayer)
     ensureFirstPersonLock = function() end
@@ -213,6 +215,11 @@ local function buildMazeEntryText(snapshot)
     end
 
     return string.format('%s [%s]', mode, reasonCode)
+end
+
+local function buildFingerprintText(snapshot)
+    local fingerprint = snapshot.BuildFingerprint or activeBuildFingerprint or 'unknown'
+    return string.format('Build: %s', fingerprint)
 end
 
 local menuBackdrop = Instance.new('Frame')
@@ -414,6 +421,27 @@ modalBackdrop.BackgroundTransparency = 0.45
 modalBackdrop.Visible = false
 modalBackdrop.Parent = screenGui
 
+local oceanSplashOverlay = Instance.new('Frame')
+oceanSplashOverlay.Name = 'OceanSplashOverlay'
+oceanSplashOverlay.Size = UDim2.fromScale(1, 1)
+oceanSplashOverlay.BackgroundColor3 = Color3.fromRGB(60, 176, 255)
+oceanSplashOverlay.BackgroundTransparency = 1
+oceanSplashOverlay.BorderSizePixel = 0
+oceanSplashOverlay.Parent = screenGui
+
+local oceanSplashGradient = Instance.new('UIGradient')
+oceanSplashGradient.Rotation = 90
+oceanSplashGradient.Color = ColorSequence.new({
+    ColorSequenceKeypoint.new(0, Color3.fromRGB(140, 220, 255)),
+    ColorSequenceKeypoint.new(1, Color3.fromRGB(32, 100, 164)),
+})
+oceanSplashGradient.Transparency = NumberSequence.new({
+    NumberSequenceKeypoint.new(0, 0.1),
+    NumberSequenceKeypoint.new(0.45, 0.65),
+    NumberSequenceKeypoint.new(1, 0.15),
+})
+oceanSplashGradient.Parent = oceanSplashOverlay
+
 local toastLabel = Instance.new('TextLabel')
 toastLabel.Name = 'Toast'
 toastLabel.AnchorPoint = Vector2.new(0.5, 0.5)
@@ -586,6 +614,32 @@ local function showGoalBanner()
 
     task.delay(3, function()
         goalBanner.Visible = false
+    end)
+end
+
+local function showOceanSplash(message)
+    showToast(message or 'Splash!', 'Success')
+
+    oceanSplashOverlay.BackgroundTransparency = 1
+
+    local flashIn = TweenService:Create(
+        oceanSplashOverlay,
+        TweenInfo.new(0.12, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+        {
+            BackgroundTransparency = 0.82,
+        }
+    )
+    local flashOut = TweenService:Create(
+        oceanSplashOverlay,
+        TweenInfo.new(0.45, Enum.EasingStyle.Quad, Enum.EasingDirection.In),
+        {
+            BackgroundTransparency = 1,
+        }
+    )
+
+    flashIn:Play()
+    flashIn.Completed:Connect(function()
+        flashOut:Play()
     end)
 end
 
@@ -835,11 +889,19 @@ Remotes.RunPrivateState.OnClientEvent:Connect(function(payload)
         end
         return
     end
+
+    if payload.Type == 'OceanSplash' then
+        showOceanSplash(payload.Message)
+        return
+    end
 end)
 
 Remotes.RunState.OnClientEvent:Connect(function(snapshot)
     local hasLaunched = snapshot.IsLaunched == true
     isRunLaunched = hasLaunched
+    if type(snapshot.BuildFingerprint) == 'string' and snapshot.BuildFingerprint ~= '' then
+        activeBuildFingerprint = snapshot.BuildFingerprint
+    end
     if not hasLaunched then
         isCampPanelVisible = true
     end
@@ -861,8 +923,12 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
         canRequestMazeEntry = false
         visibleBackpackItems = {}
         heldItemController:applyInventory(nil)
-        menuStatusLabel.Text =
-            string.format('%s\nMaze Entry: %s', snapshot.Status, buildMazeEntryText(snapshot))
+        menuStatusLabel.Text = string.format(
+            '%s\n%s\nMaze Entry: %s',
+            snapshot.Status,
+            buildFingerprintText(snapshot),
+            buildMazeEntryText(snapshot)
+        )
         singlePlayerButton.Active = true
         singlePlayerButton.AutoButtonColor = true
         singlePlayerButton.Text = string.format('Enter %s', TEMPLE_LABEL)
@@ -876,8 +942,9 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
     canRequestMazeEntry = snapshot.GateOpen == true
 
     statusLabel.Text = string.format(
-        '%s\nArea: %s | Gate: %s | Maze: %s\nEntry: %s',
+        '%s\n%s\nArea: %s | Gate: %s | Maze: %s\nEntry: %s',
         snapshot.Status,
+        buildFingerprintText(snapshot),
         snapshot.Area,
         snapshot.GateOpen and 'Open' or 'Closed',
         snapshot.MazeStatus or 'idle',


### PR DESCRIPTION
## Summary
- add an explicit static-world contract for run collision shells and ocean triggers
- validate authored run static-world structure at boot instead of silently relying on fallback geometry
- harden player init / control-state boot so run session startup no longer dies on missing component config during local Studio iteration

## What changed
- added `Collision/Scene`, `Collision/Ship`, and `Triggers/Ocean` to the run static world contract and default scaffold
- wired scene/ocean trigger support through `RunScene`, `RunInteractionRegistry`, `RunSessionService`, and `RunWorldBuilder`
- surfaced a small build fingerprint / ocean splash feedback path in the run client to help local validation
- made player component init paths tolerate missing `ComponentConfig` and restored `Gameplay.Config.Players` / `ToolItems` exports needed by run boot

## Notes
- this PR only contains the current session's source/config changes
- the validated live Studio scene placement itself was not saved back into `places/run/harness/run.rbxlx`, so this PR does **not** include the temporary in-Studio terrain/ship transform edits
