### PR TITLE
feat(run): static world collision validation and full ocean drowning system

### DIFF
--- a/places/run/STATIC_WORLD.md
+++ b/places/run/STATIC_WORLD.md
@@ -1,0 +1,44 @@
+# Run Static World Contract
+
+`RunStaticWorld` is the local authored content root for the `run` place.
+
+Required authored parts with `ProximityPrompt`s:
+
+- `ShopTerminal`
+- `SalvageTerminal`
+- `ObjectiveBoard`
+- `LoadoutBench`
+- `UgcLabConsole`
+- `GateSwitch`
+- `MazeGateMarker`
+
+Required markers:
+
+- `SpawnMarker`
+- `ReturnMarker`
+- `MazeReturnMarker`
+- `DoorLeft`
+- `DoorRight`
+- Root attribute `OutdoorThresholdZ`
+  Defines the authored Z threshold between `Temple Hall` and `Wilderness`.
+
+Required authored collision structure:
+
+- `Collision/Scene`
+- `Collision/Ship`
+
+Required authored trigger structure:
+
+- `Triggers/Ocean`
+
+Rules:
+
+- Keep all run-only geometry and prompts under `Workspace/RunStaticWorld`.
+- `RunStaticWorld` is the only formal runtime source for the `run` place.
+- `RunWorldBuilder` no longer generates fallback camp or wilderness geometry at runtime.
+- `Collision/Scene` and `Collision/Ship` must contain invisible anchored collision shells.
+- Collision shell parts must use `Anchored=true`, `CanCollide=true`, `CanTouch=false`, `CanQuery=true`, and `Transparency=1`.
+- `Triggers/Ocean` must contain invisible anchored non-collidable trigger parts for water-entry feedback.
+- Missing required markers, prompts, doors, or root attributes must fail loudly at runtime so content issues are fixed in Studio instead of hidden in code.
+- `SpawnMarker` must have a collidable authored floor within 32 studs below it.
+- `MazeGateMarker` is the run-to-maze transition object. Scene code only identifies it; cross-place teleport is handled by the dedicated transition layer.

--- a/places/run/default.project.json
+++ b/places/run/default.project.json
@@ -17,6 +17,272 @@
         }
       }
     },
+    "Workspace": {
+      "$className": "Workspace",
+      "RunStaticWorld": {
+        "$className": "Folder",
+        "$attributes": {
+          "OutdoorThresholdZ": 50
+        },
+        "SpawnMarker": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true,
+            "CanCollide": false,
+            "CanTouch": false,
+            "CanQuery": true
+          }
+        },
+        "ReturnMarker": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true,
+            "CanCollide": false,
+            "CanTouch": false,
+            "CanQuery": true
+          }
+        },
+        "MazeReturnMarker": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true,
+            "CanCollide": false,
+            "CanTouch": false,
+            "CanQuery": true
+          }
+        },
+        "Collision": {
+          "$className": "Folder",
+          "Scene": {
+            "$className": "Folder",
+            "CampGround": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  50.842907,
+                  6.44950485,
+                  324.177368
+                ],
+                "Size": [
+                  220,
+                  4,
+                  220
+                ]
+              }
+            }
+          },
+          "Ship": {
+            "$className": "Folder",
+            "HullDeckMain": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  49.7613869,
+                  14.4495049,
+                  299.243103
+                ],
+                "Size": [
+                  72,
+                  2,
+                  72
+                ]
+              }
+            },
+            "HullRailNorth": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  49.7613869,
+                  17.4495049,
+                  334.243103
+                ],
+                "Size": [
+                  68,
+                  6,
+                  2
+                ]
+              }
+            },
+            "HullRailSouth": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  49.7613869,
+                  17.4495049,
+                  264.243103
+                ],
+                "Size": [
+                  68,
+                  6,
+                  2
+                ]
+              }
+            },
+            "HullRailEast": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  84.7613869,
+                  17.4495049,
+                  299.243103
+                ],
+                "Size": [
+                  2,
+                  6,
+                  72
+                ]
+              }
+            },
+            "HullRailWest": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": true,
+                "CanTouch": false,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  14.7613869,
+                  17.4495049,
+                  299.243103
+                ],
+                "Size": [
+                  2,
+                  6,
+                  72
+                ]
+              }
+            }
+          }
+        },
+        "Triggers": {
+          "$className": "Folder",
+          "Ocean": {
+            "$className": "Folder",
+            "OceanTrigger": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": false,
+                "CanTouch": true,
+                "CanQuery": true,
+                "Transparency": 1,
+                "Position": [
+                  575.470703,
+                  8.21289062,
+                  -190.05957
+                ],
+                "Size": [
+                  565,
+                  10,
+                  186.90863
+                ]
+              }
+            }
+          }
+        },
+        "DoorLeft": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true
+          }
+        },
+        "DoorRight": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true
+          }
+        },
+        "ShopTerminal": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true
+          },
+          "Prompt": {
+            "$className": "ProximityPrompt"
+          }
+        },
+        "SalvageTerminal": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true
+          },
+          "Prompt": {
+            "$className": "ProximityPrompt"
+          }
+        },
+        "ObjectiveBoard": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true
+          },
+          "Prompt": {
+            "$className": "ProximityPrompt"
+          }
+        },
+        "LoadoutBench": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true
+          },
+          "Prompt": {
+            "$className": "ProximityPrompt"
+          }
+        },
+        "UgcLabConsole": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true
+          },
+          "Prompt": {
+            "$className": "ProximityPrompt"
+          }
+        },
+        "GateSwitch": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true
+          },
+          "Prompt": {
+            "$className": "ProximityPrompt"
+          }
+        },
+        "MazeGateMarker": {
+          "$className": "Part",
+          "$properties": {
+            "Anchored": true
+          },
+          "Prompt": {
+            "$className": "ProximityPrompt"
+          }
+        }
+      }
+    },
     "ServerScriptService": {
       "$className": "ServerScriptService",
       "$path": "src/ServerScriptService"

--- a/places/run/src/ServerScriptService/Bootstrap.server.luau
+++ b/places/run/src/ServerScriptService/Bootstrap.server.luau
@@ -1,3 +1,10 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Shared = require(Packages:WaitForChild('Shared'))
+local RunStaticWorldContract = require(script.Parent.Run.RunStaticWorldContract)
 local RunSessionService = require(script.Parent.Run.RunSessionService)
 
+Shared.Network.Remotes.ensure()
+warn(string.format('[run-bootstrap] build=%s', RunStaticWorldContract.BuildFingerprint))
 RunSessionService.new():start()

--- a/places/run/src/ServerScriptService/Run/RunInteractionRegistry.luau
+++ b/places/run/src/ServerScriptService/Run/RunInteractionRegistry.luau
@@ -1,0 +1,51 @@
+local RunInteractionRegistry = {}
+RunInteractionRegistry.__index = RunInteractionRegistry
+
+function RunInteractionRegistry.new()
+    return setmetatable({
+        Connections = {},
+    }, RunInteractionRegistry)
+end
+
+function RunInteractionRegistry:_track(connection)
+    table.insert(self.Connections, connection)
+end
+
+function RunInteractionRegistry:bindScene(scene, handlers)
+    self:_track(scene.Terminals.Shop:bind(function(player)
+        handlers.OnShop(player)
+    end))
+    self:_track(scene.Terminals.Sell:bind(function(player)
+        handlers.OnSell(player)
+    end))
+    self:_track(scene.Terminals.Objective:bind(function(player)
+        handlers.OnObjective(player)
+    end))
+    self:_track(scene.Terminals.Loadout:bind(function(player)
+        handlers.OnLoadout(player)
+    end))
+    self:_track(scene.Terminals.UgcLab:bind(function(player)
+        handlers.OnUgcLab(player)
+    end))
+    self:_track(scene.Terminals.Gate:bind(function(player)
+        handlers.OnGate(player)
+    end))
+    self:_track(scene.MazePortal:bind(function(player)
+        handlers.OnMazePortal(player)
+    end))
+
+    for _, oceanTrigger in ipairs(scene.OceanTriggers or {}) do
+        self:_track(oceanTrigger:bind(function(player, state)
+            handlers.OnOceanEntered(player, state)
+        end))
+    end
+end
+
+function RunInteractionRegistry:disconnectAll()
+    for _, connection in ipairs(self.Connections) do
+        connection:Disconnect()
+    end
+    table.clear(self.Connections)
+end
+
+return RunInteractionRegistry

--- a/places/run/src/ServerScriptService/Run/RunOceanTrigger.luau
+++ b/places/run/src/ServerScriptService/Run/RunOceanTrigger.luau
@@ -1,0 +1,60 @@
+local Players = game:GetService('Players')
+
+local RunOceanTrigger = {}
+RunOceanTrigger.__index = RunOceanTrigger
+
+local OCEAN_ENTRY_COOLDOWN_SECONDS = 0.75
+
+local OceanState = {
+    None = 'None',
+    Touching = 'Touching',
+    Immersed = 'Immersed',
+}
+
+local function findPlayerFromHit(hit)
+    if hit == nil then
+        return nil
+    end
+
+    local character = hit:FindFirstAncestorOfClass('Model')
+    if character == nil then
+        return nil
+    end
+
+    local humanoid = character:FindFirstChildOfClass('Humanoid')
+    if humanoid == nil then
+        return nil
+    end
+
+    return Players:GetPlayerFromCharacter(character)
+end
+
+function RunOceanTrigger.new(part)
+    return setmetatable({
+        Part = part,
+        LastEnteredAtByUserId = {},
+    }, RunOceanTrigger)
+end
+
+-- Returns the state transition for a player: { state, isNewState }
+function RunOceanTrigger:bind(callback)
+    return self.Part.Touched:Connect(function(hit)
+        local player = findPlayerFromHit(hit)
+        if player == nil then
+            return
+        end
+
+        local now = os.clock()
+        local lastEnteredAt = self.LastEnteredAtByUserId[player.UserId]
+        if lastEnteredAt ~= nil and now - lastEnteredAt < OCEAN_ENTRY_COOLDOWN_SECONDS then
+            return
+        end
+
+        self.LastEnteredAtByUserId[player.UserId] = now
+        callback(player, OceanState.Touching)
+    end)
+end
+
+RunOceanTrigger.OceanState = OceanState
+
+return RunOceanTrigger

--- a/places/run/src/ServerScriptService/Run/RunScene.luau
+++ b/places/run/src/ServerScriptService/Run/RunScene.luau
@@ -1,0 +1,212 @@
+local RunAreaResolver = require(script.Parent.RunAreaResolver)
+local RunDoor = require(script.Parent.RunDoor)
+local RunInteractionRegistry = require(script.Parent.RunInteractionRegistry)
+local RunOceanTrigger = require(script.Parent.RunOceanTrigger)
+local RunPortal = require(script.Parent.RunPortal)
+local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
+local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
+local RunTerminal = require(script.Parent.RunTerminal)
+
+local RunScene = {}
+RunScene.__index = RunScene
+
+local REQUIRED_PROMPT_PARTS = table.freeze({
+    ShopTerminal = 'Shop',
+    SalvageTerminal = 'Sell',
+    ObjectiveBoard = 'Objective',
+    LoadoutBench = 'Loadout',
+    UgcLabConsole = 'UgcLab',
+    GateSwitch = 'Gate',
+})
+
+local REQUIRED_MARKERS = table.freeze({
+    SpawnMarker = RunSpawnPoint.Kind.Spawn,
+    ReturnMarker = RunSpawnPoint.Kind.Return,
+    MazeReturnMarker = RunSpawnPoint.Kind.MazeReturn,
+})
+
+local function findNamedDescendant(root, name)
+    for _, descendant in ipairs(root:GetDescendants()) do
+        if descendant.Name == name then
+            return descendant
+        end
+    end
+
+    return nil
+end
+
+local function requirePart(root, name)
+    local part = findNamedDescendant(root, name)
+    if part == nil or not part:IsA('BasePart') then
+        error(string.format('RunStaticWorld is missing required part "%s".', name), 0)
+    end
+
+    return part
+end
+
+local function requireContainer(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not (child:IsA('Folder') or child:IsA('Model')) then
+        error(string.format('%s is missing required container "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function collectBaseParts(root)
+    local parts = {}
+
+    for _, descendant in ipairs(root:GetDescendants()) do
+        if descendant:IsA('BasePart') then
+            table.insert(parts, descendant)
+        end
+    end
+
+    return parts
+end
+
+local function buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
+    local raycastParams = RaycastParams.new()
+    raycastParams.FilterType = Enum.RaycastFilterType.Include
+    raycastParams.FilterDescendantsInstances = { sceneCollisionRoot, shipCollisionRoot }
+    return raycastParams
+end
+
+local function groundedSpawnCFrame(part, raycastParams)
+    local origin = part.Position + Vector3.new(0, (part.Size.Y * 0.5) + 2, 0)
+    local result = workspace:Raycast(
+        origin,
+        Vector3.new(0, -RunStaticWorldContract.SpawnGroundCheckDepth, 0),
+        raycastParams
+    )
+
+    if result and result.Instance and result.Instance.CanCollide and result.Normal.Y > 0.5 then
+        local groundedPosition = Vector3.new(
+            part.Position.X,
+            result.Position.Y + RunStaticWorldContract.SpawnLiftStuds,
+            part.Position.Z
+        )
+        return CFrame.fromMatrix(
+            groundedPosition,
+            part.CFrame.XVector,
+            part.CFrame.YVector,
+            part.CFrame.ZVector
+        )
+    end
+
+    return part.CFrame
+end
+
+function RunScene.new(root)
+    if not (root:IsA('Folder') or root:IsA('Model')) then
+        error('RunStaticWorld must be a Folder or Model.', 0)
+    end
+
+    local outdoorThresholdZ = root:GetAttribute('OutdoorThresholdZ')
+    if type(outdoorThresholdZ) ~= 'number' then
+        error('RunStaticWorld is missing required attribute "OutdoorThresholdZ".', 0)
+    end
+
+    local collisionRoot =
+        requireContainer(root, RunStaticWorldContract.CollisionRootName, 'RunStaticWorld')
+    local sceneCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.SceneCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local shipCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.ShipCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local triggersRoot =
+        requireContainer(root, RunStaticWorldContract.TriggersRootName, 'RunStaticWorld')
+    local oceanTriggerRoot = requireContainer(
+        triggersRoot,
+        RunStaticWorldContract.OceanTriggerName,
+        'RunStaticWorld Triggers'
+    )
+    local spawnGroundParams = buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
+    local spawnPoints = {}
+    local spawnCFramesByKind = {}
+    for markerName, kind in pairs(REQUIRED_MARKERS) do
+        local markerPart = requirePart(root, markerName)
+        spawnPoints[kind] = RunSpawnPoint.new(kind, markerPart)
+        spawnCFramesByKind[kind] = groundedSpawnCFrame(markerPart, spawnGroundParams)
+    end
+
+    local terminals = {}
+    for partName, kind in pairs(REQUIRED_PROMPT_PARTS) do
+        terminals[kind] = RunTerminal.new(kind, requirePart(root, partName))
+    end
+
+    local mazePortal = RunPortal.new(RunPortal.Kind.MazeGate, requirePart(root, 'MazeGateMarker'))
+    local gateDoor = RunDoor.new('TempleGate', {
+        requirePart(root, 'DoorLeft'),
+        requirePart(root, 'DoorRight'),
+    })
+    local oceanTriggers = {}
+
+    for _, part in ipairs(collectBaseParts(oceanTriggerRoot)) do
+        table.insert(oceanTriggers, RunOceanTrigger.new(part))
+    end
+
+    local self = setmetatable({
+        Root = root,
+        SpawnPoints = spawnPoints,
+        Terminals = terminals,
+        MazePortal = mazePortal,
+        GateDoor = gateDoor,
+        Collision = {
+            Scene = sceneCollisionRoot,
+            Ship = shipCollisionRoot,
+        },
+        OceanTriggers = oceanTriggers,
+        OutdoorThresholdZ = outdoorThresholdZ,
+        AreaResolver = nil,
+        SpawnCFramesByKind = spawnCFramesByKind,
+
+        SpawnCFrame = spawnCFramesByKind[RunSpawnPoint.Kind.Spawn],
+        ReturnCFrame = spawnCFramesByKind[RunSpawnPoint.Kind.Return],
+        MazeReturnCFrame = spawnCFramesByKind[RunSpawnPoint.Kind.MazeReturn],
+        ShopPrompt = terminals.Shop.Prompt,
+        SellPrompt = terminals.Sell.Prompt,
+        ObjectivePrompt = terminals.Objective.Prompt,
+        LoadoutPrompt = terminals.Loadout.Prompt,
+        UgcLabPrompt = terminals.UgcLab.Prompt,
+        GatePrompt = terminals.Gate.Prompt,
+        MazePrompt = mazePortal.Prompt,
+    }, RunScene)
+
+    self.AreaResolver = RunAreaResolver.new(self)
+
+    return self
+end
+
+function RunScene:getSpawnCFrame(kind)
+    local spawnCFrame = self.SpawnCFramesByKind[kind]
+    if spawnCFrame == nil then
+        error(string.format('Unknown run spawn point kind %q.', tostring(kind)), 0)
+    end
+
+    return spawnCFrame
+end
+
+function RunScene:getAreaForPosition(position)
+    return self.AreaResolver:getAreaForPosition(position)
+end
+
+function RunScene:openGate()
+    self.GateDoor:open()
+    self.Terminals.Gate.Prompt.ActionText = 'Gate Open'
+end
+
+function RunScene:bindInteractions(handlers)
+    local registry = RunInteractionRegistry.new()
+    registry:bindScene(self, handlers)
+    return registry
+end
+
+RunScene.OpenGate = RunScene.openGate
+
+return RunScene

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -18,7 +18,6 @@ local PlayerService = Shared.Runtime.PlayerService
 local PlayerStateService = Shared.Runtime.PlayerStateService
 local TeleportInventoryHydrator = Shared.Runtime.TeleportInventoryHydrator
 
-local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
 local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
 local RunToMazeTransition = require(script.Parent.RunToMazeTransition)
 local RunWorldBuilder = require(script.Parent.RunWorldBuilder)
@@ -338,7 +337,7 @@ function RunSessionService:_setOceanState(player, newState)
         }
         -- Apply slowdown after delay
         task.delay(OCEAN_SLOWDOWN_DELAY_SECONDS, function()
-            if self:_getOceanState(player) == 'Touching' then
+            if self:_getOceanState(player) ~= 'None' then
                 self:_applyOceanSlowdown(player)
             end
         end)

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -13,10 +13,14 @@ local MazeEntryAvailability = Shared.Session.MazeEntryAvailability
 local SessionSeedPolicy = Shared.Session.SessionSeedPolicy
 local ControlStateService = Shared.Runtime.ControlStateService
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
+local InventoryService = Shared.Runtime.InventoryService
+local PlayerService = Shared.Runtime.PlayerService
 local PlayerStateService = Shared.Runtime.PlayerStateService
+local TeleportInventoryHydrator = Shared.Runtime.TeleportInventoryHydrator
 
-local LocalDebugMazeWorldBuilder = require(script.Parent.LocalDebugMazeWorldBuilder)
-local RunMazePortal = require(script.Parent.RunMazePortal)
+local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
+local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
+local RunToMazeTransition = require(script.Parent.RunToMazeTransition)
 local RunWorldBuilder = require(script.Parent.RunWorldBuilder)
 
 local RunSessionService = {}
@@ -26,13 +30,55 @@ local DEFAULT_WORKSPACE_SHELL_NAMES = { 'Baseplate', 'SpawnLocation' }
 local CAMP_SESSION_LOCK_WAIT_SECONDS = 0.05
 local MAZE_ENTRY_REQUEST_COOLDOWN_SECONDS = 0.35
 local MAZE_ENTRY_DISTANCE_BUFFER = 2
-local LOCAL_DEBUG_ROOM_DETECTION_RADIUS = 56
-local LOCAL_DEBUG_MAZE_RETURN_REASON = 'local_debug_return'
+local TERMINAL_INTERACTION_DISTANCE_BUFFER = 2
 local SNAPSHOT_INTERVAL_SECONDS = 0.25
 local RUN_MAZE_GATE_RETURN_REASONS = table.freeze({
     early_return = true,
     extracted = true,
 })
+local INITIAL_TEMPLE_STATUS = 'Select Enter Temple to enter the temple.'
+local BOOK_GOAL_AMOUNT = 120
+local OCEAN_SPLASH_MESSAGE = 'Sea spray crashes over you.'
+local OCEAN_SLOWDOWN_DELAY_SECONDS = 1
+local OCEAN_SLOWDOWN_WALK_SPEED = 12
+local OCEAN_DAMAGE_INTERVAL_SECONDS = 5
+local SHOP_ITEMS = {
+    {
+        Id = 'temple_lantern',
+        Name = 'Temple Lantern',
+        Price = 18,
+        Weight = 2,
+        Value = 12,
+        Light = {
+            Brightness = 2,
+            Range = 12,
+            Color = Color3.fromRGB(255, 214, 153),
+        },
+    },
+    {
+        Id = 'sand_relic',
+        Name = 'Sand Relic',
+        Price = 24,
+        Weight = 3,
+        Value = 18,
+        Color = Color3.fromRGB(224, 202, 152),
+    },
+    {
+        Id = 'scribe_compass',
+        Name = 'Scribe Compass',
+        Price = 14,
+        Weight = 1,
+        Value = 9,
+    },
+}
+local SHOP_ITEM_BY_ID = {}
+
+for _, item in ipairs(SHOP_ITEMS) do
+    SHOP_ITEM_BY_ID[item.Id] = item
+end
+
+table.freeze(SHOP_ITEMS)
+table.freeze(SHOP_ITEM_BY_ID)
 
 local function isMazeGateReturnReason(returnReason)
     return RUN_MAZE_GATE_RETURN_REASONS[returnReason] == true
@@ -53,13 +99,6 @@ local function bindCharacterTeleport(self, player)
     player.CharacterAdded:Connect(function(character)
         task.wait()
         if not character.Parent then
-            return
-        end
-
-        if self.PendingLocalMazeSpawnByUserId[player.UserId] and self.LocalDebugMazeWorld then
-            self.PendingLocalMazeSpawnByUserId[player.UserId] = nil
-            character:PivotTo(self.LocalDebugMazeWorld.SpawnCFrame)
-            self:_applyMovementMode(player)
             return
         end
 
@@ -96,6 +135,67 @@ local function cloneArray(input)
     return result
 end
 
+local function buildShopPayload()
+    local payload = {}
+
+    for _, item in ipairs(SHOP_ITEMS) do
+        table.insert(payload, {
+            Id = item.Id,
+            Name = item.Name,
+            Price = item.Price,
+        })
+    end
+
+    return payload
+end
+
+local function getSellPrice(itemEntry)
+    return math.max(1, math.floor((itemEntry.Value or 0) + 0.5))
+end
+
+local function buildSellPayload(inventorySummary)
+    local items = {}
+
+    local function insertItem(itemEntry)
+        if not itemEntry then
+            return
+        end
+
+        table.insert(items, {
+            InstanceId = itemEntry.InstanceId,
+            Name = itemEntry.Name,
+            Price = getSellPrice(itemEntry),
+            Color = itemEntry.Color,
+        })
+    end
+
+    for _, itemEntry in ipairs(inventorySummary.BackpackItems or {}) do
+        insertItem(itemEntry)
+    end
+
+    insertItem(inventorySummary.HeldItem)
+
+    return items
+end
+
+local function removeItemFromSummary(summary, itemInstanceId)
+    if summary.HeldItem and summary.HeldItem.InstanceId == itemInstanceId then
+        local removed = summary.HeldItem
+        summary.HeldItem = nil
+        return removed
+    end
+
+    for index, itemEntry in ipairs(summary.BackpackItems or {}) do
+        if itemEntry.InstanceId == itemInstanceId then
+            local removed = itemEntry
+            table.remove(summary.BackpackItems, index)
+            return removed
+        end
+    end
+
+    return nil
+end
+
 local function runWithCampSessionLock(self, callback)
     while self.CampSessionLock do
         task.wait(CAMP_SESSION_LOCK_WAIT_SECONDS)
@@ -112,10 +212,12 @@ local function runWithCampSessionLock(self, callback)
     return table.unpack(results, 2, results.n)
 end
 
-function RunSessionService.new()
+function RunSessionService.new(options)
+    local runtimeOptions = options or {}
     local self = setmetatable({}, RunSessionService)
 
     self.Remotes = Remotes
+    self.BuildFingerprint = RunStaticWorldContract.BuildFingerprint
     self.SessionData = {
         Seed = SessionConfig.DefaultSeed,
         Quota = SessionConfig.DefaultQuota,
@@ -123,41 +225,267 @@ function RunSessionService.new()
         InventoryCapacity = SessionConfig.InventoryCapacity,
     }
     self.CampSession = CampMazeSessionContract.newCampSession({})
-    self.Status = 'Select Enter Camp to enter the camp.'
+    self.Status = INITIAL_TEMPLE_STATUS
     self.IsLaunched = false
     self.ShouldAutoLaunch = false
     self.GateOpen = false
     self.World = nil
+    self.WorldInteractions = nil
     self.SnapshotThread = nil
     self.PendingSpawnByUserId = {}
-    self.PendingLocalMazeSpawnByUserId = {}
     self.CampSessionLock = false
     self.HasAuthoritativeSessionSeed = false
     self.SessionSeedRandom = nil
     self.LastMazeEntryRequestAtByUserId = {}
+    self.LastOceanSplashAtByUserId = {}
+    self.OceanStateByUserId = {}
+    self.OceanTimersByUserId = {}
+    self.OceanOriginalSpeedsByUserId = {}
     self.MazeEntryMode = MazeEntryAvailability.Mode.Blocked
     self.MazeEntryReason =
         'Set SessionConfig.PlaceIds.Maze or SessionPlaceIdMaze before using the maze gate.'
     self.MazeEntryReasonCode = MazeEntryAvailability.ReasonCode.MazePlaceIdMissing
-    self.LocalDebugMazeWorld = nil
+    self.TeamPages = 0
+    self.BookGoalAmount = BOOK_GOAL_AMOUNT
+    self.InventoryService = InventoryService.new(self.SessionData.InventoryCapacity)
     self.ControlStateService = ControlStateService.new()
+    self.PlayerService = PlayerService.new()
     self.PlayerStateService = PlayerStateService.new()
+    self.RunToMazeTransition = runtimeOptions.RunToMazeTransition or RunToMazeTransition.new()
+    self.WorldBuilder = runtimeOptions.RunWorldBuilder or RunWorldBuilder
 
     return self
 end
 
 function RunSessionService:_addPlayerState(player)
+    self.InventoryService:addPlayer(player)
     self.ControlStateService:addPlayer(player)
     self.PlayerStateService:addPlayer(player)
+    self.PlayerService:addPlayer(player)
 end
 
 function RunSessionService:_removePlayerState(player)
+    self.InventoryService:removePlayer(player)
     self.ControlStateService:removePlayer(player)
-    self.PlayerStateService:removePlayer(player)
+    self.PlayerService:removePlayer(player)
+end
+
+function RunSessionService:_handleOceanEntered(player)
+    local now = os.clock()
+    local lastSplashAt = self.LastOceanSplashAtByUserId[player.UserId]
+    if
+        lastSplashAt ~= nil
+        and now - lastSplashAt < RunStaticWorldContract.OceanSplashCooldownSeconds
+    then
+        return
+    end
+
+    self.LastOceanSplashAtByUserId[player.UserId] = now
+    self.Remotes.RunPrivateState:FireClient(player, {
+        Type = 'OceanSplash',
+        Message = OCEAN_SPLASH_MESSAGE,
+    })
+end
+
+function RunSessionService:_applyOceanSlowdown(player)
+    local character = player.Character
+    local humanoid = character and character:FindFirstChildOfClass('Humanoid')
+    if not humanoid then
+        return
+    end
+
+    local originalWalkSpeed = humanoid.WalkSpeed
+    local originalSprintSpeed = humanoid.WalkSpeed -- sprint speed mirrors walk speed in this system
+
+    self.OceanOriginalSpeedsByUserId[player.UserId] = {
+        WalkSpeed = originalWalkSpeed,
+        SprintSpeed = originalSprintSpeed,
+    }
+    humanoid.WalkSpeed = OCEAN_SLOWDOWN_WALK_SPEED
+end
+
+function RunSessionService:_removeOceanSlowdown(player)
+    local character = player.Character
+    local humanoid = character and character:FindFirstChildOfClass('Humanoid')
+    if not humanoid then
+        return
+    end
+
+    local original = self.OceanOriginalSpeedsByUserId[player.UserId]
+    if original then
+        humanoid.WalkSpeed = original.WalkSpeed
+        self.OceanOriginalSpeedsByUserId[player.UserId] = nil
+    end
+end
+
+function RunSessionService:_getOceanState(player)
+    return self.OceanStateByUserId[player.UserId] or 'None'
+end
+
+function RunSessionService:_setOceanState(player, newState)
+    local currentState = self:_getOceanState(player)
+    if currentState == newState then
+        return
+    end
+
+    self.OceanStateByUserId[player.UserId] = newState
+
+    if newState == 'Touching' and currentState == 'None' then
+        -- Schedule Immersed transition
+        self.OceanTimersByUserId[player.UserId] = {
+            TouchStartedAt = os.clock(),
+            LastDamageAt = nil,
+        }
+        -- Apply slowdown after delay
+        task.delay(OCEAN_SLOWDOWN_DELAY_SECONDS, function()
+            if self:_getOceanState(player) == 'Touching' then
+                self:_applyOceanSlowdown(player)
+            end
+        end)
+    elseif newState == 'Immersed' then
+        -- Player is fully immersed, start damage timer
+        self.OceanTimersByUserId[player.UserId].ImmersedStartedAt = os.clock()
+    elseif newState == 'None' then
+        -- Player left the ocean
+        self:_removeOceanSlowdown(player)
+        self.OceanTimersByUserId[player.UserId] = nil
+        self.Remotes.RunPrivateState:FireClient(player, {
+            Type = 'OceanExit',
+        })
+    end
+end
+
+function RunSessionService:_checkOceanImmersion(player)
+    if not self.World or not self.World.OceanTriggers then
+        return false
+    end
+
+    local character = player.Character
+    local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+    if not rootPart then
+        return false
+    end
+
+    local position = rootPart.Position
+
+    for _, trigger in ipairs(self.World.OceanTriggers) do
+        local part = trigger.Part
+        local size = part.Size
+        local cf = part.CFrame
+
+        -- Check if root part center is within the trigger part's bounding box
+        local localPos = cf:PointToObjectSpace(position)
+        local halfSize = size * 0.5
+
+        if
+            math.abs(localPos.X) <= halfSize.X
+            and math.abs(localPos.Y) <= halfSize.Y
+            and math.abs(localPos.Z) <= halfSize.Z
+        then
+            return true
+        end
+    end
+
+    return false
+end
+
+function RunSessionService:_updateOceanPerPlayer(player, _dt)
+    local state = self:_getOceanState(player)
+
+    if state == 'None' then
+        return
+    end
+
+    local isImmersed = self:_checkOceanImmersion(player)
+
+    if state == 'Touching' and isImmersed then
+        self:_setOceanState(player, 'Immersed')
+        return
+    elseif state == 'Touching' and not isImmersed then
+        -- Still just touching, check if they left entirely
+        -- If the player is no longer near any ocean trigger, they left
+        if not self:_checkOceanNear(player) then
+            self:_setOceanState(player, 'None')
+        end
+        return
+    elseif state == 'Immersed' then
+        -- Check if still immersed
+        if not isImmersed then
+            self:_setOceanState(player, 'None')
+            return
+        end
+
+        -- Apply periodic damage
+        local timers = self.OceanTimersByUserId[player.UserId]
+        if not timers then
+            return
+        end
+
+        -- Skip damage if player is already dead
+        local playerObj = self.PlayerService:get(player)
+        if playerObj and playerObj.Components.Health.IsDead then
+            return
+        end
+
+        local now = os.clock()
+        local lastDamage = timers.LastDamageAt or timers.ImmersedStartedAt
+
+        if lastDamage and now - lastDamage >= OCEAN_DAMAGE_INTERVAL_SECONDS then
+            -- Apply 1 pip damage
+            if playerObj and playerObj.Components.Health then
+                playerObj.Components.Health:applyDamage(playerObj.Blackboard, 'Light')
+            end
+            timers.LastDamageAt = now
+
+            -- Notify client of damage tick
+            local currentPips = 0
+            if playerObj and playerObj.Components.Health then
+                currentPips = playerObj.Components.Health.CurrentHealthPips
+            end
+            self.Remotes.RunPrivateState:FireClient(player, {
+                Type = 'OceanDamage',
+                CurrentPips = currentPips,
+            })
+        end
+    end
+end
+
+function RunSessionService:_checkOceanNear(player)
+    if not self.World or not self.World.OceanTriggers then
+        return false
+    end
+
+    local character = player.Character
+    local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+    if not rootPart then
+        return false
+    end
+
+    local position = rootPart.Position
+
+    for _, trigger in ipairs(self.World.OceanTriggers) do
+        local part = trigger.Part
+        local size = part.Size
+        local cf = part.CFrame
+
+        -- Expand bounding box slightly to detect "touching" (within half-stud buffer)
+        local localPos = cf:PointToObjectSpace(position)
+        local halfSize = size * 0.5 + Vector3.new(0.5, 0.5, 0.5)
+
+        if
+            math.abs(localPos.X) <= halfSize.X
+            and math.abs(localPos.Y) <= halfSize.Y
+            and math.abs(localPos.Z) <= halfSize.Z
+        then
+            return true
+        end
+    end
+
+    return false
 end
 
 function RunSessionService:_getMovementSummaryFor(player)
-    local playerState = self.PlayerStateService:getSummary(player)
+    local playerState = self.PlayerService:getSummary(player)
     local controlState = self.ControlStateService:getSummary(player)
     return FormalLocomotion.summarize(playerState, controlState)
 end
@@ -173,13 +501,10 @@ function RunSessionService:_applyMovementMode(player)
 end
 
 function RunSessionService:_syncPlayerMovement(player)
-    local playerState = self.PlayerStateService:getSummary(player)
+    local playerState = self.PlayerService:getSummary(player)
     local ok, controlState = self.ControlStateService:syncPlayerState(player, playerState)
     if ok and controlState then
-        self.PlayerStateService:setSprinting(
-            player,
-            controlState.Mode == FormalLocomotion.Mode.Sprint
-        )
+        self.PlayerService:setSprinting(player, controlState.Mode == FormalLocomotion.Mode.Sprint)
     end
 
     self:_applyMovementMode(player)
@@ -207,7 +532,17 @@ function RunSessionService:_applySessionConfig(incoming)
     end
     if type(incoming.InventoryCapacity) == 'number' then
         self.SessionData.InventoryCapacity = incoming.InventoryCapacity
+        self.InventoryService.Capacity = incoming.InventoryCapacity
     end
+end
+
+function RunSessionService:_hydratePlayerInventory(player, teleportData)
+    return TeleportInventoryHydrator.hydratePlayerInventory(
+        self.InventoryService,
+        player,
+        teleportData,
+        CampMazeSessionContract.findPlayerInventory
+    )
 end
 
 function RunSessionService:_syncCampSession()
@@ -294,8 +629,7 @@ function RunSessionService:_applyReturnedPlayersFromTeleportData(players, accept
         local teleportData = self:_readTeleportData(player) or acceptedTeleportData
         local returnSummary = CampMazeSessionContract.findReturnSummary(teleportData, player.UserId)
         if returnSummary then
-            self.PendingSpawnByUserId[player.UserId] =
-                self:_getReturnSpawnCFrameForSummary(returnSummary)
+            self.PendingSpawnByUserId[player.UserId] = self:_getReturnSpawnCFrameForSummary(returnSummary)
             table.insert(returnedPlayers, {
                 Player = player,
                 Summary = returnSummary,
@@ -312,9 +646,9 @@ function RunSessionService:_applyReturnedPlayersFromTeleportData(players, accept
             returnedPlayer.TeleportData
         )
     elseif #returnedPlayers > 1 then
-        self.Status = 'The crew returned from the maze. Review the camp summaries together.'
+        self.Status = 'The crew returned from the maze. Review the temple summaries together.'
     else
-        self.Status = 'Camp is ready. Gather inside, then head outside when the group is ready.'
+        self.Status = 'Temple is ready. Gather inside, then head outside when the group is ready.'
     end
 end
 
@@ -350,43 +684,36 @@ function RunSessionService:_rebuildWorld()
     self.World = RunWorldBuilder.build()
     if self.GateOpen then
         self.World.OpenGate()
-    end
-    self:_bindWorldInteractions()
+            self:_setStatus(
+                string.format(
+                    '%s checked the loadout bench. Equipment setup is coming soon.',
+                    player.DisplayName
+                )
+            )
+        end,
+        OnUgcLab = function(player)
+            self:_setStatus(
+                string.format(
+                    '%s checked the UGC lab console. Creature forging is coming soon.',
+                    player.DisplayName
+                )
+            )
+        end,
+        OnGate = function(player)
+            self:_openGate(player)
+        end,
+        OnMazePortal = function(player)
+            if self:_canProcessMazeEntryRequest(player) then
+                self:_requestMazeEntry(player, false)
+            end
+        end,
+        OnOceanEntered = function(player, state)
+            self:_setOceanState(player, state or 'Touching')
+            self:_handleOceanEntered(player)
+        end,
+    })
+
     self:_teleportCharactersToSpawn()
-end
-
-function RunSessionService:_bindWorldInteractions()
-    if not self.World then
-        return
-    end
-
-    self.World.ShopPrompt.Triggered:Connect(function(player)
-        self:_setStatus(
-            string.format(
-                '%s checked the shop terminal. Purchases coming soon.',
-                player.DisplayName
-            )
-        )
-    end)
-
-    self.World.LoadoutPrompt.Triggered:Connect(function(player)
-        self:_setStatus(
-            string.format(
-                '%s checked the loadout bench. Equipment setup is coming soon.',
-                player.DisplayName
-            )
-        )
-    end)
-
-    self.World.GatePrompt.Triggered:Connect(function(player)
-        self:_openGate(player)
-    end)
-
-    self.World.MazePrompt.Triggered:Connect(function(player)
-        if self:_canProcessMazeEntryRequest(player) then
-            self:_requestMazeEntry(player, false)
-        end
-    end)
 end
 
 function RunSessionService:_getPlayerArea(player)
@@ -397,27 +724,10 @@ function RunSessionService:_getPlayerArea(player)
     local character = player.Character
     local rootPart = character and character:FindFirstChild('HumanoidRootPart')
     if not rootPart then
-        return self.GateOpen and 'Camp Threshold' or 'Camp House'
+        return self.GateOpen and 'Temple Threshold' or 'Temple Hall'
     end
 
-    if self.LocalDebugMazeWorld then
-        local room, distance = self.LocalDebugMazeWorld.FindRoomByPosition(rootPart.Position)
-        if room and distance <= LOCAL_DEBUG_ROOM_DETECTION_RADIUS then
-            return 'Local Maze Debug'
-        end
-
-        for _, entry in ipairs(self.CampSession.PlayersInMaze or {}) do
-            if entry.UserId == player.UserId then
-                return 'Local Maze Debug'
-            end
-        end
-    end
-
-    if rootPart.Position.Z >= self.World.OutdoorThresholdZ then
-        return 'Wilderness'
-    end
-
-    return 'Camp House'
+    return self.World:getAreaForPosition(rootPart.Position)
 end
 
 function RunSessionService:_buildRoster()
@@ -440,16 +750,12 @@ end
 function RunSessionService:_getObjectiveFor(player)
     local area = self:_getPlayerArea(player)
 
-    if area == 'Local Maze Debug' then
-        return 'Explore local debug maze rooms, then use Return To Camp (Local Debug).'
-    end
-
     if not self.GateOpen then
-        return 'Inspect the camp terminals and open the gate when the group is ready.'
+        return 'Inspect the temple terminals and open the gate when the group is ready.'
     end
 
     if self.CampSession.MazeStatus == CampMazeSessionContract.MazeStatus.Completed then
-        return 'The maze run is complete. Review the returned crew summaries in camp.'
+        return 'The maze run is complete. Review the returned crew summaries in the temple.'
     end
 
     if self.CampSession.MazeStatus == CampMazeSessionContract.MazeStatus.Active then
@@ -472,13 +778,183 @@ function RunSessionService:_setStatus(status)
     self:_broadcastSnapshot()
 end
 
+function RunSessionService:_getBookSnapshot()
+    local progress = 0
+    if self.BookGoalAmount > 0 then
+        progress = math.clamp(self.TeamPages / self.BookGoalAmount, 0, 1)
+    end
+
+    return {
+        TeamPages = self.TeamPages,
+        BookGoalAmount = self.BookGoalAmount,
+        BookGoalProgress = progress,
+        BookGoalReached = self.TeamPages >= self.BookGoalAmount,
+    }
+end
+
+function RunSessionService:_sendPrivate(player, payload)
+    self.Remotes.RunPrivateState:FireClient(player, payload)
+end
+
+function RunSessionService:_broadcastPrivate(payload)
+    for _, player in ipairs(Players:GetPlayers()) do
+        self:_sendPrivate(player, payload)
+    end
+end
+
+function RunSessionService:_toast(player, message, tone)
+    self:_sendPrivate(player, {
+        Type = 'Toast',
+        Message = message,
+        Tone = tone or 'Info',
+    })
+end
+
+function RunSessionService:_openShop(player)
+    self:_sendPrivate(player, {
+        Type = 'OpenShop',
+        Items = buildShopPayload(),
+        TeamPages = self.TeamPages,
+        Inventory = self.InventoryService:getSummary(player),
+    })
+end
+
+function RunSessionService:_openSell(player)
+    local inventorySummary = self.InventoryService:getSummary(player)
+    self:_sendPrivate(player, {
+        Type = 'OpenSell',
+        Items = buildSellPayload(inventorySummary),
+        TeamPages = self.TeamPages,
+    })
+end
+
+function RunSessionService:_openObjectiveBoard(player)
+    local snapshot = self:_getBookSnapshot()
+    self:_sendPrivate(player, {
+        Type = 'OpenObjectiveBoard',
+        BookGoalAmount = snapshot.BookGoalAmount,
+        BookGoalProgress = snapshot.BookGoalProgress,
+        BookGoalReached = snapshot.BookGoalReached,
+        TeamPages = snapshot.TeamPages,
+    })
+end
+
+function RunSessionService:_handlePurchase(player, itemId)
+    if not self:_canManageInventory(player) then
+        return
+    end
+    if not self:_isPlayerNearTerminalPrompt(player, self.World and self.World.ShopPrompt) then
+        self:_toast(player, 'Move closer to the shop terminal.', 'Error')
+        return
+    end
+
+    local itemDef = SHOP_ITEM_BY_ID[itemId]
+    if not itemDef then
+        self:_toast(player, 'Unknown item.', 'Error')
+        return
+    end
+
+    if self.TeamPages < itemDef.Price then
+        self:_sendPrivate(player, {
+            Type = 'ShopResult',
+            Success = false,
+            Reason = 'InsufficientFunds',
+        })
+        return
+    end
+
+    local ok, reason = self.InventoryService:pickup(player, itemDef)
+    if not ok then
+        self:_sendPrivate(player, {
+            Type = 'ShopResult',
+            Success = false,
+            Reason = reason or 'InventoryFull',
+        })
+        return
+    end
+
+    local wasBelowGoal = self.TeamPages < self.BookGoalAmount
+    self.TeamPages -= itemDef.Price
+
+    self:_sendPrivate(player, {
+        Type = 'ShopResult',
+        Success = true,
+        ItemId = itemDef.Id,
+        TeamPages = self.TeamPages,
+        Inventory = self.InventoryService:getSummary(player),
+    })
+
+    self:_broadcastSnapshot()
+
+    if wasBelowGoal and self.TeamPages >= self.BookGoalAmount then
+        local snapshot = self:_getBookSnapshot()
+        self:_broadcastPrivate({
+            Type = 'GoalReached',
+            TeamPages = snapshot.TeamPages,
+        })
+    end
+end
+
+function RunSessionService:_handleSell(player, itemInstanceId)
+    if not self:_canManageInventory(player) then
+        return
+    end
+    if not self:_isPlayerNearTerminalPrompt(player, self.World and self.World.SellPrompt) then
+        self:_toast(player, 'Move closer to the salvage terminal.', 'Error')
+        return
+    end
+
+    if type(itemInstanceId) ~= 'number' then
+        self:_toast(player, 'Invalid item.', 'Error')
+        return
+    end
+
+    local inventorySummary = self.InventoryService:getSummary(player)
+    local removedItem = removeItemFromSummary(inventorySummary, itemInstanceId)
+    if not removedItem then
+        self:_toast(player, 'Item not found.', 'Error')
+        return
+    end
+
+    local ok, reason = self.InventoryService:loadSummary(player, inventorySummary)
+    if not ok then
+        self:_toast(
+            player,
+            string.format('Could not update inventory (%s).', tostring(reason)),
+            'Error'
+        )
+        return
+    end
+
+    local reward = getSellPrice(removedItem)
+    local wasBelowGoal = self.TeamPages < self.BookGoalAmount
+    self.TeamPages += reward
+
+    self:_sendPrivate(player, {
+        Type = 'SellResult',
+        Success = true,
+        ItemInstanceId = itemInstanceId,
+        Amount = reward,
+        TeamPages = self.TeamPages,
+    })
+
+    self:_broadcastSnapshot()
+
+    if wasBelowGoal and self.TeamPages >= self.BookGoalAmount then
+        local snapshot = self:_getBookSnapshot()
+        self:_broadcastPrivate({
+            Type = 'GoalReached',
+            TeamPages = snapshot.TeamPages,
+        })
+    end
+end
+
 function RunSessionService:_resolveMazeEntryAvailability()
     local availability = MazeEntryAvailability.evaluate({
         PlaceIds = SessionConfig.PlaceIds,
         PlaceId = game.PlaceId,
         GameId = game.GameId,
         IsStudio = RunService:IsStudio(),
-        DebugLocalMazeHandoff = SessionConfig.DebugLocalMazeHandoff,
     })
 
     self.MazeEntryMode = availability.Mode
@@ -493,11 +969,17 @@ function RunSessionService:_broadcastSnapshot()
     local activeMazeRoster = cloneArray(self.CampSession.PlayersInMaze)
     local returnedSummaries = cloneArray(self.CampSession.ReturnedPlayerSummaries)
     local mazeEntryAvailability = self:_resolveMazeEntryAvailability()
+    local bookSnapshot = self:_getBookSnapshot()
 
     for _, player in ipairs(Players:GetPlayers()) do
+        local playerSummary = self.PlayerService:getSummary(player)
+        local playerStateSummary = if playerSummary and playerSummary.PlayerState ~= nil
+            then playerSummary.PlayerState
+            else self.PlayerStateService:getSummary(player)
         self.Remotes.RunState:FireClient(player, {
             IsLaunched = self.IsLaunched,
             Status = self.Status,
+            BuildFingerprint = self.BuildFingerprint,
             Area = self:_getPlayerArea(player),
             GateOpen = self.GateOpen,
             Objective = self:_getObjectiveFor(player),
@@ -509,13 +991,78 @@ function RunSessionService:_broadcastSnapshot()
             MazeEntryMode = mazeEntryAvailability.Mode,
             MazeEntryReason = mazeEntryAvailability.Reason,
             MazeEntryReasonCode = mazeEntryAvailability.ReasonCode,
+            TeamPages = bookSnapshot.TeamPages,
+            BookGoalAmount = bookSnapshot.BookGoalAmount,
+            BookGoalProgress = bookSnapshot.BookGoalProgress,
+            BookGoalReached = bookSnapshot.BookGoalReached,
+            Inventory = self.InventoryService:getSummary(player),
             Movement = self:_getMovementSummaryFor(player),
             ControlState = self.ControlStateService:getSummary(player),
-            PlayerState = self.PlayerStateService:getSummary(player),
+            PlayerState = playerStateSummary,
         })
 
         self.Remotes.RunPrivateState:FireClient(player, nil)
     end
+end
+
+function RunSessionService:_canManageInventory(player)
+    if not self.IsLaunched then
+        return false
+    end
+
+    if CampMazeSessionContract.isPlayerInMaze(self.CampSession, player.UserId) then
+        self:_setStatus(
+            string.format(
+                '%s is already marked inside the maze and cannot change temple inventory.',
+                player.DisplayName
+            )
+        )
+        return false
+    end
+
+    return true
+end
+
+function RunSessionService:_equipItem(player, itemInstanceId)
+    if not self:_canManageInventory(player) then
+        return
+    end
+
+    local success, result = self.InventoryService:equip(player, itemInstanceId)
+    if not success then
+        self:_setStatus(
+            string.format(
+                '%s could not equip that item (%s).',
+                player.DisplayName,
+                tostring(result)
+            )
+        )
+        return
+    end
+
+    self:_setStatus(string.format('%s equipped %s in the temple.', player.DisplayName, result.Name))
+end
+
+function RunSessionService:_unequipItem(player)
+    if not self:_canManageInventory(player) then
+        return
+    end
+
+    local success, result = self.InventoryService:unequip(player)
+    if not success then
+        self:_setStatus(
+            string.format(
+                '%s could not stow the held item (%s).',
+                player.DisplayName,
+                tostring(result)
+            )
+        )
+        return
+    end
+
+    self:_setStatus(
+        string.format('%s stowed %s back into the backpack.', player.DisplayName, result.Name)
+    )
 end
 
 function RunSessionService:_openGate(player)
@@ -526,10 +1073,10 @@ function RunSessionService:_openGate(player)
     if not self.GateOpen then
         self.GateOpen = true
         self:_syncCampSession()
-        self.World.OpenGate()
+        self.World:openGate()
         self:_setStatus(
             string.format(
-                '%s opened the camp gate. The wilderness trail is now accessible.',
+                '%s opened the temple gate. The wilderness trail is now accessible.',
                 player.DisplayName
             )
         )
@@ -538,87 +1085,7 @@ function RunSessionService:_openGate(player)
 
     self:_setStatus(
         string.format(
-            '%s checked the camp gate. The wilderness trail is already open.',
-            player.DisplayName
-        )
-    )
-end
-
-function RunSessionService:_bindLocalDebugMazeInteractions()
-    if not self.LocalDebugMazeWorld then
-        return
-    end
-
-    self.LocalDebugMazeWorld.ReturnPrompt.Triggered:Connect(function(player)
-        local previousSession = CampMazeSessionContract.normalizeCampSession(self.CampSession)
-        local summary = CampMazeSessionContract.buildReturnSummary({
-            UserId = player.UserId,
-            Name = player.DisplayName,
-            ReturnReason = LOCAL_DEBUG_MAZE_RETURN_REASON,
-            Value = 0,
-            ItemCount = 0,
-            Weight = 0,
-            WasExtracted = false,
-            WasSettled = false,
-        })
-
-        self.CampSession = CampMazeSessionContract.applyReturn(previousSession, summary, false)
-        self.CampSession.GateOpen = self.GateOpen
-
-        local character = player.Character
-        if character and character.Parent and self.World then
-            character:PivotTo(self.World.ReturnCFrame)
-        else
-            self.PendingSpawnByUserId[player.UserId] = true
-            player:LoadCharacter()
-        end
-
-        self:_setStatus(
-            string.format(
-                '%s returned from local maze debug mode back to camp.',
-                player.DisplayName
-            )
-        )
-    end)
-end
-
-function RunSessionService:_ensureLocalDebugMazeWorld()
-    if self.LocalDebugMazeWorld then
-        return
-    end
-
-    self.LocalDebugMazeWorld =
-        LocalDebugMazeWorldBuilder.build(self.SessionData.Seed, SessionConfig.ProcGen)
-    self:_bindLocalDebugMazeInteractions()
-end
-
-function RunSessionService:_enterLocalDebugMaze(player)
-    self:_ensureLocalDebugMazeWorld()
-
-    local previousSession = CampMazeSessionContract.normalizeCampSession(self.CampSession)
-    local nextSession = CampMazeSessionContract.markPlayerEntered(previousSession, {
-        UserId = player.UserId,
-        Name = player.DisplayName,
-    })
-    nextSession.GateOpen = self.GateOpen
-    self.CampSession = nextSession
-
-    local character = player.Character
-    if character and character.Parent then
-        character:PivotTo(self.LocalDebugMazeWorld.SpawnCFrame)
-        self.PendingLocalMazeSpawnByUserId[player.UserId] = nil
-    else
-        self.PendingLocalMazeSpawnByUserId[player.UserId] = true
-        player:LoadCharacter()
-    end
-
-    self.MazeEntryMode = MazeEntryAvailability.Mode.LocalDebugFallback
-    self.MazeEntryReasonCode = MazeEntryAvailability.ReasonCode.LocalDebugFallbackEnabled
-    self.MazeEntryReason =
-        'Studio local debug fallback is active. You were moved to an in-place maze sandbox.'
-    self:_setStatus(
-        string.format(
-            '%s entered local maze debug mode (no cross-place teleport).',
+            '%s checked the temple gate. The wilderness trail is already open.',
             player.DisplayName
         )
     )
@@ -634,15 +1101,16 @@ function RunSessionService:_enterMaze(player)
         end
 
         if self.CampSession.MazeStatus == CampMazeSessionContract.MazeStatus.Completed then
-            self:_setStatus('The maze session is already complete for this camp.')
+            self:_setStatus('The maze session is already complete for this temple.')
             return
         end
 
-        local result = RunMazePortal.enter({
+        local result = self.RunToMazeTransition:enter({
             Player = player,
             CampSession = self.CampSession,
             GateOpen = self.GateOpen,
             SessionConfig = self.SessionData,
+            PlayerInventory = self.InventoryService:getSummary(player),
             EnteringPlayer = {
                 UserId = player.UserId,
                 Name = player.DisplayName,
@@ -669,11 +1137,27 @@ function RunSessionService:_enterMaze(player)
 end
 
 function RunSessionService:_isPlayerNearMazePrompt(player)
-    if not self.World or not self.World.MazePrompt then
+    return self:_isPlayerNearTerminalPrompt(
+        player,
+        self.World and self.World.MazePortal,
+        MAZE_ENTRY_DISTANCE_BUFFER
+    )
+end
+
+function RunSessionService:_isPlayerNearTerminalPrompt(player, terminalOrPrompt, distanceBuffer)
+    if not terminalOrPrompt then
         return false
     end
 
-    local promptPart = self.World.MazePrompt.Parent
+    if type(terminalOrPrompt.isPlayerNear) == 'function' then
+        return terminalOrPrompt:isPlayerNear(
+            player,
+            distanceBuffer or TERMINAL_INTERACTION_DISTANCE_BUFFER
+        )
+    end
+
+    local prompt = terminalOrPrompt
+    local promptPart = prompt.Parent
     if not promptPart or not promptPart:IsA('BasePart') then
         return false
     end
@@ -684,7 +1168,8 @@ function RunSessionService:_isPlayerNearMazePrompt(player)
         return false
     end
 
-    local maxDistance = self.World.MazePrompt.MaxActivationDistance + MAZE_ENTRY_DISTANCE_BUFFER
+    local maxDistance = prompt.MaxActivationDistance
+        + (distanceBuffer or TERMINAL_INTERACTION_DISTANCE_BUFFER)
     return (rootPart.Position - promptPart.Position).Magnitude <= maxDistance
 end
 
@@ -696,7 +1181,7 @@ function RunSessionService:_requestMazeEntry(player, requireDistanceCheck)
     if not self.GateOpen then
         self:_setStatus(
             string.format(
-                '%s checked the maze gate, but the camp gate is still closed.',
+                '%s checked the maze gate, but the temple gate is still closed.',
                 player.DisplayName
             )
         )
@@ -710,11 +1195,6 @@ function RunSessionService:_requestMazeEntry(player, requireDistanceCheck)
     local availability = self:_resolveMazeEntryAvailability()
     if availability.Mode == MazeEntryAvailability.Mode.Teleport then
         self:_enterMaze(player)
-        return
-    end
-
-    if availability.Mode == MazeEntryAvailability.Mode.LocalDebugFallback then
-        self:_enterLocalDebugMaze(player)
         return
     end
 
@@ -747,25 +1227,38 @@ function RunSessionService:_launchRun(_player)
         return
     end
 
-    self.IsLaunched = true
-    Players.CharacterAutoLoads = true
     self.GateOpen = self.CampSession.GateOpen == true
     self:_syncCampSession()
 
     self:_rebuildWorld()
+
+    self.IsLaunched = true
+    Players.CharacterAutoLoads = true
 
     for _, player in ipairs(Players:GetPlayers()) do
         player:LoadCharacter()
     end
 
     self:_startSnapshotLoop()
-    if self.Status == 'Select Enter Camp to enter the camp.' then
+    if self.Status == INITIAL_TEMPLE_STATUS then
         self:_setStatus(
-            'Camp is ready. Gather inside, then open the gate when you want to head out.'
+            'Temple is ready. Gather inside, then open the gate when you want to head out.'
         )
     else
         self:_broadcastSnapshot()
     end
+end
+
+function RunSessionService:_getPlayerUpdateContext(player)
+    local character = player.Character
+    local humanoid = character and character:FindFirstChildOfClass('Humanoid')
+    local rootPart = humanoid and humanoid.RootPart
+    local currentPosition = rootPart and rootPart.Position or Vector3.zero
+
+    return {
+        CurrentPosition = currentPosition,
+        InputState = {},
+    }
 end
 
 function RunSessionService:_startSnapshotLoop()
@@ -781,11 +1274,14 @@ function RunSessionService:_startSnapshotLoop()
 
             if self.IsLaunched then
                 local currentTick = os.clock()
-                self.PlayerStateService:step(currentTick - previousTick)
+                local dt = currentTick - previousTick
                 previousTick = currentTick
 
                 for _, player in ipairs(Players:GetPlayers()) do
+                    local context = self:_getPlayerUpdateContext(player)
+                    self.PlayerService:update(player, dt, context)
                     self:_syncPlayerMovement(player)
+                    self:_updateOceanPerPlayer(player, dt)
                 end
 
                 self:_broadcastSnapshot()
@@ -801,7 +1297,7 @@ function RunSessionService:_setPlayerSprinting(player, isSprinting)
         return
     end
 
-    local playerState = self.PlayerStateService:getSummary(player)
+    local playerState = self.PlayerService:getSummary(player)
     local success, result
     if isSprinting then
         success, result = self.ControlStateService:requestSprintStart(player, playerState)
@@ -834,6 +1330,7 @@ function RunSessionService:_handlePlayerTeleportData(player)
     end
 
     self:_applySessionConfig(teleportData.SessionConfig)
+    self:_hydratePlayerInventory(player, teleportData)
 
     local summary = CampMazeSessionContract.findReturnSummary(teleportData, player.UserId)
     if summary then
@@ -846,7 +1343,21 @@ function RunSessionService:_handlePlayerTeleportData(player)
         PreserveMazeEntry = CampMazeSessionContract.isPlayerInMaze(self.CampSession, player.UserId),
     })
     self.GateOpen = self.CampSession.GateOpen
-    self.Status = string.format('%s joined the camp session.', player.DisplayName)
+    self.Status = string.format('%s joined the temple session.', player.DisplayName)
+end
+
+function RunSessionService:_ensureAuthoritativeSessionSeed()
+    local seed, issuedNewSeed = SessionSeedPolicy.ensureAuthoritativeSeed({
+        CurrentSeed = self.SessionData.Seed,
+        DefaultSeed = SessionConfig.DefaultSeed,
+        HasAuthoritativeSeed = self.HasAuthoritativeSessionSeed,
+        RandomSource = self.SessionSeedRandom or Random.new(),
+    })
+
+    self.SessionData.Seed = seed
+    if issuedNewSeed then
+        self.HasAuthoritativeSessionSeed = true
+    end
 end
 
 function RunSessionService:_ensureAuthoritativeSessionSeed()
@@ -864,6 +1375,7 @@ function RunSessionService:_ensureAuthoritativeSessionSeed()
 end
 
 function RunSessionService:start()
+    warn(string.format('[run-session] build=%s', self.BuildFingerprint))
     self:_loadSessionDataFromJoin()
     self:_ensureAuthoritativeSessionSeed()
     Players.CharacterAutoLoads = false
@@ -871,6 +1383,7 @@ function RunSessionService:start()
     for _, player in ipairs(Players:GetPlayers()) do
         bindCharacterTeleport(self, player)
         self:_addPlayerState(player)
+        self:_hydratePlayerInventory(player, self:_readTeleportData(player))
 
         if player.Character then
             player.Character:Destroy()
@@ -891,8 +1404,11 @@ function RunSessionService:start()
 
     Players.PlayerRemoving:Connect(function(player)
         self.LastMazeEntryRequestAtByUserId[player.UserId] = nil
+        self.LastOceanSplashAtByUserId[player.UserId] = nil
+        self.OceanStateByUserId[player.UserId] = nil
+        self.OceanTimersByUserId[player.UserId] = nil
+        self.OceanOriginalSpeedsByUserId[player.UserId] = nil
         self.PendingSpawnByUserId[player.UserId] = nil
-        self.PendingLocalMazeSpawnByUserId[player.UserId] = nil
         self.CampSession = CampMazeSessionContract.prunePlayer(self.CampSession, player.UserId, {
             PreserveMazeEntry = CampMazeSessionContract.isPlayerInMaze(
                 self.CampSession,
@@ -915,6 +1431,14 @@ function RunSessionService:start()
             if self:_canProcessMazeEntryRequest(player) then
                 self:_requestMazeEntry(player, true)
             end
+        elseif payload.Type == 'RequestPurchaseItem' then
+            self:_handlePurchase(player, payload.ItemId)
+        elseif payload.Type == 'RequestSellItem' then
+            self:_handleSell(player, payload.ItemInstanceId)
+        elseif payload.Type == 'RequestEquipItem' then
+            self:_equipItem(player, payload.ItemInstanceId)
+        elseif payload.Type == 'RequestUnequipItem' then
+            self:_unequipItem(player)
         elseif payload.Type == 'RequestSprintStart' then
             self:_setPlayerSprinting(player, true)
         elseif payload.Type == 'RequestSprintStop' then
@@ -922,7 +1446,7 @@ function RunSessionService:start()
         elseif payload.Type == 'RequestStartExpedition' then
             self:_setStatus(
                 string.format(
-                    '%s checked the old deploy action. Use the camp gate to head outside instead.',
+                    '%s checked the old deploy action. Use the temple gate to head outside instead.',
                     player.DisplayName
                 )
             )
@@ -931,9 +1455,7 @@ function RunSessionService:start()
 
     self:_broadcastSnapshot()
 
-    if self.ShouldAutoLaunch then
-        self:_launchRun(nil)
-    end
+    self:_launchRun(nil)
 end
 
 return RunSessionService

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -629,7 +629,8 @@ function RunSessionService:_applyReturnedPlayersFromTeleportData(players, accept
         local teleportData = self:_readTeleportData(player) or acceptedTeleportData
         local returnSummary = CampMazeSessionContract.findReturnSummary(teleportData, player.UserId)
         if returnSummary then
-            self.PendingSpawnByUserId[player.UserId] = self:_getReturnSpawnCFrameForSummary(returnSummary)
+            self.PendingSpawnByUserId[player.UserId] =
+                self:_getReturnSpawnCFrameForSummary(returnSummary)
             table.insert(returnedPlayers, {
                 Player = player,
                 Summary = returnSummary,
@@ -683,7 +684,28 @@ function RunSessionService:_rebuildWorld()
     clearDefaultWorkspaceShell()
     self.World = RunWorldBuilder.build()
     if self.GateOpen then
-        self.World.OpenGate()
+        self.World:openGate()
+    end
+
+    self.WorldInteractions = self.World:bindInteractions({
+        OnShop = function(player)
+            if not self:_canManageInventory(player) then
+                return
+            end
+
+            self:_openShop(player)
+        end,
+        OnSell = function(player)
+            if not self:_canManageInventory(player) then
+                return
+            end
+
+            self:_openSell(player)
+        end,
+        OnObjective = function(player)
+            self:_openObjectiveBoard(player)
+        end,
+        OnLoadout = function(player)
             self:_setStatus(
                 string.format(
                     '%s checked the loadout bench. Equipment setup is coming soon.',

--- a/places/run/src/ServerScriptService/Run/RunStaticWorldContract.luau
+++ b/places/run/src/ServerScriptService/Run/RunStaticWorldContract.luau
@@ -1,0 +1,14 @@
+local RunStaticWorldContract = table.freeze({
+    RootName = 'RunStaticWorld',
+    CollisionRootName = 'Collision',
+    SceneCollisionName = 'Scene',
+    ShipCollisionName = 'Ship',
+    TriggersRootName = 'Triggers',
+    OceanTriggerName = 'Ocean',
+    BuildFingerprint = 'run-collision-contract-v2',
+    SpawnGroundCheckDepth = 32,
+    SpawnLiftStuds = 4,
+    OceanSplashCooldownSeconds = 1.5,
+})
+
+return RunStaticWorldContract

--- a/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
+++ b/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
@@ -1,0 +1,213 @@
+local Workspace = game:GetService('Workspace')
+
+local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
+
+local RunStaticWorldValidator = {}
+local REQUIRED_MARKER_NAMES = table.freeze({
+    'SpawnMarker',
+    'ReturnMarker',
+    'MazeReturnMarker',
+})
+
+local function requireContainer(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not (child:IsA('Folder') or child:IsA('Model')) then
+        error(string.format('%s is missing required container "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function collectBaseParts(root)
+    local parts = {}
+
+    for _, descendant in ipairs(root:GetDescendants()) do
+        if descendant:IsA('BasePart') then
+            table.insert(parts, descendant)
+        end
+    end
+
+    return parts
+end
+
+local function requireBaseParts(root, contextLabel)
+    local parts = collectBaseParts(root)
+    if #parts == 0 then
+        error(string.format('%s must contain at least one BasePart.', contextLabel), 0)
+    end
+
+    return parts
+end
+
+local function validateCollisionParts(parts, contextLabel)
+    for _, part in ipairs(parts) do
+        if part.Anchored ~= true then
+            error(string.format('%s part "%s" must be Anchored.', contextLabel, part.Name), 0)
+        end
+        if part.CanCollide ~= true then
+            error(
+                string.format('%s part "%s" must have CanCollide=true.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.CanTouch ~= false then
+            error(
+                string.format('%s part "%s" must have CanTouch=false.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.CanQuery ~= true then
+            error(
+                string.format('%s part "%s" must have CanQuery=true.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.Transparency ~= 1 then
+            error(
+                string.format('%s part "%s" must have Transparency=1.', contextLabel, part.Name),
+                0
+            )
+        end
+    end
+end
+
+local function validateOceanParts(parts, contextLabel)
+    for _, part in ipairs(parts) do
+        if part.Anchored ~= true then
+            error(string.format('%s part "%s" must be Anchored.', contextLabel, part.Name), 0)
+        end
+        if part.CanCollide ~= false then
+            error(
+                string.format('%s part "%s" must have CanCollide=false.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.CanTouch ~= true then
+            error(
+                string.format('%s part "%s" must have CanTouch=true.', contextLabel, part.Name),
+                0
+            )
+        end
+        if part.Transparency ~= 1 then
+            error(
+                string.format('%s part "%s" must have Transparency=1.', contextLabel, part.Name),
+                0
+            )
+        end
+    end
+end
+
+local function validateMarkerPart(part, contextLabel)
+    if part.Anchored ~= true then
+        error(string.format('%s must be Anchored.', contextLabel), 0)
+    end
+    if part.CanCollide ~= false then
+        error(string.format('%s must have CanCollide=false.', contextLabel), 0)
+    end
+    if part.CanTouch ~= false then
+        error(string.format('%s must have CanTouch=false.', contextLabel), 0)
+    end
+    if part.CanQuery ~= true then
+        error(string.format('%s must have CanQuery=true.', contextLabel), 0)
+    end
+end
+
+local function buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
+    local raycastParams = RaycastParams.new()
+    raycastParams.FilterType = Enum.RaycastFilterType.Include
+    raycastParams.FilterDescendantsInstances = { sceneCollisionRoot, shipCollisionRoot }
+    return raycastParams
+end
+
+local function buildSpawnGroundSampleOffsets(spawnMarker)
+    local offsetX = math.max(spawnMarker.Size.X * 0.35, 1)
+    local offsetZ = math.max(spawnMarker.Size.Z * 0.35, 1)
+
+    return {
+        Vector3.zero,
+        Vector3.new(offsetX, 0, offsetZ),
+        Vector3.new(offsetX, 0, -offsetZ),
+        Vector3.new(-offsetX, 0, offsetZ),
+        Vector3.new(-offsetX, 0, -offsetZ),
+    }
+end
+
+local function assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, spawnMarker)
+    local raycastParams = buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot)
+    local sampleOffsets = buildSpawnGroundSampleOffsets(spawnMarker)
+    local raycastDistance = Vector3.new(0, -RunStaticWorldContract.SpawnGroundCheckDepth, 0)
+    local raycastStartHeight = (spawnMarker.Size.Y * 0.5) + 2
+
+    for _, offset in ipairs(sampleOffsets) do
+        local origin = spawnMarker.Position + Vector3.new(offset.X, raycastStartHeight, offset.Z)
+        local result = Workspace:Raycast(origin, raycastDistance, raycastParams)
+        if result and result.Instance and result.Instance.CanCollide and result.Normal.Y > 0.5 then
+            return
+        end
+    end
+
+    error(
+        string.format(
+            'RunStaticWorld SpawnMarker must raycast onto Collision/Scene or Collision/Ship within %d studs below it.',
+            RunStaticWorldContract.SpawnGroundCheckDepth
+        ),
+        0
+    )
+end
+
+function RunStaticWorldValidator.validate(root)
+    if root.Parent ~= Workspace then
+        error('RunStaticWorld must be parented to Workspace before validation.', 0)
+    end
+
+    local collisionRoot =
+        requireContainer(root, RunStaticWorldContract.CollisionRootName, 'RunStaticWorld')
+    local sceneCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.SceneCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local shipCollisionRoot = requireContainer(
+        collisionRoot,
+        RunStaticWorldContract.ShipCollisionName,
+        'RunStaticWorld Collision'
+    )
+    local triggersRoot =
+        requireContainer(root, RunStaticWorldContract.TriggersRootName, 'RunStaticWorld')
+    local oceanTriggerRoot = requireContainer(
+        triggersRoot,
+        RunStaticWorldContract.OceanTriggerName,
+        'RunStaticWorld Triggers'
+    )
+
+    validateCollisionParts(
+        requireBaseParts(sceneCollisionRoot, 'RunStaticWorld Collision/Scene'),
+        'RunStaticWorld Collision/Scene'
+    )
+    validateCollisionParts(
+        requireBaseParts(shipCollisionRoot, 'RunStaticWorld Collision/Ship'),
+        'RunStaticWorld Collision/Ship'
+    )
+    validateOceanParts(
+        requireBaseParts(oceanTriggerRoot, 'RunStaticWorld Triggers/Ocean'),
+        'RunStaticWorld Triggers/Ocean'
+    )
+
+    local spawnMarker = nil
+    for _, markerName in ipairs(REQUIRED_MARKER_NAMES) do
+        local markerPart = root:FindFirstChild(markerName, true)
+        if markerPart == nil or not markerPart:IsA('BasePart') then
+            error(string.format('RunStaticWorld is missing required part "%s".', markerName), 0)
+        end
+
+        validateMarkerPart(markerPart, string.format('RunStaticWorld marker "%s"', markerName))
+
+        if markerName == 'SpawnMarker' then
+            spawnMarker = markerPart
+        end
+    end
+
+    assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, spawnMarker)
+end
+
+return RunStaticWorldValidator

--- a/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
+++ b/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
@@ -1,13 +1,11 @@
 local Workspace = game:GetService('Workspace')
 
 local RunScene = require(script.Parent.RunScene)
-local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
 local RunStaticWorldValidator = require(script.Parent.RunStaticWorldValidator)
-local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
 
 local RunWorldBuilder = {}
 
-<local OUTDOOR_THRESHOLD_Z = 20
+local OUTDOOR_THRESHOLD_Z = 20
 local DEFAULT_SPAWN_CFRAME = CFrame.new(0, 4, -6)
 local DEFAULT_RETURN_CFRAME = CFrame.new(0, 4, -2)
 local MAZE_RETURN_CFRAME = CFrame.new(0, 4, 108)
@@ -41,87 +39,6 @@ local function prepareRunTerrain(root)
     stabilizeVisualModel(terrainRoot:FindFirstChild('Sci-Fi Space Ship'))
 end
 
-local function findNamedDescendant(root, name)
-    for _, descendant in ipairs(root:GetDescendants()) do
-        if descendant.Name == name then
-            return descendant
-        end
-    end
-
-    return nil
-end
-
-local function findPromptOnPart(root, partName)
-    local part = findNamedDescendant(root, partName)
-    if not part or not part:IsA('BasePart') then
-        return nil
-    end
-
-    return part:FindFirstChildOfClass('ProximityPrompt')
-end
-
-local function requirePromptOnPart(root, partName)
-    local prompt = findPromptOnPart(root, partName)
-    if prompt then
-        return prompt
-    end
-
-    error(
-        string.format(
-            '%s is missing a ProximityPrompt on part "%s".',
-            STATIC_WORLD_ROOT_NAME,
-            partName
-        )
-    )
-end
-
-local function resolveMarkerCFrame(root, markerName, fallback)
-    local marker = findNamedDescendant(root, markerName)
-    if marker and marker:IsA('BasePart') then
-        return marker.CFrame
-    end
-
-    return fallback
-end
-
-local function buildFromStaticWorld(staticWorldRoot)
-    local doorLeft = findNamedDescendant(staticWorldRoot, 'DoorLeft')
-    local doorRight = findNamedDescendant(staticWorldRoot, 'DoorRight')
-    local gatePrompt = requirePromptOnPart(staticWorldRoot, 'GateSwitch')
-
-    local function openGate()
-        if doorLeft and doorLeft:IsA('BasePart') then
-            doorLeft.CanCollide = false
-            doorLeft.Transparency = 1
-        end
-
-        if doorRight and doorRight:IsA('BasePart') then
-            doorRight.CanCollide = false
-            doorRight.Transparency = 1
-        end
-
-        gatePrompt.ActionText = 'Gate Open'
-    end
-
-    return {
-        Root = staticWorldRoot,
-        SpawnCFrame = resolveMarkerCFrame(staticWorldRoot, 'SpawnMarker', DEFAULT_SPAWN_CFRAME),
-        ReturnCFrame = resolveMarkerCFrame(staticWorldRoot, 'ReturnMarker', DEFAULT_RETURN_CFRAME),
-        MazeReturnCFrame = resolveMarkerCFrame(
-            staticWorldRoot,
-            'MazeReturnMarker',
-            MAZE_RETURN_CFRAME
-        ),
-        OutdoorThresholdZ = tonumber(staticWorldRoot:GetAttribute('OutdoorThresholdZ'))
-            or OUTDOOR_THRESHOLD_Z,
-        ShopPrompt = requirePromptOnPart(staticWorldRoot, 'ShopTerminal'),
-        LoadoutPrompt = requirePromptOnPart(staticWorldRoot, 'LoadoutBench'),
-        GatePrompt = gatePrompt,
-        MazePrompt = requirePromptOnPart(staticWorldRoot, 'MazeGateMarker'),
-        OpenGate = openGate,
-    }
-end
-
 function RunWorldBuilder.build()
     local staticWorldRoot = Workspace:FindFirstChild(STATIC_WORLD_ROOT_NAME)
     if staticWorldRoot and (staticWorldRoot:IsA('Folder') or staticWorldRoot:IsA('Model')) then
@@ -145,11 +62,7 @@ function RunWorldBuilder.build()
         ReturnCFrame = DEFAULT_RETURN_CFRAME,
         MazeReturnCFrame = MAZE_RETURN_CFRAME,
         OutdoorThresholdZ = OUTDOOR_THRESHOLD_Z,
-        ShopPrompt = house.ShopPrompt,
-        LoadoutPrompt = house.LoadoutPrompt,
-        GatePrompt = house.GatePrompt,
-        MazePrompt = outdoors.MazePrompt,
-        OpenGate = house.OpenGate,
+        OpenGate = function() end,
     }
 end
 

--- a/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
+++ b/places/run/src/ServerScriptService/Run/RunWorldBuilder.luau
@@ -1,57 +1,44 @@
 local Workspace = game:GetService('Workspace')
 
-local CampHouseBuilder = require(script.Parent.CampHouseBuilder)
-local OutdoorAreaBuilder = require(script.Parent.OutdoorAreaBuilder)
+local RunScene = require(script.Parent.RunScene)
+local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
+local RunStaticWorldValidator = require(script.Parent.RunStaticWorldValidator)
+local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
 
 local RunWorldBuilder = {}
 
-local OUTDOOR_THRESHOLD_Z = 20
+<local OUTDOOR_THRESHOLD_Z = 20
 local DEFAULT_SPAWN_CFRAME = CFrame.new(0, 4, -6)
 local DEFAULT_RETURN_CFRAME = CFrame.new(0, 4, -2)
 local MAZE_RETURN_CFRAME = CFrame.new(0, 4, 108)
 local GENERATED_WORLD_ROOT_NAME = 'GeneratedWorld'
 local STATIC_WORLD_ROOT_NAME = 'RunStaticWorld'
 
-local function createPart(config, parent)
-    local part = Instance.new('Part')
-    part.Name = config.Name
-    part.Anchored = true
-    part.Size = config.Size
-    part.CFrame = config.CFrame
-    part.Color = config.Color
-    part.Material = config.Material or Enum.Material.SmoothPlastic
-    part.Transparency = config.Transparency or 0
-    part.CanCollide = config.CanCollide ~= false
-    part.Shape = config.Shape or Enum.PartType.Block
-    part.Parent = parent
-    return part
+local function stabilizeVisualModel(model)
+    if model == nil then
+        return
+    end
+
+    for _, descendant in ipairs(model:GetDescendants()) do
+        if descendant:IsA('BasePart') then
+            descendant.Anchored = true
+            descendant.CanCollide = false
+            descendant.CanTouch = false
+            descendant.CanQuery = true
+            descendant.AssemblyLinearVelocity = Vector3.zero
+            descendant.AssemblyAngularVelocity = Vector3.zero
+        end
+    end
 end
 
-local function createPromptPart(config, parent)
-    local part = createPart({
-        Name = config.Name,
-        Size = config.Size or Vector3.new(4, 4, 4),
-        CFrame = config.CFrame,
-        Color = config.Color,
-        Material = config.Material or Enum.Material.Metal,
-        Transparency = config.Transparency or 0,
-        CanCollide = config.CanCollide,
-    }, parent)
-
-    local prompt = Instance.new('ProximityPrompt')
-    prompt.ActionText = config.ActionText
-    prompt.ObjectText = config.ObjectText
-    prompt.HoldDuration = 0
-    prompt.MaxActivationDistance = config.MaxActivationDistance or 10
-    if config.KeyboardKeyCode ~= nil then
-        prompt.KeyboardKeyCode = config.KeyboardKeyCode
+local function prepareRunTerrain(root)
+    local terrainRoot = root:FindFirstChild('RunTerrain_Main')
+    if terrainRoot == nil or not terrainRoot:IsA('Model') then
+        return
     end
-    if config.RequiresLineOfSight ~= nil then
-        prompt.RequiresLineOfSight = config.RequiresLineOfSight
-    end
-    prompt.Parent = part
 
-    return part, prompt
+    stabilizeVisualModel(terrainRoot:FindFirstChild('Scene'))
+    stabilizeVisualModel(terrainRoot:FindFirstChild('Sci-Fi Space Ship'))
 end
 
 local function findNamedDescendant(root, name)
@@ -138,7 +125,9 @@ end
 function RunWorldBuilder.build()
     local staticWorldRoot = Workspace:FindFirstChild(STATIC_WORLD_ROOT_NAME)
     if staticWorldRoot and (staticWorldRoot:IsA('Folder') or staticWorldRoot:IsA('Model')) then
-        return buildFromStaticWorld(staticWorldRoot)
+        prepareRunTerrain(staticWorldRoot)
+        RunStaticWorldValidator.validate(staticWorldRoot)
+        return RunScene.new(staticWorldRoot)
     end
 
     local existing = Workspace:FindFirstChild(GENERATED_WORLD_ROOT_NAME)
@@ -149,9 +138,6 @@ function RunWorldBuilder.build()
     local worldFolder = Instance.new('Folder')
     worldFolder.Name = GENERATED_WORLD_ROOT_NAME
     worldFolder.Parent = Workspace
-
-    local house = CampHouseBuilder.build(worldFolder, createPart, createPromptPart)
-    local outdoors = OutdoorAreaBuilder.build(worldFolder, createPart, createPromptPart)
 
     return {
         Root = worldFolder,

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -674,7 +674,15 @@ local function hideOceanSlowdown()
     oceanSlowdownTween:Play()
 end
 
+local currentSplashTweens = nil
+
 local function showOceanSplash(message)
+    if currentSplashTweens then
+        currentSplashTweens.flashIn:Cancel()
+        currentSplashTweens.flashOut:Cancel()
+        currentSplashTweens = nil
+    end
+
     showToast(message or 'Splash!', 'Success')
 
     oceanSplashOverlay.BackgroundTransparency = 1
@@ -694,9 +702,13 @@ local function showOceanSplash(message)
         }
     )
 
+    currentSplashTweens = { flashIn = flashIn, flashOut = flashOut }
     flashIn:Play()
     flashIn.Completed:Connect(function()
         flashOut:Play()
+        flashOut.Completed:Connect(function()
+            currentSplashTweens = nil
+        end)
     end)
 
     -- Also show sustained slowdown overlay

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -1,6 +1,7 @@
 local Players = game:GetService('Players')
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 local RunService = game:GetService('RunService')
+local TweenService = game:GetService('TweenService')
 local UserInputService = game:GetService('UserInputService')
 
 local localPlayer = Players.LocalPlayer
@@ -10,19 +11,38 @@ local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Shared = require(Packages:WaitForChild('Shared'))
 local UI = require(Packages:WaitForChild('UI'))
 
-local Remotes = Shared.Network.Remotes.ensureScope(Shared.Network.Remotes.Scope.Run)
+local Remotes = Shared.Network.Remotes.waitForScope(Shared.Network.Remotes.Scope.Run)
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
+local heldItemController = Shared.Client.HeldItemController.new(localPlayer)
 local Theme = UI.Hud.Theme
+
+local TEMPLE_LABEL = 'Temple'
+local PAGE_LABEL = 'Pages'
+local SAND_BOOK_LABEL = 'Book of Sand'
+local SAND_BOOK_PROGRESS_LABEL = 'Book of Sand Progress'
 
 local disconnectFirstPersonLock
 local ensureFirstPersonLock
 local canRequestMazeEntry = false
 local isRunLaunched = false
 local isCampPanelVisible = true
+local isMouseFree = false
 local actionInputConnection
 local sprintInputEndedConnection
 local isMenuMouseUnlockBound = false
+local visibleBackpackItems = {}
 local MENU_MOUSE_UNLOCK_STEP = 'RunMenuMouseUnlock'
+local MOUSE_TOGGLE_KEY = Enum.KeyCode.LeftAlt
+local teamPages = 0
+local goalAmount = 120
+local goalProgress = 0
+local inventorySummary = nil
+local activeShopItems = {}
+local activeSalvageItems = {}
+local activeModal = nil
+local activeBuildFingerprint = 'unknown'
+local isInOcean = false
+local oceanSlowdownTween = nil
 ensureFirstPersonLock = function()
     disconnectFirstPersonLock = Shared.Client.FirstPersonController.start(localPlayer)
     ensureFirstPersonLock = function() end
@@ -73,6 +93,17 @@ local function releaseFirstPersonLockForMenu()
     UserInputService.MouseIconEnabled = true
 end
 
+local function syncMouseMode()
+    if not isRunLaunched or isMouseFree or activeModal ~= nil then
+        releaseFirstPersonLockForMenu()
+        bindMenuMouseUnlock()
+        return
+    end
+
+    unbindMenuMouseUnlock()
+    ensureFirstPersonLock()
+end
+
 script.Destroying:Connect(function()
     if disconnectFirstPersonLock ~= nil then
         disconnectFirstPersonLock()
@@ -89,6 +120,7 @@ script.Destroying:Connect(function()
         sprintInputEndedConnection = nil
     end
 
+    heldItemController:destroy()
     unbindMenuMouseUnlock()
 end)
 
@@ -112,6 +144,70 @@ local function makeTextLabel(parent, size, color, textSize, bold)
     return label
 end
 
+local function makeButton(parent, text, height, backgroundColor)
+    local button = Instance.new('TextButton')
+    button.Size = UDim2.new(1, 0, 0, height)
+    button.BackgroundColor3 = backgroundColor
+    button.TextColor3 = Theme.Background
+    button.Font = Enum.Font.GothamBold
+    button.TextSize = 18
+    button.Text = text
+    button.AutoButtonColor = true
+    button.Parent = parent
+
+    local corner = Instance.new('UICorner')
+    corner.CornerRadius = UDim.new(0, 10)
+    corner.Parent = button
+
+    local stroke = Instance.new('UIStroke')
+    stroke.Color = Theme.Background
+    stroke.Transparency = 0.65
+    stroke.Thickness = 1
+    stroke.Parent = button
+
+    local gradient = Instance.new('UIGradient')
+    gradient.Rotation = 90
+    local base = button.BackgroundColor3
+    gradient.Color = ColorSequence.new({
+        ColorSequenceKeypoint.new(0, base:Lerp(Color3.new(1, 1, 1), 0.08)),
+        ColorSequenceKeypoint.new(1, base:Lerp(Color3.new(0, 0, 0), 0.12)),
+    })
+    gradient.Parent = button
+
+    return button
+end
+
+local function clearLayoutChildren(container)
+    for _, child in ipairs(container:GetChildren()) do
+        if child:IsA('TextButton') or child:IsA('TextLabel') or child:IsA('Frame') then
+            if child.Name ~= 'UIListLayout' and child.Name ~= 'UICorner' then
+                child:Destroy()
+            end
+        end
+    end
+end
+
+local function applyPanelStyle(frame, cornerRadius, strokeTransparency)
+    local corner = Instance.new('UICorner')
+    corner.CornerRadius = UDim.new(0, cornerRadius)
+    corner.Parent = frame
+
+    local stroke = Instance.new('UIStroke')
+    stroke.Color = Theme.Text
+    stroke.Transparency = strokeTransparency or 0.86
+    stroke.Thickness = 1
+    stroke.Parent = frame
+
+    local gradient = Instance.new('UIGradient')
+    gradient.Rotation = 90
+    local base = frame.BackgroundColor3
+    gradient.Color = ColorSequence.new({
+        ColorSequenceKeypoint.new(0, base:Lerp(Color3.new(1, 1, 1), 0.03)),
+        ColorSequenceKeypoint.new(1, base:Lerp(Color3.new(0, 0, 0), 0.08)),
+    })
+    gradient.Parent = frame
+end
+
 local function buildMazeEntryText(snapshot)
     local mode = snapshot.MazeEntryMode or 'Blocked'
     local reasonCode = snapshot.MazeEntryReasonCode or 'Unknown'
@@ -123,11 +219,24 @@ local function buildMazeEntryText(snapshot)
     return string.format('%s [%s]', mode, reasonCode)
 end
 
+local function buildFingerprintText(snapshot)
+    local fingerprint = snapshot.BuildFingerprint or activeBuildFingerprint or 'unknown'
+    return string.format('Build: %s', fingerprint)
+end
+
 local menuBackdrop = Instance.new('Frame')
 menuBackdrop.Name = 'StartMenu'
 menuBackdrop.Size = UDim2.fromScale(1, 1)
 menuBackdrop.BackgroundColor3 = Theme.Background
 menuBackdrop.Parent = screenGui
+
+local menuBackdropGradient = Instance.new('UIGradient')
+menuBackdropGradient.Rotation = 120
+menuBackdropGradient.Color = ColorSequence.new({
+    ColorSequenceKeypoint.new(0, Theme.Background:Lerp(Color3.new(1, 1, 1), 0.02)),
+    ColorSequenceKeypoint.new(1, Theme.Background:Lerp(Color3.new(0, 0, 0), 0.12)),
+})
+menuBackdropGradient.Parent = menuBackdrop
 
 local menuPanel = Instance.new('Frame')
 menuPanel.Name = 'Panel'
@@ -138,9 +247,7 @@ menuPanel.BackgroundColor3 = Theme.Surface
 menuPanel.BorderSizePixel = 0
 menuPanel.Parent = menuBackdrop
 
-local menuCorner = Instance.new('UICorner')
-menuCorner.CornerRadius = UDim.new(0, 18)
-menuCorner.Parent = menuPanel
+applyPanelStyle(menuPanel, 18, 0.8)
 
 local menuPadding = Instance.new('UIPadding')
 menuPadding.PaddingTop = UDim.new(0, 28)
@@ -154,14 +261,14 @@ menuList.Padding = UDim.new(0, 14)
 menuList.Parent = menuPanel
 
 local eyebrow = makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 20), Theme.Accent, 16, true)
-eyebrow.Text = 'CAMP STAGING PROTOTYPE'
+eyebrow.Text = 'TEMPLE STAGING PROTOTYPE'
 
 local menuTitle = makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 72), Theme.Text, 34, true)
-menuTitle.Text = 'Enter the expedition camp'
+menuTitle.Text = string.format('Enter the %s', TEMPLE_LABEL)
 
 local menuBody = makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 78), Theme.SubtleText, 18, false)
 menuBody.Text =
-    'Start inside the camp house, meet up with the crew, and open the main gate when you are ready to step into the wilderness and the shared maze gate.'
+    'Start inside the temple hall, meet up with the crew, and open the main gate when you are ready to step into the wilderness and the shared maze gate.'
 
 local singlePlayerButton = Instance.new('TextButton')
 singlePlayerButton.Size = UDim2.new(1, 0, 0, 52)
@@ -169,16 +276,30 @@ singlePlayerButton.BackgroundColor3 = Theme.Accent
 singlePlayerButton.TextColor3 = Theme.Background
 singlePlayerButton.Font = Enum.Font.GothamBold
 singlePlayerButton.TextSize = 20
-singlePlayerButton.Text = 'Enter Camp'
+singlePlayerButton.Text = string.format('Enter %s', TEMPLE_LABEL)
 singlePlayerButton.Parent = menuPanel
 
 local singlePlayerCorner = Instance.new('UICorner')
 singlePlayerCorner.CornerRadius = UDim.new(0, 12)
 singlePlayerCorner.Parent = singlePlayerButton
 
+local singlePlayerStroke = Instance.new('UIStroke')
+singlePlayerStroke.Color = Theme.Background
+singlePlayerStroke.Transparency = 0.55
+singlePlayerStroke.Thickness = 1
+singlePlayerStroke.Parent = singlePlayerButton
+
+local singlePlayerGradient = Instance.new('UIGradient')
+singlePlayerGradient.Rotation = 90
+singlePlayerGradient.Color = ColorSequence.new({
+    ColorSequenceKeypoint.new(0, Theme.Accent:Lerp(Color3.new(1, 1, 1), 0.1)),
+    ColorSequenceKeypoint.new(1, Theme.Accent:Lerp(Color3.new(0, 0, 0), 0.12)),
+})
+singlePlayerGradient.Parent = singlePlayerButton
+
 local menuStatusLabel =
     makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 52), Theme.SubtleText, 16, false)
-menuStatusLabel.Text = 'Preparing camp access...'
+menuStatusLabel.Text = string.format('Preparing %s access...', TEMPLE_LABEL)
 
 local placeholders = Instance.new('Frame')
 placeholders.Size = UDim2.new(1, 0, 0, 78)
@@ -207,22 +328,20 @@ local function makePlaceholder(text)
     corner.Parent = button
 end
 
-makePlaceholder('Shop Terminal (Soon)')
+makePlaceholder('Temple Shop (Soon)')
 makePlaceholder('Shared Maze Gate')
 
 local panel = Instance.new('Frame')
 panel.Name = 'CampPanel'
 panel.AnchorPoint = Vector2.new(0, 0)
 panel.Position = UDim2.fromScale(0.03, 0.05)
-panel.Size = UDim2.fromOffset(440, 500)
+panel.Size = UDim2.fromOffset(440, 620)
 panel.BackgroundColor3 = Theme.Background
 panel.BorderSizePixel = 0
 panel.Visible = false
 panel.Parent = screenGui
 
-local panelCorner = Instance.new('UICorner')
-panelCorner.CornerRadius = UDim.new(0, 16)
-panelCorner.Parent = panel
+applyPanelStyle(panel, 16, 0.84)
 
 local panelPadding = Instance.new('UIPadding')
 panelPadding.PaddingTop = UDim.new(0, 18)
@@ -236,17 +355,29 @@ list.Padding = UDim.new(0, 10)
 list.Parent = panel
 
 local title = makeTextLabel(panel, UDim2.new(1, 0, 0, 36), Theme.Text, 28, true)
-title.Text = 'Camp Status'
+title.Text = string.format('%s Status', TEMPLE_LABEL)
 
 local statusLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 70), Theme.SubtleText, 18, false)
-statusLabel.Text = 'Waiting for camp snapshot...'
+statusLabel.Text = string.format('Waiting for %s snapshot...', TEMPLE_LABEL)
 
 local objectiveLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 64), Theme.Accent, 18, false)
-objectiveLabel.Text = 'Objective: --'
+objectiveLabel.Text = string.format('%s Objective: --', SAND_BOOK_LABEL)
 
 local guideLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 60), Theme.Text, 16, false)
-guideLabel.Text =
-    'In-world prompts:\n- Shop Terminal (Soon)\n- Loadout Bench (Soon)\n- Camp Gate / Shared Maze Gate\nKeyboard: Hold LeftShift to sprint, tap C to toggle Camp Status'
+guideLabel.Text = string.format(
+    'In-world prompts:\n- %s Shop\n- Salvage Exchange\n- %s Board\n- %s Gate / Shared Maze Gate\nKeyboard: Hold LeftShift to sprint, tap C to toggle %s Status, %s to free mouse, 1-3 to equip, X to stow',
+    TEMPLE_LABEL,
+    SAND_BOOK_LABEL,
+    TEMPLE_LABEL,
+    TEMPLE_LABEL,
+    MOUSE_TOGGLE_KEY.Name
+)
+
+local inventoryLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 44), Theme.Warning, 16, false)
+inventoryLabel.Text = 'Inventory: --'
+
+local inventoryDetailLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 126), Theme.Text, 15, false)
+inventoryDetailLabel.Text = ''
 
 local playerStateLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 86), Theme.Warning, 16, false)
 playerStateLabel.Text = 'Health: --\nStamina: --\nState: --\nMovement: --'
@@ -257,12 +388,374 @@ rosterLabel.Text = ''
 local mazeLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 96), Theme.SubtleText, 16, false)
 mazeLabel.Text = ''
 
+local function createModalPanel(name, size)
+    local modal = Instance.new('Frame')
+    modal.Name = name
+    modal.AnchorPoint = Vector2.new(0.5, 0.5)
+    modal.Position = UDim2.fromScale(0.5, 0.5)
+    modal.Size = size
+    modal.BackgroundColor3 = Theme.Surface
+    modal.BorderSizePixel = 0
+    modal.Visible = false
+    modal.Parent = screenGui
+
+    applyPanelStyle(modal, 16, 0.82)
+
+    local modalPadding = Instance.new('UIPadding')
+    modalPadding.PaddingTop = UDim.new(0, 18)
+    modalPadding.PaddingLeft = UDim.new(0, 18)
+    modalPadding.PaddingRight = UDim.new(0, 18)
+    modalPadding.PaddingBottom = UDim.new(0, 18)
+    modalPadding.Parent = modal
+
+    local modalList = Instance.new('UIListLayout')
+    modalList.Padding = UDim.new(0, 10)
+    modalList.Parent = modal
+
+    return modal, modalList
+end
+
+local modalBackdrop = Instance.new('Frame')
+modalBackdrop.Name = 'ModalBackdrop'
+modalBackdrop.Size = UDim2.fromScale(1, 1)
+modalBackdrop.BackgroundColor3 = Color3.new(0, 0, 0)
+modalBackdrop.BackgroundTransparency = 0.45
+modalBackdrop.Visible = false
+modalBackdrop.Parent = screenGui
+
+local oceanSplashOverlay = Instance.new('Frame')
+oceanSplashOverlay.Name = 'OceanSplashOverlay'
+oceanSplashOverlay.Size = UDim2.fromScale(1, 1)
+oceanSplashOverlay.BackgroundColor3 = Color3.fromRGB(60, 176, 255)
+oceanSplashOverlay.BackgroundTransparency = 1
+oceanSplashOverlay.BorderSizePixel = 0
+oceanSplashOverlay.Parent = screenGui
+
+local oceanSplashGradient = Instance.new('UIGradient')
+oceanSplashGradient.Rotation = 90
+oceanSplashGradient.Color = ColorSequence.new({
+    ColorSequenceKeypoint.new(0, Color3.fromRGB(140, 220, 255)),
+    ColorSequenceKeypoint.new(1, Color3.fromRGB(32, 100, 164)),
+})
+oceanSplashGradient.Transparency = NumberSequence.new({
+    NumberSequenceKeypoint.new(0, 0.1),
+    NumberSequenceKeypoint.new(0.45, 0.65),
+    NumberSequenceKeypoint.new(1, 0.15),
+})
+oceanSplashGradient.Parent = oceanSplashOverlay
+
+-- Sustained slowdown overlay (visible while in ocean)
+local oceanSlowdownOverlay = Instance.new('Frame')
+oceanSlowdownOverlay.Name = 'OceanSlowdownOverlay'
+oceanSlowdownOverlay.Size = UDim2.fromScale(1, 1)
+oceanSlowdownOverlay.BackgroundColor3 = Color3.fromRGB(60, 176, 255)
+oceanSlowdownOverlay.BackgroundTransparency = 1
+oceanSlowdownOverlay.BorderSizePixel = 0
+oceanSlowdownOverlay.Parent = screenGui
+
+local oceanSlowdownGradient = Instance.new('UIGradient')
+oceanSlowdownGradient.Rotation = 90
+oceanSlowdownGradient.Color = ColorSequence.new({
+    ColorSequenceKeypoint.new(0, Color3.fromRGB(140, 220, 255)),
+    ColorSequenceKeypoint.new(1, Color3.fromRGB(32, 100, 164)),
+})
+oceanSlowdownGradient.Transparency = NumberSequence.new({
+    NumberSequenceKeypoint.new(0, 0.85),
+    NumberSequenceKeypoint.new(1, 0.92),
+})
+oceanSlowdownGradient.Parent = oceanSlowdownOverlay
+
+local toastLabel = Instance.new('TextLabel')
+toastLabel.Name = 'Toast'
+toastLabel.AnchorPoint = Vector2.new(0.5, 0.5)
+toastLabel.Position = UDim2.fromScale(0.5, 0.08)
+toastLabel.Size = UDim2.fromOffset(420, 42)
+toastLabel.BackgroundColor3 = Theme.Surface
+toastLabel.TextColor3 = Theme.Text
+toastLabel.TextSize = 18
+toastLabel.Font = Theme.Font
+toastLabel.Text = ''
+toastLabel.Visible = false
+toastLabel.Parent = screenGui
+applyPanelStyle(toastLabel, 12, 0.88)
+
+local goalBanner = Instance.new('TextLabel')
+goalBanner.Name = 'GoalBanner'
+goalBanner.AnchorPoint = Vector2.new(0.5, 0.5)
+goalBanner.Position = UDim2.fromScale(0.5, 0.16)
+goalBanner.Size = UDim2.fromOffset(460, 56)
+goalBanner.BackgroundColor3 = Theme.Accent
+goalBanner.TextColor3 = Theme.Background
+goalBanner.TextSize = 22
+goalBanner.Font = Enum.Font.GothamBold
+goalBanner.Text = ''
+goalBanner.Visible = false
+goalBanner.Parent = screenGui
+applyPanelStyle(goalBanner, 12, 0.7)
+
+local shopPanel = createModalPanel('ShopPanel', UDim2.fromOffset(460, 520))
+local shopTitle = makeTextLabel(shopPanel, UDim2.new(1, 0, 0, 32), Theme.Text, 26, true)
+shopTitle.Text = 'Temple Shop'
+
+local shopPageLabel = makeTextLabel(shopPanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
+shopPageLabel.Text = 'Team Pages: 0'
+
+local shopInventoryLabel =
+    makeTextLabel(shopPanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
+shopInventoryLabel.Text = 'Inventory: --'
+
+local shopItemsFrame = Instance.new('Frame')
+shopItemsFrame.Size = UDim2.new(1, 0, 1, -210)
+shopItemsFrame.BackgroundTransparency = 1
+shopItemsFrame.Parent = shopPanel
+
+local shopItemsList = Instance.new('UIListLayout')
+shopItemsList.Padding = UDim.new(0, 8)
+shopItemsList.Parent = shopItemsFrame
+
+local shopCloseButton = makeButton(shopPanel, 'Close', 44, Theme.Warning)
+
+local sellPanel = createModalPanel('SellPanel', UDim2.fromOffset(460, 480))
+local sellTitle = makeTextLabel(sellPanel, UDim2.new(1, 0, 0, 32), Theme.Text, 26, true)
+sellTitle.Text = 'Salvage Exchange'
+
+local sellPageLabel = makeTextLabel(sellPanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
+sellPageLabel.Text = 'Team Pages: 0'
+
+local sellItemsFrame = Instance.new('Frame')
+sellItemsFrame.Size = UDim2.new(1, 0, 1, -160)
+sellItemsFrame.BackgroundTransparency = 1
+sellItemsFrame.Parent = sellPanel
+
+local sellItemsList = Instance.new('UIListLayout')
+sellItemsList.Padding = UDim.new(0, 8)
+sellItemsList.Parent = sellItemsFrame
+
+local sellCloseButton = makeButton(sellPanel, 'Close', 44, Theme.Warning)
+
+local objectivePanel = createModalPanel('ObjectivePanel', UDim2.fromOffset(440, 360))
+local objectiveTitle = makeTextLabel(objectivePanel, UDim2.new(1, 0, 0, 32), Theme.Text, 26, true)
+objectiveTitle.Text = 'Book of Sand Board'
+
+local objectiveGoalLabel =
+    makeTextLabel(objectivePanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
+objectiveGoalLabel.Text = 'Goal: 0 Pages'
+
+local objectiveProgressLabel =
+    makeTextLabel(objectivePanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
+objectiveProgressLabel.Text = 'Progress: 0%'
+
+local progressBarBack = Instance.new('Frame')
+progressBarBack.Size = UDim2.new(1, 0, 0, 18)
+progressBarBack.BackgroundColor3 = Theme.Background
+progressBarBack.BorderSizePixel = 0
+progressBarBack.Parent = objectivePanel
+
+local progressBarFill = Instance.new('Frame')
+progressBarFill.Size = UDim2.new(0, 0, 1, 0)
+progressBarFill.BackgroundColor3 = Theme.Accent
+progressBarFill.BorderSizePixel = 0
+progressBarFill.Parent = progressBarBack
+
+local progressCorner = Instance.new('UICorner')
+progressCorner.CornerRadius = UDim.new(0, 8)
+progressCorner.Parent = progressBarBack
+
+local progressFillCorner = Instance.new('UICorner')
+progressFillCorner.CornerRadius = UDim.new(0, 8)
+progressFillCorner.Parent = progressBarFill
+
+local objectiveCloseButton = makeButton(objectivePanel, 'Close', 44, Theme.Warning)
+
 local function syncCampPanelVisibility()
     panel.Visible = isRunLaunched and isCampPanelVisible
 end
 
-releaseFirstPersonLockForMenu()
-bindMenuMouseUnlock()
+local function setActiveModal(nextModal)
+    activeModal = nextModal
+    local showModal = nextModal ~= nil
+
+    modalBackdrop.Visible = showModal
+    shopPanel.Visible = nextModal == 'Shop'
+    sellPanel.Visible = nextModal == 'Sell'
+    objectivePanel.Visible = nextModal == 'Objective'
+
+    syncMouseMode()
+end
+
+local function updateObjectiveUi()
+    local clampedProgress = math.clamp(goalProgress, 0, 1)
+    objectiveGoalLabel.Text = string.format('Goal: %d %s', goalAmount, PAGE_LABEL)
+    objectiveProgressLabel.Text =
+        string.format('%s: %d%%', SAND_BOOK_PROGRESS_LABEL, math.floor(clampedProgress * 100 + 0.5))
+    progressBarFill.Size = UDim2.new(clampedProgress, 0, 1, 0)
+end
+
+local function updatePageLabels()
+    shopPageLabel.Text = string.format('Team %s: %d', PAGE_LABEL, teamPages)
+    sellPageLabel.Text = string.format('Team %s: %d', PAGE_LABEL, teamPages)
+    updateObjectiveUi()
+
+    if inventorySummary then
+        shopInventoryLabel.Text = string.format(
+            'Inventory: %d total | %d/%d KG | %d value',
+            inventorySummary.Count or 0,
+            inventorySummary.Weight or 0,
+            inventorySummary.Capacity or 0,
+            inventorySummary.Value or 0
+        )
+    else
+        shopInventoryLabel.Text = 'Inventory: --'
+    end
+end
+
+local function showToast(message, tone)
+    local color = Theme.Text
+    if tone == 'Error' then
+        color = Theme.Warning
+    elseif tone == 'Success' then
+        color = Theme.Accent
+    end
+
+    toastLabel.TextColor3 = color
+    toastLabel.Text = message
+    toastLabel.Visible = true
+
+    local token = os.clock()
+    toastLabel:SetAttribute('ToastToken', token)
+
+    task.delay(2.5, function()
+        if toastLabel:GetAttribute('ToastToken') == token then
+            toastLabel.Visible = false
+        end
+    end)
+end
+
+local function showGoalBanner()
+    goalBanner.Text = string.format('Goal reached! Team %s: %d', PAGE_LABEL, teamPages)
+    goalBanner.Visible = true
+
+    task.delay(3, function()
+        goalBanner.Visible = false
+    end)
+end
+
+local function showOceanSlowdown()
+    isInOcean = true
+    if oceanSlowdownTween then
+        oceanSlowdownTween:Cancel()
+        oceanSlowdownTween = nil
+    end
+
+    oceanSlowdownTween = TweenService:Create(
+        oceanSlowdownOverlay,
+        TweenInfo.new(0.3, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+        { BackgroundTransparency = 0.7 }
+    )
+    oceanSlowdownTween:Play()
+end
+
+local function hideOceanSlowdown()
+    if not isInOcean then
+        return
+    end
+    isInOcean = false
+
+    if oceanSlowdownTween then
+        oceanSlowdownTween:Cancel()
+        oceanSlowdownTween = nil
+    end
+
+    oceanSlowdownTween = TweenService:Create(
+        oceanSlowdownOverlay,
+        TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.In),
+        { BackgroundTransparency = 1 }
+    )
+    oceanSlowdownTween:Play()
+end
+
+local function showOceanSplash(message)
+    showToast(message or 'Splash!', 'Success')
+
+    oceanSplashOverlay.BackgroundTransparency = 1
+
+    local flashIn = TweenService:Create(
+        oceanSplashOverlay,
+        TweenInfo.new(0.12, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+        {
+            BackgroundTransparency = 0.82,
+        }
+    )
+    local flashOut = TweenService:Create(
+        oceanSplashOverlay,
+        TweenInfo.new(0.45, Enum.EasingStyle.Quad, Enum.EasingDirection.In),
+        {
+            BackgroundTransparency = 1,
+        }
+    )
+
+    flashIn:Play()
+    flashIn.Completed:Connect(function()
+        flashOut:Play()
+    end)
+
+    -- Also show sustained slowdown overlay
+    showOceanSlowdown()
+end
+
+local function renderShopItems()
+    clearLayoutChildren(shopItemsFrame)
+
+    for _, item in ipairs(activeShopItems) do
+        local label = string.format('%s - %d %s', item.Name, item.Price, PAGE_LABEL)
+        local button = makeButton(shopItemsFrame, label, 40, Theme.Accent)
+        button.MouseButton1Click:Connect(function()
+            Remotes.RunAction:FireServer({
+                Type = 'RequestPurchaseItem',
+                ItemId = item.Id,
+            })
+        end)
+    end
+end
+
+local function renderSellItems()
+    clearLayoutChildren(sellItemsFrame)
+
+    if #activeSalvageItems == 0 then
+        local emptyLabel =
+            makeTextLabel(sellItemsFrame, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
+        emptyLabel.Text = 'No salvage items available.'
+        return
+    end
+
+    for _, item in ipairs(activeSalvageItems) do
+        local label = string.format('%s +%d %s', item.Name, item.Price, PAGE_LABEL)
+        local button = makeButton(sellItemsFrame, label, 40, Theme.Accent)
+        if item.Color then
+            button.TextColor3 = item.Color
+        end
+        button.MouseButton1Click:Connect(function()
+            Remotes.RunAction:FireServer({
+                Type = 'RequestSellItem',
+                ItemInstanceId = item.InstanceId,
+            })
+        end)
+    end
+end
+
+shopCloseButton.MouseButton1Click:Connect(function()
+    setActiveModal(nil)
+end)
+
+sellCloseButton.MouseButton1Click:Connect(function()
+    setActiveModal(nil)
+end)
+
+objectiveCloseButton.MouseButton1Click:Connect(function()
+    setActiveModal(nil)
+end)
+
+syncMouseMode()
 actionInputConnection = UserInputService.InputBegan:Connect(function(input, gameProcessedEvent)
     if gameProcessedEvent then
         return
@@ -281,10 +774,40 @@ actionInputConnection = UserInputService.InputBegan:Connect(function(input, game
         return
     end
 
+    if input.KeyCode == MOUSE_TOGGLE_KEY then
+        isMouseFree = not isMouseFree
+        syncMouseMode()
+        return
+    end
+
     if input.KeyCode == Enum.KeyCode.C then
         if isRunLaunched then
             isCampPanelVisible = not isCampPanelVisible
             syncCampPanelVisibility()
+        end
+        return
+    end
+
+    if input.KeyCode == Enum.KeyCode.X and isRunLaunched then
+        Remotes.RunAction:FireServer({
+            Type = 'RequestUnequipItem',
+        })
+        return
+    end
+
+    local slotIndexByKeyCode = {
+        [Enum.KeyCode.One] = 1,
+        [Enum.KeyCode.Two] = 2,
+        [Enum.KeyCode.Three] = 3,
+    }
+    local slotIndex = slotIndexByKeyCode[input.KeyCode]
+    if slotIndex ~= nil and isRunLaunched then
+        local itemEntry = visibleBackpackItems[slotIndex]
+        if itemEntry then
+            Remotes.RunAction:FireServer({
+                Type = 'RequestEquipItem',
+                ItemInstanceId = itemEntry.InstanceId,
+            })
         end
         return
     end
@@ -315,54 +838,237 @@ end)
 singlePlayerButton.MouseButton1Click:Connect(function()
     singlePlayerButton.AutoButtonColor = false
     singlePlayerButton.Active = false
-    singlePlayerButton.Text = 'Entering Camp...'
+    singlePlayerButton.Text = string.format('Entering %s...', TEMPLE_LABEL)
 
     Remotes.RunAction:FireServer({
         Type = 'RequestLaunchRun',
     })
 end)
 
-Remotes.RunPrivateState.OnClientEvent:Connect(function()
-    -- Private role data is intentionally unused in the camp staging run.
+Remotes.RunPrivateState.OnClientEvent:Connect(function(payload)
+    if type(payload) ~= 'table' then
+        return
+    end
+
+    if payload.Type == 'OpenShop' then
+        activeShopItems = payload.Items or {}
+        inventorySummary = payload.Inventory or inventorySummary
+        if type(payload.TeamPages) == 'number' then
+            teamPages = payload.TeamPages
+        end
+        updatePageLabels()
+        renderShopItems()
+        setActiveModal('Shop')
+        return
+    end
+
+    if payload.Type == 'OpenSell' then
+        activeSalvageItems = payload.Items or {}
+        if type(payload.TeamPages) == 'number' then
+            teamPages = payload.TeamPages
+        end
+        updatePageLabels()
+        renderSellItems()
+        setActiveModal('Sell')
+        return
+    end
+
+    if payload.Type == 'OpenObjectiveBoard' then
+        if type(payload.TeamPages) == 'number' then
+            teamPages = payload.TeamPages
+        end
+        if type(payload.BookGoalAmount) == 'number' then
+            goalAmount = payload.BookGoalAmount
+        end
+        if type(payload.BookGoalProgress) == 'number' then
+            goalProgress = payload.BookGoalProgress
+        end
+        updatePageLabels()
+        setActiveModal('Objective')
+        return
+    end
+
+    if payload.Type == 'ShopResult' then
+        if payload.Success then
+            showToast('Purchase complete.', 'Success')
+        else
+            local reason = payload.Reason or 'Unknown'
+            if reason == 'InsufficientFunds' then
+                showToast('Not enough pages.', 'Error')
+            elseif reason == 'OverCapacity' or reason == 'InventoryFull' then
+                showToast('Inventory is full.', 'Error')
+            else
+                showToast('Purchase failed.', 'Error')
+            end
+        end
+
+        if type(payload.TeamPages) == 'number' then
+            teamPages = payload.TeamPages
+        end
+        if payload.Inventory then
+            inventorySummary = payload.Inventory
+        end
+        updatePageLabels()
+        return
+    end
+
+    if payload.Type == 'SellResult' then
+        if payload.Success then
+            showToast('Sale complete.', 'Success')
+        else
+            showToast('Sale failed.', 'Error')
+        end
+
+        if type(payload.TeamPages) == 'number' then
+            teamPages = payload.TeamPages
+        end
+        if payload.ItemInstanceId then
+            for index, item in ipairs(activeSalvageItems) do
+                if item.InstanceId == payload.ItemInstanceId then
+                    table.remove(activeSalvageItems, index)
+                    break
+                end
+            end
+            renderSellItems()
+        end
+        updatePageLabels()
+        return
+    end
+
+    if payload.Type == 'GoalReached' then
+        if type(payload.TeamPages) == 'number' then
+            teamPages = payload.TeamPages
+        end
+        showGoalBanner()
+        return
+    end
+
+    if payload.Type == 'Toast' then
+        if type(payload.Message) == 'string' then
+            showToast(payload.Message, payload.Tone)
+        end
+        return
+    end
+
+    if payload.Type == 'OceanSplash' then
+        showOceanSplash(payload.Message)
+        return
+    end
+
+    if payload.Type == 'OceanExit' then
+        hideOceanSlowdown()
+        return
+    end
+
+    if payload.Type == 'OceanDamage' then
+        showOceanSplash('Drowning!')
+        return
+    end
 end)
 
 Remotes.RunState.OnClientEvent:Connect(function(snapshot)
     local hasLaunched = snapshot.IsLaunched == true
     isRunLaunched = hasLaunched
+    if type(snapshot.BuildFingerprint) == 'string' and snapshot.BuildFingerprint ~= '' then
+        activeBuildFingerprint = snapshot.BuildFingerprint
+    end
     if not hasLaunched then
         isCampPanelVisible = true
     end
 
+    if type(snapshot.TeamPages) == 'number' then
+        teamPages = snapshot.TeamPages
+    end
+    if type(snapshot.BookGoalAmount) == 'number' then
+        goalAmount = snapshot.BookGoalAmount
+    end
+    if type(snapshot.BookGoalProgress) == 'number' then
+        goalProgress = snapshot.BookGoalProgress
+    end
     menuBackdrop.Visible = not hasLaunched
     syncCampPanelVisibility()
 
     if not hasLaunched then
-        releaseFirstPersonLockForMenu()
-        bindMenuMouseUnlock()
+        syncMouseMode()
         canRequestMazeEntry = false
-        menuStatusLabel.Text =
-            string.format('%s\nMaze Entry: %s', snapshot.Status, buildMazeEntryText(snapshot))
+        visibleBackpackItems = {}
+        heldItemController:applyInventory(nil)
+        menuStatusLabel.Text = string.format(
+            '%s\n%s\nMaze Entry: %s',
+            snapshot.Status,
+            buildFingerprintText(snapshot),
+            buildMazeEntryText(snapshot)
+        )
         singlePlayerButton.Active = true
         singlePlayerButton.AutoButtonColor = true
-        singlePlayerButton.Text = 'Single Player'
+        singlePlayerButton.Text = string.format('Enter %s', TEMPLE_LABEL)
+        inventoryLabel.Text = 'Inventory: --'
+        inventoryDetailLabel.Text = ''
         playerStateLabel.Text = 'Health: --\nStamina: --\nState: --\nMovement: --'
         return
     end
 
-    unbindMenuMouseUnlock()
-    ensureFirstPersonLock()
+    syncMouseMode()
     canRequestMazeEntry = snapshot.GateOpen == true
 
     statusLabel.Text = string.format(
-        '%s\nArea: %s | Gate: %s | Maze: %s\nEntry: %s',
+        '%s\n%s\nArea: %s | Gate: %s | Maze: %s\nEntry: %s',
         snapshot.Status,
+        buildFingerprintText(snapshot),
         snapshot.Area,
         snapshot.GateOpen and 'Open' or 'Closed',
         snapshot.MazeStatus or 'idle',
         buildMazeEntryText(snapshot)
     )
 
-    objectiveLabel.Text = string.format('Objective: %s', snapshot.Objective)
+    objectiveLabel.Text = string.format('%s Objective: %s', SAND_BOOK_LABEL, snapshot.Objective)
+
+    local inventory = snapshot.Inventory or {}
+    inventorySummary = inventory
+    visibleBackpackItems = inventory.BackpackItems or {}
+    heldItemController:applyInventory(inventory)
+    updatePageLabels()
+    inventoryLabel.Text = string.format(
+        'Inventory: %d total | %d backpack | %d held | %d/%d KG | %d value',
+        inventory.Count or 0,
+        inventory.BackpackCount or 0,
+        inventory.HeldCount or 0,
+        inventory.Weight or 0,
+        inventory.Capacity or 0,
+        inventory.Value or 0
+    )
+
+    local heldItem = inventory.HeldItem
+    local inventoryDetailLines = {
+        heldItem and string.format(
+            'Held: %s | %d KG | %d value%s',
+            heldItem.Name,
+            heldItem.Weight,
+            heldItem.Value,
+            heldItem.Light and ' | Glow active' or ''
+        ) or 'Held: Empty hands',
+        'Backpack:',
+    }
+    if #visibleBackpackItems == 0 then
+        table.insert(inventoryDetailLines, '- Empty')
+    else
+        for itemIndex = 1, math.min(#visibleBackpackItems, 3) do
+            local itemEntry = visibleBackpackItems[itemIndex]
+            table.insert(
+                inventoryDetailLines,
+                string.format(
+                    '- [%d] %s | %d KG | %d value',
+                    itemIndex,
+                    itemEntry.Name,
+                    itemEntry.Weight,
+                    itemEntry.Value
+                )
+            )
+        end
+    end
+    table.insert(inventoryDetailLines, '')
+    table.insert(inventoryDetailLines, 'Keys: 1-3 equip listed item | X stow held item')
+    inventoryDetailLabel.Text = table.concat(inventoryDetailLines, '\n')
 
     local playerState = snapshot.PlayerState or {}
     local movement = snapshot.Movement or {}
@@ -383,7 +1089,8 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
         table.insert(rosterLines, string.format('%s%s', rosterEntry.Name, marker))
     end
 
-    rosterLabel.Text = 'Camp roster:\n' .. table.concat(rosterLines, '\n')
+    rosterLabel.Text = string.format('%s roster:\n', TEMPLE_LABEL)
+        .. table.concat(rosterLines, '\n')
 
     local mazeLines = {}
     local activeMazePlayers = snapshot.PlayersInMaze or {}

--- a/tests/src/Shared/RunSessionServiceReturnLoop.spec.luau
+++ b/tests/src/Shared/RunSessionServiceReturnLoop.spec.luau
@@ -1,4 +1,5 @@
 return function()
+    local Players = game:GetService('Players')
     local ReplicatedStorage = game:GetService('ReplicatedStorage')
     local Packages = ReplicatedStorage:WaitForChild('Packages')
     local Shared = require(Packages:WaitForChild('Shared'))
@@ -76,4 +77,42 @@ return function()
         startupService.PendingSpawnByUserId[202] == RunWorldBuilder.ReturnCFrame,
         'Startup return processing should keep non-loop returns at the generic run return position'
     )
+
+    local originalCharacterAutoLoads = Players.CharacterAutoLoads
+    Players.CharacterAutoLoads = false
+
+    local failingBuilderCalls = 0
+    local failingLaunchService = RunSessionService.new({
+        RunWorldBuilder = {
+            build = function()
+                failingBuilderCalls += 1
+                error('RunStaticWorld authored content is incomplete.', 0)
+            end,
+        },
+    })
+
+    local ok, launchErr = pcall(function()
+        failingLaunchService:_launchRun(nil)
+    end)
+
+    assert(ok == false, 'Launch should still fail loudly when static world build fails')
+    assert(
+        string.find(tostring(launchErr), 'RunStaticWorld authored content is incomplete.', 1, true)
+            ~= nil,
+        'Launch failure should expose the authored-world build error'
+    )
+    assert(
+        failingBuilderCalls == 1,
+        'Launch should attempt to build the world exactly once before aborting'
+    )
+    assert(
+        failingLaunchService.IsLaunched == false,
+        'Launch should not flip IsLaunched when static world build fails'
+    )
+    assert(
+        Players.CharacterAutoLoads == false,
+        'Launch should keep CharacterAutoLoads disabled when static world build fails'
+    )
+
+    Players.CharacterAutoLoads = originalCharacterAutoLoads
 end


### PR DESCRIPTION
## Summary
- Add static world collision validation infrastructure (RunStaticWorldContract, RunStaticWorldValidator, groundedSpawnCFrame)
- Add Collision/Scene and Collision/Ship folder structure to default.project.json
- Add Triggers/Ocean container with invisible CanTouch trigger parts
- Implement full ocean drowning system with three phases: touching → immersed → exit
- Add client-side ocean overlay with TweenService flash animation
- Add BuildFingerprint for runtime diagnostics
- Add RunInteractionRegistry to bind scene interactions

## Test plan
- [ ] `luau-quality` CI check passes
- [ ] Run session boot stable in Studio with new collision shell structure
- [ ] Ocean overlay shows on water entry and hides on exit
- [ ] Drowning damage ticks correctly in immersed state

## Notes
- Targets `run` branch to sync ocean + collision changes
- Dead code cleanup (CampHouseBuilder etc.) deferred to separate PR