### PR TITLE
feat(run): add static world collision structure and spawn-grounding system

### DIFF
--- a/places/run/STATIC_WORLD.md
+++ b/places/run/STATIC_WORLD.md
@@ -22,10 +22,23 @@ Required markers:
 - Root attribute `OutdoorThresholdZ`
   Defines the authored Z threshold between `Temple Hall` and `Wilderness`.
 
+Required authored collision structure:
+
+- `Collision/Scene`
+- `Collision/Ship`
+
+Required authored trigger structure:
+
+- `Triggers/Ocean`
+
 Rules:
 
 - Keep all run-only geometry and prompts under `Workspace/RunStaticWorld`.
 - `RunStaticWorld` is the only formal runtime source for the `run` place.
 - `RunWorldBuilder` no longer generates fallback camp or wilderness geometry at runtime.
+- `Collision/Scene` and `Collision/Ship` must contain invisible anchored collision shells.
+- Collision shell parts must use `Anchored=true`, `CanCollide=true`, `CanTouch=false`, `CanQuery=true`, and `Transparency=1`.
+- `Triggers/Ocean` must contain invisible anchored non-collidable trigger parts for water-entry feedback.
 - Missing required markers, prompts, doors, or root attributes must fail loudly at runtime so content issues are fixed in Studio instead of hidden in code.
+- `SpawnMarker` must have a collidable authored floor within 32 studs below it.
 - `MazeGateMarker` is the run-to-maze transition object. Scene code only identifies it; cross-place teleport is handled by the dedicated transition layer.

--- a/places/run/STATIC_WORLD.md
+++ b/places/run/STATIC_WORLD.md
@@ -31,6 +31,10 @@ Required authored trigger structure:
 
 - `Triggers/Ocean`
 
+Required authored terrain model:
+
+- `RunTerrain_Main` (Model) — contains `Scene` and `Sci-Fi Space Ship` visual sub-models. Must be present at boot.
+
 Rules:
 
 - Keep all run-only geometry and prompts under `Workspace/RunStaticWorld`.

--- a/places/run/default.project.json
+++ b/places/run/default.project.json
@@ -212,6 +212,15 @@
             }
           }
         },
+        "RunTerrain_Main": {
+          "$className": "Model",
+          "Scene": {
+            "$className": "Folder"
+          },
+          "Sci-Fi Space Ship": {
+            "$className": "Folder"
+          }
+        },
         "DoorLeft": {
           "$className": "Part",
           "$properties": {

--- a/places/run/default.project.json
+++ b/places/run/default.project.json
@@ -33,19 +33,183 @@
         "SpawnMarker": {
           "$className": "Part",
           "$properties": {
-            "Anchored": true
+            "Anchored": true,
+            "CanCollide": false,
+            "CanTouch": false,
+            "CanQuery": true
           }
         },
         "ReturnMarker": {
           "$className": "Part",
           "$properties": {
-            "Anchored": true
+            "Anchored": true,
+            "CanCollide": false,
+            "CanTouch": false,
+            "CanQuery": true
           }
         },
         "MazeReturnMarker": {
           "$className": "Part",
           "$properties": {
-            "Anchored": true
+            "Anchored": true,
+            "CanCollide": false,
+            "CanTouch": false,
+            "CanQuery": true
+          }
+        },
+        "Collision": {
+          "$className": "Folder",
+          "Scene": {
+            "$className": "Folder",
+            "CampGround": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  50.842907,
+                  6.44950485,
+                  324.177368
+                ],
+                "Size": [
+                  220,
+                  4,
+                  220
+                ]
+              }
+            }
+          },
+          "Ship": {
+            "$className": "Folder",
+            "HullDeckMain": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  49.7613869,
+                  14.4495049,
+                  299.243103
+                ],
+                "Size": [
+                  72,
+                  2,
+                  72
+                ]
+              }
+            },
+            "HullRailNorth": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  49.7613869,
+                  17.4495049,
+                  334.243103
+                ],
+                "Size": [
+                  68,
+                  6,
+                  2
+                ]
+              }
+            },
+            "HullRailSouth": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  49.7613869,
+                  17.4495049,
+                  264.243103
+                ],
+                "Size": [
+                  68,
+                  6,
+                  2
+                ]
+              }
+            },
+            "HullRailEast": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  84.7613869,
+                  17.4495049,
+                  299.243103
+                ],
+                "Size": [
+                  2,
+                  6,
+                  72
+                ]
+              }
+            },
+            "HullRailWest": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  14.7613869,
+                  17.4495049,
+                  299.243103
+                ],
+                "Size": [
+                  2,
+                  6,
+                  72
+                ]
+              }
+            }
+          }
+        },
+        "Triggers": {
+          "$className": "Folder",
+          "Ocean": {
+            "$className": "Folder",
+            "OceanTrigger": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": false,
+                "CanTouch": true,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  575.470703,
+                  8.21289062,
+                  -190.05957
+                ],
+                "Size": [
+                  565,
+                  10,
+                  186.90863
+                ]
+              }
+            }
           }
         },
         "DoorLeft": {

--- a/places/run/src/ServerScriptService/Run/RunScene.luau
+++ b/places/run/src/ServerScriptService/Run/RunScene.luau
@@ -45,31 +45,15 @@ local function requirePart(root, name)
 end
 
 local function requireContainer(parent, name, contextLabel)
-    local child = parent:FindFirstChild(name)
-    if child == nil or not (child:IsA('Folder') or child:IsA('Model')) then
-        error(string.format('%s is missing required container "%s".', contextLabel, name), 0)
-    end
-
-    return child
+    return RunStaticWorldContract.requireContainer(parent, name, contextLabel)
 end
 
 local function collectBaseParts(root)
-    local parts = {}
-
-    for _, descendant in ipairs(root:GetDescendants()) do
-        if descendant:IsA('BasePart') then
-            table.insert(parts, descendant)
-        end
-    end
-
-    return parts
+    return RunStaticWorldContract.collectBaseParts(root)
 end
 
 local function buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
-    local raycastParams = RaycastParams.new()
-    raycastParams.FilterType = Enum.RaycastFilterType.Include
-    raycastParams.FilterDescendantsInstances = { sceneCollisionRoot, shipCollisionRoot }
-    return raycastParams
+    return RunStaticWorldContract.buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
 end
 
 local function groundedSpawnCFrame(part, raycastParams)

--- a/places/run/src/ServerScriptService/Run/RunScene.luau
+++ b/places/run/src/ServerScriptService/Run/RunScene.luau
@@ -1,8 +1,10 @@
 local RunAreaResolver = require(script.Parent.RunAreaResolver)
 local RunDoor = require(script.Parent.RunDoor)
 local RunInteractionRegistry = require(script.Parent.RunInteractionRegistry)
+local RunOceanTrigger = require(script.Parent.RunOceanTrigger)
 local RunPortal = require(script.Parent.RunPortal)
 local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
+local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
 local RunTerminal = require(script.Parent.RunTerminal)
 
 local RunScene = {}
@@ -42,6 +44,59 @@ local function requirePart(root, name)
     return part
 end
 
+local function requireContainer(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not (child:IsA('Folder') or child:IsA('Model')) then
+        error(string.format('%s is missing required container "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function collectBaseParts(root)
+    local parts = {}
+
+    for _, descendant in ipairs(root:GetDescendants()) do
+        if descendant:IsA('BasePart') then
+            table.insert(parts, descendant)
+        end
+    end
+
+    return parts
+end
+
+local function buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
+    local raycastParams = RaycastParams.new()
+    raycastParams.FilterType = Enum.RaycastFilterType.Include
+    raycastParams.FilterDescendantsInstances = { sceneCollisionRoot, shipCollisionRoot }
+    return raycastParams
+end
+
+local function groundedSpawnCFrame(part, raycastParams)
+    local origin = part.Position + Vector3.new(0, (part.Size.Y * 0.5) + 2, 0)
+    local result = workspace:Raycast(
+        origin,
+        Vector3.new(0, -RunStaticWorldContract.SpawnGroundCheckDepth, 0),
+        raycastParams
+    )
+
+    if result and result.Instance and result.Instance.CanCollide and result.Normal.Y > 0.5 then
+        local groundedPosition = Vector3.new(
+            part.Position.X,
+            result.Position.Y + RunStaticWorldContract.SpawnLiftStuds,
+            part.Position.Z
+        )
+        return CFrame.fromMatrix(
+            groundedPosition,
+            part.CFrame.XVector,
+            part.CFrame.YVector,
+            part.CFrame.ZVector
+        )
+    end
+
+    return part.CFrame
+end
+
 function RunScene.new(root)
     if not (root:IsA('Folder') or root:IsA('Model')) then
         error('RunStaticWorld must be a Folder or Model.', 0)
@@ -52,9 +107,32 @@ function RunScene.new(root)
         error('RunStaticWorld is missing required attribute "OutdoorThresholdZ".', 0)
     end
 
+    local collisionRoot =
+        requireContainer(root, RunStaticWorldContract.CollisionRootName, 'RunStaticWorld')
+    local sceneCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.SceneCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local shipCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.ShipCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local triggersRoot =
+        requireContainer(root, RunStaticWorldContract.TriggersRootName, 'RunStaticWorld')
+    local oceanTriggerRoot = requireContainer(
+        triggersRoot,
+        RunStaticWorldContract.OceanTriggerName,
+        'RunStaticWorld Triggers'
+    )
+    local spawnGroundParams = buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
     local spawnPoints = {}
+    local spawnCFramesByKind = {}
     for markerName, kind in pairs(REQUIRED_MARKERS) do
-        spawnPoints[kind] = RunSpawnPoint.new(kind, requirePart(root, markerName))
+        local markerPart = requirePart(root, markerName)
+        spawnPoints[kind] = RunSpawnPoint.new(kind, markerPart)
+        spawnCFramesByKind[kind] = groundedSpawnCFrame(markerPart, spawnGroundParams)
     end
 
     local terminals = {}
@@ -67,6 +145,11 @@ function RunScene.new(root)
         requirePart(root, 'DoorLeft'),
         requirePart(root, 'DoorRight'),
     })
+    local oceanTriggers = {}
+
+    for _, part in ipairs(collectBaseParts(oceanTriggerRoot)) do
+        table.insert(oceanTriggers, RunOceanTrigger.new(part))
+    end
 
     local self = setmetatable({
         Root = root,
@@ -74,12 +157,18 @@ function RunScene.new(root)
         Terminals = terminals,
         MazePortal = mazePortal,
         GateDoor = gateDoor,
+        Collision = {
+            Scene = sceneCollisionRoot,
+            Ship = shipCollisionRoot,
+        },
+        OceanTriggers = oceanTriggers,
         OutdoorThresholdZ = outdoorThresholdZ,
         AreaResolver = nil,
+        SpawnCFramesByKind = spawnCFramesByKind,
 
-        SpawnCFrame = spawnPoints[RunSpawnPoint.Kind.Spawn]:getCFrame(),
-        ReturnCFrame = spawnPoints[RunSpawnPoint.Kind.Return]:getCFrame(),
-        MazeReturnCFrame = spawnPoints[RunSpawnPoint.Kind.MazeReturn]:getCFrame(),
+        SpawnCFrame = spawnCFramesByKind[RunSpawnPoint.Kind.Spawn],
+        ReturnCFrame = spawnCFramesByKind[RunSpawnPoint.Kind.Return],
+        MazeReturnCFrame = spawnCFramesByKind[RunSpawnPoint.Kind.MazeReturn],
         ShopPrompt = terminals.Shop.Prompt,
         SellPrompt = terminals.Sell.Prompt,
         ObjectivePrompt = terminals.Objective.Prompt,
@@ -95,12 +184,12 @@ function RunScene.new(root)
 end
 
 function RunScene:getSpawnCFrame(kind)
-    local spawnPoint = self.SpawnPoints[kind]
-    if spawnPoint == nil then
+    local spawnCFrame = self.SpawnCFramesByKind[kind]
+    if spawnCFrame == nil then
         error(string.format('Unknown run spawn point kind %q.', tostring(kind)), 0)
     end
 
-    return spawnPoint:getCFrame()
+    return spawnCFrame
 end
 
 function RunScene:getAreaForPosition(position)

--- a/places/run/src/ServerScriptService/Run/RunStaticWorldContract.luau
+++ b/places/run/src/ServerScriptService/Run/RunStaticWorldContract.luau
@@ -1,0 +1,14 @@
+local RunStaticWorldContract = table.freeze({
+    RootName = 'RunStaticWorld',
+    CollisionRootName = 'Collision',
+    SceneCollisionName = 'Scene',
+    ShipCollisionName = 'Ship',
+    TriggersRootName = 'Triggers',
+    OceanTriggerName = 'Ocean',
+    BuildFingerprint = 'run-collision-contract-v2',
+    SpawnGroundCheckDepth = 32,
+    SpawnLiftStuds = 4,
+    OceanSplashCooldownSeconds = 1.5,
+})
+
+return RunStaticWorldContract

--- a/places/run/src/ServerScriptService/Run/RunStaticWorldContract.luau
+++ b/places/run/src/ServerScriptService/Run/RunStaticWorldContract.luau
@@ -11,4 +11,37 @@ local RunStaticWorldContract = table.freeze({
     OceanSplashCooldownSeconds = 1.5,
 })
 
+-- Shared helper functions used by both RunScene and RunStaticWorldValidator
+local function requireContainer(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not (child:IsA('Folder') or child:IsA('Model')) then
+        error(string.format('%s is missing required container "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function collectBaseParts(root)
+    local parts = {}
+
+    for _, descendant in ipairs(root:GetDescendants()) do
+        if descendant:IsA('BasePart') then
+            table.insert(parts, descendant)
+        end
+    end
+
+    return parts
+end
+
+local function buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
+    local raycastParams = RaycastParams.new()
+    raycastParams.FilterType = Enum.RaycastFilterType.Include
+    raycastParams.FilterDescendantsInstances = { sceneCollisionRoot, shipCollisionRoot }
+    return raycastParams
+end
+
+RunStaticWorldContract.requireContainer = requireContainer
+RunStaticWorldContract.collectBaseParts = collectBaseParts
+RunStaticWorldContract.buildSpawnGroundParams = buildSpawnGroundParams
+
 return RunStaticWorldContract

--- a/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
+++ b/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
@@ -1,0 +1,213 @@
+local Workspace = game:GetService('Workspace')
+
+local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
+
+local RunStaticWorldValidator = {}
+local REQUIRED_MARKER_NAMES = table.freeze({
+    'SpawnMarker',
+    'ReturnMarker',
+    'MazeReturnMarker',
+})
+
+local function requireContainer(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not (child:IsA('Folder') or child:IsA('Model')) then
+        error(string.format('%s is missing required container "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function collectBaseParts(root)
+    local parts = {}
+
+    for _, descendant in ipairs(root:GetDescendants()) do
+        if descendant:IsA('BasePart') then
+            table.insert(parts, descendant)
+        end
+    end
+
+    return parts
+end
+
+local function requireBaseParts(root, contextLabel)
+    local parts = collectBaseParts(root)
+    if #parts == 0 then
+        error(string.format('%s must contain at least one BasePart.', contextLabel), 0)
+    end
+
+    return parts
+end
+
+local function validateCollisionParts(parts, contextLabel)
+    for _, part in ipairs(parts) do
+        if part.Anchored ~= true then
+            error(string.format('%s part "%s" must be Anchored.', contextLabel, part.Name), 0)
+        end
+        if part.CanCollide ~= true then
+            error(
+                string.format('%s part "%s" must have CanCollide=true.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.CanTouch ~= false then
+            error(
+                string.format('%s part "%s" must have CanTouch=false.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.CanQuery ~= true then
+            error(
+                string.format('%s part "%s" must have CanQuery=true.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.Transparency ~= 1 then
+            error(
+                string.format('%s part "%s" must have Transparency=1.', contextLabel, part.Name),
+                0
+            )
+        end
+    end
+end
+
+local function validateOceanParts(parts, contextLabel)
+    for _, part in ipairs(parts) do
+        if part.Anchored ~= true then
+            error(string.format('%s part "%s" must be Anchored.', contextLabel, part.Name), 0)
+        end
+        if part.CanCollide ~= false then
+            error(
+                string.format('%s part "%s" must have CanCollide=false.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.CanTouch ~= true then
+            error(
+                string.format('%s part "%s" must have CanTouch=true.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.Transparency ~= 1 then
+            error(
+                string.format('%s part "%s" must have Transparency=1.', contextLabel, part.Name),
+                0
+            )
+        end
+    end
+end
+
+local function validateMarkerPart(part, contextLabel)
+    if part.Anchored ~= true then
+        error(string.format('%s must be Anchored.', contextLabel), 0)
+    end
+    if part.CanCollide ~= false then
+        error(string.format('%s must have CanCollide=false.', contextLabel), 0)
+    end
+    if part.CanTouch ~= false then
+        error(string.format('%s must have CanTouch=false.', contextLabel), 0)
+    end
+    if part.CanQuery ~= true then
+        error(string.format('%s must have CanQuery=true.', contextLabel), 0)
+    end
+end
+
+local function buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
+    local raycastParams = RaycastParams.new()
+    raycastParams.FilterType = Enum.RaycastFilterType.Include
+    raycastParams.FilterDescendantsInstances = { sceneCollisionRoot, shipCollisionRoot }
+    return raycastParams
+end
+
+local function buildSpawnGroundSampleOffsets(spawnMarker)
+    local offsetX = math.max(spawnMarker.Size.X * 0.35, 1)
+    local offsetZ = math.max(spawnMarker.Size.Z * 0.35, 1)
+
+    return {
+        Vector3.zero,
+        Vector3.new(offsetX, 0, offsetZ),
+        Vector3.new(offsetX, 0, -offsetZ),
+        Vector3.new(-offsetX, 0, offsetZ),
+        Vector3.new(-offsetX, 0, -offsetZ),
+    }
+end
+
+local function assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, spawnMarker)
+    local raycastParams = buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
+    local sampleOffsets = buildSpawnGroundSampleOffsets(spawnMarker)
+    local raycastDistance = Vector3.new(0, -RunStaticWorldContract.SpawnGroundCheckDepth, 0)
+    local raycastStartHeight = (spawnMarker.Size.Y * 0.5) + 2
+
+    for _, offset in ipairs(sampleOffsets) do
+        local origin = spawnMarker.Position + Vector3.new(offset.X, raycastStartHeight, offset.Z)
+        local result = Workspace:Raycast(origin, raycastDistance, raycastParams)
+        if result and result.Instance and result.Instance.CanCollide and result.Normal.Y > 0.5 then
+            return
+        end
+    end
+
+    error(
+        string.format(
+            'RunStaticWorld SpawnMarker must raycast onto Collision/Scene or Collision/Ship within %d studs below it.',
+            RunStaticWorldContract.SpawnGroundCheckDepth
+        ),
+        0
+    )
+end
+
+function RunStaticWorldValidator.validate(root)
+    if root.Parent ~= Workspace then
+        error('RunStaticWorld must be parented to Workspace before validation.', 0)
+    end
+
+    local collisionRoot =
+        requireContainer(root, RunStaticWorldContract.CollisionRootName, 'RunStaticWorld')
+    local sceneCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.SceneCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local shipCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.ShipCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local triggersRoot =
+        requireContainer(root, RunStaticWorldContract.TriggersRootName, 'RunStaticWorld')
+    local oceanTriggerRoot = requireContainer(
+        triggersRoot,
+        RunStaticWorldContract.OceanTriggerName,
+        'RunStaticWorld Triggers'
+    )
+
+    validateCollisionParts(
+        requireBaseParts(sceneCollisionRoot, 'RunStaticWorld Collision/Scene'),
+        'RunStaticWorld Collision/Scene'
+    )
+    validateCollisionParts(
+        requireBaseParts(shipCollisionRoot, 'RunStaticWorld Collision/Ship'),
+        'RunStaticWorld Collision/Ship'
+    )
+    validateOceanParts(
+        requireBaseParts(oceanTriggerRoot, 'RunStaticWorld Triggers/Ocean'),
+        'RunStaticWorld Triggers/Ocean'
+    )
+
+    local spawnMarker = nil
+    for _, markerName in ipairs(REQUIRED_MARKER_NAMES) do
+        local markerPart = root:FindFirstChild(markerName, true)
+        if markerPart == nil or not markerPart:IsA('BasePart') then
+            error(string.format('RunStaticWorld is missing required part "%s".', markerName), 0)
+        end
+
+        validateMarkerPart(markerPart, string.format('RunStaticWorld marker "%s"', markerName))
+
+        if markerName == 'SpawnMarker' then
+            spawnMarker = markerPart
+        end
+    end
+
+    assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, spawnMarker)
+end
+
+return RunStaticWorldValidator

--- a/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
+++ b/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
@@ -9,29 +9,8 @@ local REQUIRED_MARKER_NAMES = table.freeze({
     'MazeReturnMarker',
 })
 
-local function requireContainer(parent, name, contextLabel)
-    local child = parent:FindFirstChild(name)
-    if child == nil or not (child:IsA('Folder') or child:IsA('Model')) then
-        error(string.format('%s is missing required container "%s".', contextLabel, name), 0)
-    end
-
-    return child
-end
-
-local function collectBaseParts(root)
-    local parts = {}
-
-    for _, descendant in ipairs(root:GetDescendants()) do
-        if descendant:IsA('BasePart') then
-            table.insert(parts, descendant)
-        end
-    end
-
-    return parts
-end
-
 local function requireBaseParts(root, contextLabel)
-    local parts = collectBaseParts(root)
+    local parts = RunStaticWorldContract.collectBaseParts(root)
     if #parts == 0 then
         error(string.format('%s must contain at least one BasePart.', contextLabel), 0)
     end
@@ -113,10 +92,7 @@ local function validateMarkerPart(part, contextLabel)
 end
 
 local function buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
-    local raycastParams = RaycastParams.new()
-    raycastParams.FilterType = Enum.RaycastFilterType.Include
-    raycastParams.FilterDescendantsInstances = { sceneCollisionRoot, shipCollisionRoot }
-    return raycastParams
+    return RunStaticWorldContract.buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
 end
 
 local function buildSpawnGroundSampleOffsets(spawnMarker)
@@ -161,20 +137,20 @@ function RunStaticWorldValidator.validate(root)
     end
 
     local collisionRoot =
-        requireContainer(root, RunStaticWorldContract.CollisionRootName, 'RunStaticWorld')
-    local sceneCollisionRoot = requireContainer(
+        RunStaticWorldContract.requireContainer(root, RunStaticWorldContract.CollisionRootName, 'RunStaticWorld')
+    local sceneCollisionRoot = RunStaticWorldContract.requireContainer(
         collisionRoot,
         RunStaticWorldContract.SceneCollisionName,
         'RunStaticWorld Collision'
     )
-    local shipCollisionRoot = requireContainer(
+    local shipCollisionRoot = RunStaticWorldContract.requireContainer(
         collisionRoot,
         RunStaticWorldContract.ShipCollisionName,
         'RunStaticWorld Collision'
     )
     local triggersRoot =
-        requireContainer(root, RunStaticWorldContract.TriggersRootName, 'RunStaticWorld')
-    local oceanTriggerRoot = requireContainer(
+        RunStaticWorldContract.requireContainer(root, RunStaticWorldContract.TriggersRootName, 'RunStaticWorld')
+    local oceanTriggerRoot = RunStaticWorldContract.requireContainer(
         triggersRoot,
         RunStaticWorldContract.OceanTriggerName,
         'RunStaticWorld Triggers'

--- a/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
+++ b/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
@@ -1,21 +1,57 @@
 local Workspace = game:GetService('Workspace')
 
 local RunScene = require(script.Parent.RunScene)
+local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
+local RunStaticWorldValidator = require(script.Parent.RunStaticWorldValidator)
 local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
 
 local RunWorldBuilder = {}
 
-local STATIC_WORLD_ROOT_NAME = 'RunStaticWorld'
+local function stabilizeVisualModel(model)
+    if model == nil then
+        return
+    end
+
+    for _, descendant in ipairs(model:GetDescendants()) do
+        if descendant:IsA('BasePart') then
+            descendant.Anchored = true
+            descendant.CanCollide = false
+            descendant.CanTouch = false
+            descendant.CanQuery = true
+            descendant.AssemblyLinearVelocity = Vector3.zero
+            descendant.AssemblyAngularVelocity = Vector3.zero
+        end
+    end
+end
+
+local function prepareRunTerrain(root)
+    local terrainRoot = root:FindFirstChild('RunTerrain_Main')
+    if terrainRoot == nil or not terrainRoot:IsA('Model') then
+        return
+    end
+
+    stabilizeVisualModel(terrainRoot:FindFirstChild('Scene'))
+    stabilizeVisualModel(terrainRoot:FindFirstChild('Sci-Fi Space Ship'))
+end
 
 function RunWorldBuilder.build()
-    local staticWorldRoot = Workspace:FindFirstChild(STATIC_WORLD_ROOT_NAME)
+    local staticWorldRoot = Workspace:FindFirstChild(RunStaticWorldContract.RootName)
     if staticWorldRoot == nil then
-        error('Workspace is missing required authored root "RunStaticWorld".', 0)
+        error(
+            string.format(
+                'Workspace is missing required authored root "%s".',
+                RunStaticWorldContract.RootName
+            ),
+            0
+        )
     end
 
     if not (staticWorldRoot:IsA('Folder') or staticWorldRoot:IsA('Model')) then
         error('RunStaticWorld must be a Folder or Model.', 0)
     end
+
+    prepareRunTerrain(staticWorldRoot)
+    RunStaticWorldValidator.validate(staticWorldRoot)
 
     return RunScene.new(staticWorldRoot)
 end

--- a/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
+++ b/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
@@ -27,7 +27,7 @@ end
 local function prepareRunTerrain(root)
     local terrainRoot = root:FindFirstChild('RunTerrain_Main')
     if terrainRoot == nil or not terrainRoot:IsA('Model') then
-        return
+        error('RunStaticWorld is missing required authored terrain model "RunTerrain_Main".', 0)
     end
 
     stabilizeVisualModel(terrainRoot:FindFirstChild('Scene'))

--- a/tests/src/Shared/RunScene.spec.luau
+++ b/tests/src/Shared/RunScene.spec.luau
@@ -1,5 +1,6 @@
 return function()
     local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local Workspace = game:GetService('Workspace')
 
     local runModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Run')
     local RunScene = require(runModules:WaitForChild('RunScene'))
@@ -8,6 +9,27 @@ return function()
     local root = Instance.new('Folder')
     root.Name = 'RunStaticWorld'
     root:SetAttribute('OutdoorThresholdZ', 50)
+    root.Parent = Workspace
+
+    local collisionRoot = Instance.new('Folder')
+    collisionRoot.Name = 'Collision'
+    collisionRoot.Parent = root
+
+    local sceneCollisionRoot = Instance.new('Folder')
+    sceneCollisionRoot.Name = 'Scene'
+    sceneCollisionRoot.Parent = collisionRoot
+
+    local shipCollisionRoot = Instance.new('Folder')
+    shipCollisionRoot.Name = 'Ship'
+    shipCollisionRoot.Parent = collisionRoot
+
+    local triggersRoot = Instance.new('Folder')
+    triggersRoot.Name = 'Triggers'
+    triggersRoot.Parent = root
+
+    local oceanTriggerRoot = Instance.new('Folder')
+    oceanTriggerRoot.Name = 'Ocean'
+    oceanTriggerRoot.Parent = triggersRoot
 
     local function createPromptPart(name, z)
         local part = Instance.new('Part')
@@ -25,18 +47,27 @@ return function()
     local spawnMarker = Instance.new('Part')
     spawnMarker.Name = 'SpawnMarker'
     spawnMarker.Anchored = true
+    spawnMarker.CanCollide = false
+    spawnMarker.CanTouch = false
+    spawnMarker.CanQuery = true
     spawnMarker.CFrame = CFrame.new(0, 4, 0)
     spawnMarker.Parent = root
 
     local returnMarker = Instance.new('Part')
     returnMarker.Name = 'ReturnMarker'
     returnMarker.Anchored = true
+    returnMarker.CanCollide = false
+    returnMarker.CanTouch = false
+    returnMarker.CanQuery = true
     returnMarker.CFrame = CFrame.new(0, 4, 8)
     returnMarker.Parent = root
 
     local mazeReturnMarker = Instance.new('Part')
     mazeReturnMarker.Name = 'MazeReturnMarker'
     mazeReturnMarker.Anchored = true
+    mazeReturnMarker.CanCollide = false
+    mazeReturnMarker.CanTouch = false
+    mazeReturnMarker.CanQuery = true
     mazeReturnMarker.CFrame = CFrame.new(0, 4, 64)
     mazeReturnMarker.Parent = root
 
@@ -50,6 +81,34 @@ return function()
     doorRight.Anchored = true
     doorRight.Parent = root
 
+    local sceneFloor = Instance.new('Part')
+    sceneFloor.Name = 'SceneFloor'
+    sceneFloor.Anchored = true
+    sceneFloor.CanCollide = true
+    sceneFloor.CanTouch = false
+    sceneFloor.CanQuery = true
+    sceneFloor.Transparency = 1
+    sceneFloor.Parent = sceneCollisionRoot
+
+    local shipDeck = Instance.new('Part')
+    shipDeck.Name = 'ShipDeck'
+    shipDeck.Anchored = true
+    shipDeck.CanCollide = true
+    shipDeck.CanTouch = false
+    shipDeck.CanQuery = true
+    shipDeck.Transparency = 1
+    shipDeck.CFrame = CFrame.new(0, 0, 0)
+    shipDeck.Size = Vector3.new(24, 1, 24)
+    shipDeck.Parent = shipCollisionRoot
+
+    local oceanTrigger = Instance.new('Part')
+    oceanTrigger.Name = 'OceanSurface'
+    oceanTrigger.Anchored = true
+    oceanTrigger.CanCollide = false
+    oceanTrigger.CanTouch = true
+    oceanTrigger.Transparency = 1
+    oceanTrigger.Parent = oceanTriggerRoot
+
     createPromptPart('ShopTerminal', 0)
     createPromptPart('SalvageTerminal', 2)
     createPromptPart('ObjectiveBoard', 4)
@@ -61,12 +120,16 @@ return function()
     local scene = RunScene.new(root)
 
     assert(
-        scene:getSpawnCFrame(RunSpawnPoint.Kind.Spawn) == spawnMarker.CFrame,
-        'RunScene should expose the authored spawn marker'
+        math.abs(scene:getSpawnCFrame(RunSpawnPoint.Kind.Spawn).Position.Y - 4.5) < 0.001,
+        'RunScene should lift grounded spawn points above authored collision shells'
     )
     assert(
-        scene:getSpawnCFrame(RunSpawnPoint.Kind.Return) == returnMarker.CFrame,
-        'RunScene should expose the authored return marker'
+        math.abs(scene:getSpawnCFrame(RunSpawnPoint.Kind.Return).Position.Y - 4.5) < 0.001,
+        'RunScene should also ground return markers when collision exists beneath them'
+    )
+    assert(
+        scene:getSpawnCFrame(RunSpawnPoint.Kind.MazeReturn) == mazeReturnMarker.CFrame,
+        'RunScene should fall back to the authored marker when no collision shell exists beneath it'
     )
     assert(
         scene:getAreaForPosition(Vector3.new(0, 0, 80)) == 'Wilderness',
@@ -76,9 +139,17 @@ return function()
         scene:getAreaForPosition(Vector3.new(0, 0, 20)) == 'Temple Hall',
         'RunScene should classify interior positions as temple hall'
     )
+    assert(
+        scene.Collision.Scene == sceneCollisionRoot,
+        'RunScene should expose scene collision root'
+    )
+    assert(scene.Collision.Ship == shipCollisionRoot, 'RunScene should expose ship collision root')
+    assert(#scene.OceanTriggers == 1, 'RunScene should expose authored ocean triggers')
 
     scene:openGate()
     assert(doorLeft.Transparency == 1, 'RunScene gate opening should hide the left door')
     assert(doorRight.Transparency == 1, 'RunScene gate opening should hide the right door')
     assert(gatePrompt.ActionText == 'Gate Open', 'RunScene should update gate prompt copy')
+
+    root:Destroy()
 end

--- a/tests/src/Shared/RunWorldBuilderStaticWorld.spec.luau
+++ b/tests/src/Shared/RunWorldBuilderStaticWorld.spec.luau
@@ -4,13 +4,43 @@ return function()
 
     local runModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Run')
     local builder = require(runModules:WaitForChild('RunWorldBuilder'))
+    local RunStaticWorldContract = require(runModules:WaitForChild('RunStaticWorldContract'))
 
-    local root = Instance.new('Folder')
-    root.Name = 'RunStaticWorld'
-    root:SetAttribute('OutdoorThresholdZ', 88)
-    root.Parent = Workspace
+    local function createRunStaticWorldRoot(outdoorThresholdZ)
+        local root = Instance.new('Folder')
+        root.Name = 'RunStaticWorld'
+        root:SetAttribute('OutdoorThresholdZ', outdoorThresholdZ or 88)
+        root.Parent = Workspace
 
-    local function createPromptPart(name, cframe)
+        local collisionRoot = Instance.new('Folder')
+        collisionRoot.Name = 'Collision'
+        collisionRoot.Parent = root
+
+        local sceneCollisionRoot = Instance.new('Folder')
+        sceneCollisionRoot.Name = 'Scene'
+        sceneCollisionRoot.Parent = collisionRoot
+
+        local shipCollisionRoot = Instance.new('Folder')
+        shipCollisionRoot.Name = 'Ship'
+        shipCollisionRoot.Parent = collisionRoot
+
+        local triggersRoot = Instance.new('Folder')
+        triggersRoot.Name = 'Triggers'
+        triggersRoot.Parent = root
+
+        local oceanTriggerRoot = Instance.new('Folder')
+        oceanTriggerRoot.Name = 'Ocean'
+        oceanTriggerRoot.Parent = triggersRoot
+
+        return {
+            Root = root,
+            SceneCollisionRoot = sceneCollisionRoot,
+            ShipCollisionRoot = shipCollisionRoot,
+            OceanTriggerRoot = oceanTriggerRoot,
+        }
+    end
+
+    local function createPromptPart(root, name, cframe)
         local part = Instance.new('Part')
         part.Name = name
         part.Anchored = true
@@ -23,52 +53,129 @@ return function()
         return part, prompt
     end
 
-    local spawnMarker = Instance.new('Part')
-    spawnMarker.Name = 'SpawnMarker'
-    spawnMarker.Anchored = true
-    spawnMarker.CFrame = CFrame.new(10, 4, -3)
-    spawnMarker.Parent = root
+    local function createCollisionPart(parent, name, cframe, size)
+        local part = Instance.new('Part')
+        part.Name = name
+        part.Anchored = true
+        part.CanCollide = true
+        part.CanTouch = false
+        part.CanQuery = true
+        part.Transparency = 1
+        part.Size = size or Vector3.new(12, 1, 12)
+        part.CFrame = cframe or CFrame.new()
+        part.Parent = parent
+        return part
+    end
 
-    local returnMarker = Instance.new('Part')
-    returnMarker.Name = 'ReturnMarker'
-    returnMarker.Anchored = true
-    returnMarker.CFrame = CFrame.new(11, 4, -1)
-    returnMarker.Parent = root
+    local function createOceanTrigger(parent, name, cframe, size)
+        local part = Instance.new('Part')
+        part.Name = name or 'OceanSurface'
+        part.Anchored = true
+        part.CanCollide = false
+        part.CanTouch = true
+        part.Transparency = 1
+        part.Size = size or Vector3.new(64, 2, 64)
+        part.CFrame = cframe or CFrame.new()
+        part.Parent = parent
+        return part
+    end
 
-    local mazeReturnMarker = Instance.new('Part')
-    mazeReturnMarker.Name = 'MazeReturnMarker'
-    mazeReturnMarker.Anchored = true
-    mazeReturnMarker.CFrame = CFrame.new(3, 4, 120)
-    mazeReturnMarker.Parent = root
+    local function createMarker(root, name, cframe)
+        local marker = Instance.new('Part')
+        marker.Name = name
+        marker.Anchored = true
+        marker.CanCollide = false
+        marker.CanTouch = false
+        marker.CanQuery = true
+        marker.Size = Vector3.new(4, 1, 4)
+        marker.CFrame = cframe
+        marker.Parent = root
+        return marker
+    end
 
-    local doorLeft = Instance.new('Part')
-    doorLeft.Name = 'DoorLeft'
-    doorLeft.Anchored = true
-    doorLeft.Parent = root
+    local function createRequiredPromptParts(root, originX, originZ)
+        local promptNames = {
+            'ShopTerminal',
+            'SalvageTerminal',
+            'ObjectiveBoard',
+            'LoadoutBench',
+            'UgcLabConsole',
+            'GateSwitch',
+            'MazeGateMarker',
+        }
 
-    local doorRight = Instance.new('Part')
-    doorRight.Name = 'DoorRight'
-    doorRight.Anchored = true
-    doorRight.Parent = root
+        local prompts = {}
+        for index, name in ipairs(promptNames) do
+            local part, prompt =
+                createPromptPart(root, name, CFrame.new(originX + index * 4, 4, originZ))
+            prompts[name] = {
+                Part = part,
+                Prompt = prompt,
+            }
+        end
 
-    local _, shopPrompt = createPromptPart('ShopTerminal')
-    local _, sellPrompt = createPromptPart('SalvageTerminal')
-    local _, objectivePrompt = createPromptPart('ObjectiveBoard')
-    local _, loadoutPrompt = createPromptPart('LoadoutBench')
-    local _, ugcLabPrompt = createPromptPart('UgcLabConsole')
-    local _, gatePrompt = createPromptPart('GateSwitch')
-    local _, mazePrompt = createPromptPart('MazeGateMarker')
+        return prompts
+    end
+
+    local validWorld = createRunStaticWorldRoot(88)
+    createMarker(validWorld.Root, 'SpawnMarker', CFrame.new(10, 4, -3))
+    createMarker(validWorld.Root, 'ReturnMarker', CFrame.new(11, 4, -1))
+    local mazeReturnMarker =
+        createMarker(validWorld.Root, 'MazeReturnMarker', CFrame.new(3, 4, 120))
+    local doorLeft = createMarker(validWorld.Root, 'DoorLeft', CFrame.new(8, 4, 16))
+    local doorRight = createMarker(validWorld.Root, 'DoorRight', CFrame.new(12, 4, 16))
+    local validPrompts = createRequiredPromptParts(validWorld.Root, 10, 20)
+
+    local runTerrainMain = Instance.new('Model')
+    runTerrainMain.Name = 'RunTerrain_Main'
+    runTerrainMain.Parent = validWorld.Root
+
+    local visualScene = Instance.new('Model')
+    visualScene.Name = 'Scene'
+    visualScene.Parent = runTerrainMain
+
+    local visualScenePart = Instance.new('Part')
+    visualScenePart.Name = 'VisualScenePart'
+    visualScenePart.Anchored = false
+    visualScenePart.CanCollide = true
+    visualScenePart.Parent = visualScene
+
+    local visualShip = Instance.new('Model')
+    visualShip.Name = 'Sci-Fi Space Ship'
+    visualShip.Parent = runTerrainMain
+
+    local visualShipPart = Instance.new('Part')
+    visualShipPart.Name = 'VisualShipPart'
+    visualShipPart.Anchored = false
+    visualShipPart.CanCollide = true
+    visualShipPart.Parent = visualShip
+
+    createCollisionPart(
+        validWorld.SceneCollisionRoot,
+        'SpawnFloor',
+        CFrame.new(10, 0, -3),
+        Vector3.new(24, 1, 24)
+    )
+    createCollisionPart(
+        validWorld.ShipCollisionRoot,
+        'ShipDeck',
+        CFrame.new(24, 6, 12),
+        Vector3.new(16, 1, 16)
+    )
+    createOceanTrigger(validWorld.OceanTriggerRoot, 'OceanSurface', CFrame.new(10, -8, -3))
 
     local world = builder.build()
 
-    assert(world.Root == root, 'Run static world should preserve the authored root')
+    assert(world.Root == validWorld.Root, 'Run static world should preserve the authored root')
     assert(
-        world.SpawnCFrame == spawnMarker.CFrame,
-        'Run static world should expose the authored spawn marker'
+        math.abs(world.SpawnCFrame.Position.Y - (0.5 + RunStaticWorldContract.SpawnLiftStuds))
+            < 0.001,
+        'Run static world should lift the spawn point above authored collision shells'
     )
     assert(
-        world.ReturnCFrame == returnMarker.CFrame,
-        'Run static world should expose the authored return marker'
+        math.abs(world.ReturnCFrame.Position.Y - (0.5 + RunStaticWorldContract.SpawnLiftStuds))
+            < 0.001,
+        'Run static world should also lift grounded return markers above collision shells'
     )
     assert(
         world.MazeReturnCFrame == mazeReturnMarker.CFrame,
@@ -78,71 +185,237 @@ return function()
         world.OutdoorThresholdZ == 88,
         'Run static world should expose the authored outdoor threshold'
     )
-    assert(world.ShopPrompt == shopPrompt, 'Run static world should expose the shop prompt')
-    assert(world.SellPrompt == sellPrompt, 'Run static world should expose the salvage prompt')
     assert(
-        world.ObjectivePrompt == objectivePrompt,
+        world.ShopPrompt == validPrompts.ShopTerminal.Prompt,
+        'Run static world should expose the shop prompt'
+    )
+    assert(
+        world.SellPrompt == validPrompts.SalvageTerminal.Prompt,
+        'Run static world should expose the salvage prompt'
+    )
+    assert(
+        world.ObjectivePrompt == validPrompts.ObjectiveBoard.Prompt,
         'Run static world should expose the objective prompt'
     )
     assert(
-        world.LoadoutPrompt == loadoutPrompt,
+        world.LoadoutPrompt == validPrompts.LoadoutBench.Prompt,
         'Run static world should expose the loadout prompt'
     )
-    assert(world.UgcLabPrompt == ugcLabPrompt, 'Run static world should expose the UGC lab prompt')
-    assert(world.GatePrompt == gatePrompt, 'Run static world should expose the gate prompt')
-    assert(world.MazePrompt == mazePrompt, 'Run static world should expose the maze prompt')
+    assert(
+        world.UgcLabPrompt == validPrompts.UgcLabConsole.Prompt,
+        'Run static world should expose the UGC lab prompt'
+    )
+    assert(
+        world.GatePrompt == validPrompts.GateSwitch.Prompt,
+        'Run static world should expose the gate prompt'
+    )
+    assert(
+        world.MazePrompt == validPrompts.MazeGateMarker.Prompt,
+        'Run static world should expose the maze prompt'
+    )
+    assert(#world.OceanTriggers == 1, 'Run static world should expose authored ocean trigger parts')
+    assert(
+        visualScenePart.Anchored == true and visualScenePart.CanCollide == false,
+        'Run world builder should stabilize scene visual parts instead of letting them carry physics'
+    )
+    assert(
+        visualShipPart.Anchored == true and visualShipPart.CanCollide == false,
+        'Run world builder should stabilize ship visual parts instead of letting them break apart'
+    )
 
     world.OpenGate()
     assert(doorLeft.Transparency == 1, 'Opening the static gate should hide the left door')
     assert(doorRight.Transparency == 1, 'Opening the static gate should hide the right door')
     assert(
-        gatePrompt.ActionText == 'Gate Open',
+        validPrompts.GateSwitch.Prompt.ActionText == 'Gate Open',
         'Opening the static gate should update the prompt copy'
     )
 
-    root:Destroy()
+    validWorld.Root:Destroy()
 
-    local invalidRoot = Instance.new('Folder')
-    invalidRoot.Name = 'RunStaticWorld'
-    invalidRoot:SetAttribute('OutdoorThresholdZ', 12)
-    invalidRoot.Parent = Workspace
+    local missingPromptWorld = createRunStaticWorldRoot(12)
+    createMarker(missingPromptWorld.Root, 'SpawnMarker', CFrame.new(0, 4, 0))
+    createMarker(missingPromptWorld.Root, 'ReturnMarker', CFrame.new(4, 4, 0))
+    createMarker(missingPromptWorld.Root, 'MazeReturnMarker', CFrame.new(8, 4, 0))
+    createMarker(missingPromptWorld.Root, 'DoorLeft', CFrame.new(0, 2, 12))
+    createMarker(missingPromptWorld.Root, 'DoorRight', CFrame.new(4, 2, 12))
+    createCollisionPart(
+        missingPromptWorld.SceneCollisionRoot,
+        'SceneFloor',
+        CFrame.new(0, 0, 0),
+        Vector3.new(24, 1, 24)
+    )
+    createCollisionPart(
+        missingPromptWorld.ShipCollisionRoot,
+        'ShipDeck',
+        CFrame.new(16, 4, 0),
+        Vector3.new(16, 1, 16)
+    )
+    createOceanTrigger(missingPromptWorld.OceanTriggerRoot, 'OceanSurface', CFrame.new(0, -6, 0))
 
-    local invalidSpawn = Instance.new('Part')
-    invalidSpawn.Name = 'SpawnMarker'
-    invalidSpawn.Anchored = true
-    invalidSpawn.Parent = invalidRoot
-
-    local invalidReturn = Instance.new('Part')
-    invalidReturn.Name = 'ReturnMarker'
-    invalidReturn.Anchored = true
-    invalidReturn.Parent = invalidRoot
-
-    local invalidMazeReturn = Instance.new('Part')
-    invalidMazeReturn.Name = 'MazeReturnMarker'
-    invalidMazeReturn.Anchored = true
-    invalidMazeReturn.Parent = invalidRoot
-
-    local invalidDoorLeft = Instance.new('Part')
-    invalidDoorLeft.Name = 'DoorLeft'
-    invalidDoorLeft.Anchored = true
-    invalidDoorLeft.Parent = invalidRoot
-
-    local invalidDoorRight = Instance.new('Part')
-    invalidDoorRight.Name = 'DoorRight'
-    invalidDoorRight.Anchored = true
-    invalidDoorRight.Parent = invalidRoot
-
-    local ok, err = pcall(function()
+    local missingPromptOk, missingPromptErr = pcall(function()
         builder.build()
     end)
     assert(
-        ok == false,
+        missingPromptOk == false,
         'Run static world should fail loudly when required prompt parts are missing'
     )
     assert(
-        string.find(tostring(err), 'ShopTerminal', 1, true) ~= nil,
+        string.find(tostring(missingPromptErr), 'ShopTerminal', 1, true) ~= nil,
         'Run static world failures should mention the missing prompt part'
     )
 
-    invalidRoot:Destroy()
+    missingPromptWorld.Root:Destroy()
+
+    local missingFloorWorld = createRunStaticWorldRoot(24)
+    createMarker(missingFloorWorld.Root, 'SpawnMarker', CFrame.new(0, 20, 0))
+    createMarker(missingFloorWorld.Root, 'ReturnMarker', CFrame.new(4, 4, 0))
+    createMarker(missingFloorWorld.Root, 'MazeReturnMarker', CFrame.new(8, 4, 0))
+    createMarker(missingFloorWorld.Root, 'DoorLeft', CFrame.new(40, 2, 40))
+    createMarker(missingFloorWorld.Root, 'DoorRight', CFrame.new(44, 2, 40))
+    createRequiredPromptParts(missingFloorWorld.Root, 60, 60)
+    createCollisionPart(
+        missingFloorWorld.SceneCollisionRoot,
+        'SceneShelf',
+        CFrame.new(20, 0, 20),
+        Vector3.new(12, 1, 12)
+    )
+    createCollisionPart(
+        missingFloorWorld.ShipCollisionRoot,
+        'ShipDeck',
+        CFrame.new(30, 4, 30),
+        Vector3.new(16, 1, 16)
+    )
+    createOceanTrigger(missingFloorWorld.OceanTriggerRoot)
+
+    local missingFloorOk, missingFloorErr = pcall(function()
+        builder.build()
+    end)
+    assert(
+        missingFloorOk == false,
+        'Run static world should fail loudly when SpawnMarker has no authored floor below it'
+    )
+    assert(
+        string.find(tostring(missingFloorErr), 'SpawnMarker must raycast onto', 1, true) ~= nil,
+        'Missing spawn floor failures should mention the authored collision floor requirement'
+    )
+
+    missingFloorWorld.Root:Destroy()
+
+    local strayColliderWorld = createRunStaticWorldRoot(42)
+    createMarker(strayColliderWorld.Root, 'SpawnMarker', CFrame.new(0, 8, 0))
+    createMarker(strayColliderWorld.Root, 'ReturnMarker', CFrame.new(4, 4, 0))
+    createMarker(strayColliderWorld.Root, 'MazeReturnMarker', CFrame.new(8, 4, 0))
+    createMarker(strayColliderWorld.Root, 'DoorLeft', CFrame.new(0, 2, 12))
+    createMarker(strayColliderWorld.Root, 'DoorRight', CFrame.new(4, 2, 12))
+    createRequiredPromptParts(strayColliderWorld.Root, 40, 10)
+    createCollisionPart(
+        strayColliderWorld.SceneCollisionRoot,
+        'SceneDecoration',
+        CFrame.new(30, 2, 30),
+        Vector3.new(12, 1, 12)
+    )
+    createCollisionPart(
+        strayColliderWorld.ShipCollisionRoot,
+        'ShipDeck',
+        CFrame.new(32, 2, 32),
+        Vector3.new(16, 1, 16)
+    )
+    createOceanTrigger(strayColliderWorld.OceanTriggerRoot)
+
+    local fakeFloor = Instance.new('Part')
+    fakeFloor.Name = 'FakeFloor'
+    fakeFloor.Anchored = true
+    fakeFloor.CanCollide = true
+    fakeFloor.Size = Vector3.new(20, 1, 20)
+    fakeFloor.CFrame = CFrame.new(0, 2, 0)
+    fakeFloor.Parent = strayColliderWorld.Root
+
+    local strayColliderOk, strayColliderErr = pcall(function()
+        builder.build()
+    end)
+    assert(
+        strayColliderOk == false,
+        'Run static world should reject ordinary root-level collidable parts as spawn floors'
+    )
+    assert(
+        string.find(tostring(strayColliderErr), 'SpawnMarker must raycast onto', 1, true) ~= nil,
+        'Ordinary root-level blockers should not satisfy the authored collision floor requirement'
+    )
+
+    strayColliderWorld.Root:Destroy()
+
+    local edgeGapWorld = createRunStaticWorldRoot(58)
+    createMarker(edgeGapWorld.Root, 'SpawnMarker', CFrame.new(0, 8, 0))
+    createMarker(edgeGapWorld.Root, 'ReturnMarker', CFrame.new(4, 4, 0))
+    createMarker(edgeGapWorld.Root, 'MazeReturnMarker', CFrame.new(8, 4, 0))
+    createMarker(edgeGapWorld.Root, 'DoorLeft', CFrame.new(0, 2, 10))
+    createMarker(edgeGapWorld.Root, 'DoorRight', CFrame.new(4, 2, 10))
+    createRequiredPromptParts(edgeGapWorld.Root, 40, 10)
+    createCollisionPart(
+        edgeGapWorld.SceneCollisionRoot,
+        'TinyCenterFloor',
+        CFrame.new(0, 2, 0),
+        Vector3.new(1, 1, 1)
+    )
+    createCollisionPart(
+        edgeGapWorld.ShipCollisionRoot,
+        'ShipDeck',
+        CFrame.new(30, 2, 30),
+        Vector3.new(16, 1, 16)
+    )
+    createOceanTrigger(edgeGapWorld.OceanTriggerRoot)
+
+    local edgeGapOk, edgeGapErr = pcall(function()
+        builder.build()
+    end)
+    assert(
+        edgeGapOk == false,
+        'Run static world should reject a spawn floor that only supports the center point'
+    )
+    assert(
+        string.find(tostring(edgeGapErr), 'SpawnMarker must raycast onto', 1, true) ~= nil,
+        'Edge-gap failures should mention the authored collision floor requirement'
+    )
+
+    edgeGapWorld.Root:Destroy()
+
+    local collidableMarkerWorld = createRunStaticWorldRoot(64)
+    local collidableSpawnMarker =
+        createMarker(collidableMarkerWorld.Root, 'SpawnMarker', CFrame.new(0, 8, 0))
+    createMarker(collidableMarkerWorld.Root, 'ReturnMarker', CFrame.new(4, 4, 0))
+    createMarker(collidableMarkerWorld.Root, 'MazeReturnMarker', CFrame.new(8, 4, 0))
+    createMarker(collidableMarkerWorld.Root, 'DoorLeft', CFrame.new(0, 2, 10))
+    createMarker(collidableMarkerWorld.Root, 'DoorRight', CFrame.new(4, 2, 10))
+    createRequiredPromptParts(collidableMarkerWorld.Root, 40, 10)
+    createCollisionPart(
+        collidableMarkerWorld.SceneCollisionRoot,
+        'SceneFloor',
+        CFrame.new(0, 2, 0),
+        Vector3.new(24, 1, 24)
+    )
+    createCollisionPart(
+        collidableMarkerWorld.ShipCollisionRoot,
+        'ShipDeck',
+        CFrame.new(30, 2, 30),
+        Vector3.new(16, 1, 16)
+    )
+    createOceanTrigger(collidableMarkerWorld.OceanTriggerRoot)
+    collidableSpawnMarker.CanCollide = true
+
+    local collidableMarkerOk, collidableMarkerErr = pcall(function()
+        builder.build()
+    end)
+    assert(collidableMarkerOk == false, 'Run static world should reject collidable spawn markers')
+    assert(
+        string.find(
+            tostring(collidableMarkerErr),
+            'RunStaticWorld marker "SpawnMarker" must have CanCollide=false.',
+            1,
+            true
+        ) ~= nil,
+        'Marker validation should mention that spawn markers must not block player movement'
+    )
+
+    collidableMarkerWorld.Root:Destroy()
 end


### PR DESCRIPTION
## 改动

- **Collision 结构**：新增 `Collision/Scene` 和 `Collision/Ship` 碰撞壳
- **出生点贴地**：使用 RaycastParams 从 SpawnMarker 向下检测，自动抬升 Y 坐标
- **Fail-loud**：RunTerrain_Main 缺失时报错
- **代码去重**：辅助函数提取到 `RunStaticWorldContract`

## 新增文件

- `RunStaticWorldContract.luau` — 常量契约 + 共享工具函数
- `RunStaticWorldValidator.luau` — 静态世界结构验证器

🤖 Generated with [Claude Code](https://claude.com/claude-code)