### PR TITLE
消除 Run ItemService 与 Inventory 双轨，契约拷贝与 ItemFields 单源对齐（#229/#230/#232）

### DIFF
--- a/packages/gameplay/src/Config/ItemFields.luau
+++ b/packages/gameplay/src/Config/ItemFields.luau
@@ -1,0 +1,106 @@
+--!strict
+-- Single source for inventory item entry fields copied into summaries and teleport contracts.
+-- See issues #232 / #229: Inventory.cloneItemEntry and CampMazeSessionContract.cloneInventoryItem must stay aligned.
+
+local ItemFields = {}
+
+local function cloneLightConfig(lightConfig: any): any
+    if type(lightConfig) ~= 'table' then
+        return nil
+    end
+
+    return {
+        Brightness = lightConfig.Brightness,
+        Range = lightConfig.Range,
+        Color = lightConfig.Color,
+    }
+end
+
+function ItemFields.copyItemEntry(itemEntry: any): any
+    if type(itemEntry) ~= 'table' then
+        return nil
+    end
+
+    return {
+        InstanceId = itemEntry.InstanceId,
+        Id = itemEntry.Id,
+        Name = itemEntry.Name,
+        Weight = itemEntry.Weight,
+        Value = itemEntry.Value,
+        Color = itemEntry.Color,
+        Light = cloneLightConfig(itemEntry.Light),
+        Description = itemEntry.Description,
+        IconAssetId = itemEntry.IconAssetId,
+        ToolTemplateName = itemEntry.ToolTemplateName,
+        ToolCategory = itemEntry.ToolCategory,
+        StateModel = itemEntry.StateModel,
+        InitialState = itemEntry.InitialState,
+        CurrentState = itemEntry.CurrentState,
+        ConsumePerUse = itemEntry.ConsumePerUse,
+        CooldownSeconds = itemEntry.CooldownSeconds,
+        LastUsedAt = itemEntry.LastUsedAt,
+        SwingRange = itemEntry.SwingRange,
+        SwingArcDegrees = itemEntry.SwingArcDegrees,
+        KnockbackStrength = itemEntry.KnockbackStrength,
+        MeleeDamage = itemEntry.MeleeDamage,
+        HealHealthPips = itemEntry.HealHealthPips,
+    }
+end
+
+function ItemFields.normalizeItemEntryForLoad(rawItemEntry: any): any
+    if type(rawItemEntry) ~= 'table' or type(rawItemEntry.InstanceId) ~= 'number' then
+        return nil
+    end
+
+    return {
+        InstanceId = rawItemEntry.InstanceId,
+        Id = rawItemEntry.Id,
+        Name = rawItemEntry.Name,
+        Weight = rawItemEntry.Weight or 0,
+        Value = rawItemEntry.Value or 0,
+        Color = rawItemEntry.Color,
+        Light = cloneLightConfig(rawItemEntry.Light),
+        Description = rawItemEntry.Description,
+        IconAssetId = rawItemEntry.IconAssetId,
+        ToolTemplateName = rawItemEntry.ToolTemplateName,
+        ToolCategory = rawItemEntry.ToolCategory,
+        StateModel = rawItemEntry.StateModel,
+        InitialState = rawItemEntry.InitialState,
+        CurrentState = rawItemEntry.CurrentState,
+        ConsumePerUse = rawItemEntry.ConsumePerUse,
+        CooldownSeconds = rawItemEntry.CooldownSeconds,
+        LastUsedAt = rawItemEntry.LastUsedAt,
+        SwingRange = rawItemEntry.SwingRange,
+        SwingArcDegrees = rawItemEntry.SwingArcDegrees,
+        KnockbackStrength = rawItemEntry.KnockbackStrength,
+        MeleeDamage = rawItemEntry.MeleeDamage,
+        HealHealthPips = rawItemEntry.HealHealthPips,
+    }
+end
+
+ItemFields.ENTRY_FIELD_NAMES = table.freeze({
+    'InstanceId',
+    'Id',
+    'Name',
+    'Weight',
+    'Value',
+    'Color',
+    'Light',
+    'Description',
+    'IconAssetId',
+    'ToolTemplateName',
+    'ToolCategory',
+    'StateModel',
+    'InitialState',
+    'CurrentState',
+    'ConsumePerUse',
+    'CooldownSeconds',
+    'LastUsedAt',
+    'SwingRange',
+    'SwingArcDegrees',
+    'KnockbackStrength',
+    'MeleeDamage',
+    'HealHealthPips',
+})
+
+return ItemFields

--- a/packages/gameplay/src/Config/ToolItems.luau
+++ b/packages/gameplay/src/Config/ToolItems.luau
@@ -21,6 +21,24 @@ local ToolItems = {
         CooldownSeconds = 0,
     },
 
+    -- 绳索：攀爬 / 套索等营地交互（与 ToolCategory == 'Rope' 对齐）
+    ['tool-rope'] = {
+        Id = 'tool-rope',
+        Name = 'Rope',
+        Description = '攀爬高处、跨越断层、固定目标。',
+        ToolCategory = 'Rope',
+        Weight = 2,
+        Value = 0,
+        Color = Color3.fromRGB(180, 160, 120),
+        IsEquipable = true,
+        IconAssetId = '',
+        ToolTemplateName = '',
+        StateModel = 'Durability',
+        InitialState = 5,
+        ConsumePerUse = 0,
+        CooldownSeconds = 0.5,
+    },
+
     -- 撬棍：近战挥舞击退怪物
     ['tool-crowbar'] = {
         Id = 'tool-crowbar',

--- a/packages/gameplay/src/Config/init.luau
+++ b/packages/gameplay/src/Config/init.luau
@@ -1,4 +1,5 @@
 return {
+    ItemFields = require(script.ItemFields),
     Items = require(script.Items),
     ItemPresentation = require(script.ItemPresentation),
     Monsters = require(script.Monsters),

--- a/packages/gameplay/src/Inventory.luau
+++ b/packages/gameplay/src/Inventory.luau
@@ -1,73 +1,10 @@
+local ItemFields = require(script.Parent.Config.ItemFields)
+
 local Inventory = {}
 Inventory.__index = Inventory
 
-local function cloneLightConfig(lightConfig)
-    if type(lightConfig) ~= 'table' then
-        return nil
-    end
-
-    return {
-        Brightness = lightConfig.Brightness,
-        Range = lightConfig.Range,
-        Color = lightConfig.Color,
-    }
-end
-
--- ItemEntry field groups aligned to the live item payload shape:
--- Core (must-have): InstanceId (handled separately), Id, Name, Value
--- Optional — Weight
--- Optional — Tool state: InitialState, CurrentState, ConsumePerUse, CooldownSeconds, LastUsedAt, ToolCategory, StateModel
--- Optional — Light: Color (Light handled separately via cloneLightConfig)
--- Optional — Melee tool: SwingRange, SwingArcDegrees, KnockbackStrength, MeleeDamage
--- Optional — Consumable: ItemKind, ConsumableEffect, MaxCarryPerId
--- Optional — Presentation: Description, IconAssetId, ToolTemplateName
--- Optional — Heal: HealHealthPips
-local ITEM_COPY_FIELDS = table.freeze({
-    -- Core
-    'Id',
-    'Name',
-    'Value',
-    -- Optional: Weight
-    'Weight',
-    -- Optional: Tool state
-    'InitialState',
-    'CurrentState',
-    'ConsumePerUse',
-    'CooldownSeconds',
-    'LastUsedAt',
-    'ToolCategory',
-    'StateModel',
-    -- Optional: Light
-    'Color',
-    -- Optional: Melee tool
-    'SwingRange',
-    'SwingArcDegrees',
-    'KnockbackStrength',
-    'MeleeDamage',
-    -- Optional: Consumable
-    'ItemKind',
-    'ConsumableEffect',
-    'MaxCarryPerId',
-    -- Optional: Presentation
-    'Description',
-    'IconAssetId',
-    'ToolTemplateName',
-    -- Optional: Heal
-    'HealHealthPips',
-})
-
-local function copyItemFields(source, target)
-    for _, field in ipairs(ITEM_COPY_FIELDS) do
-        target[field] = source[field]
-    end
-    target.Light = cloneLightConfig(source.Light)
-    return target
-end
-
 local function cloneItemEntry(itemEntry)
-    return copyItemFields(itemEntry, {
-        InstanceId = itemEntry.InstanceId,
-    })
+    return ItemFields.copyItemEntry(itemEntry)
 end
 
 local function cloneArray(items)
@@ -98,27 +35,37 @@ function Inventory:getCount()
 end
 
 function Inventory:_buildItemEntry(itemDef)
-    local itemEntry = copyItemFields(itemDef, {
-        InstanceId = self.NextItemInstanceId,
-    })
-    itemEntry.CurrentState = itemDef.InitialState
-
+    local instanceId = self.NextItemInstanceId
     self.NextItemInstanceId += 1
 
-    return itemEntry
+    return ItemFields.copyItemEntry({
+        InstanceId = instanceId,
+        Id = itemDef.Id,
+        Name = itemDef.Name,
+        Weight = itemDef.Weight,
+        Value = itemDef.Value,
+        Color = itemDef.Color,
+        Light = itemDef.Light,
+        Description = itemDef.Description,
+        IconAssetId = itemDef.IconAssetId,
+        ToolTemplateName = itemDef.ToolTemplateName,
+        ToolCategory = itemDef.ToolCategory,
+        StateModel = itemDef.StateModel,
+        InitialState = itemDef.InitialState,
+        CurrentState = itemDef.InitialState,
+        ConsumePerUse = itemDef.ConsumePerUse,
+        CooldownSeconds = itemDef.CooldownSeconds,
+        LastUsedAt = itemDef.LastUsedAt,
+        SwingRange = itemDef.SwingRange,
+        SwingArcDegrees = itemDef.SwingArcDegrees,
+        KnockbackStrength = itemDef.KnockbackStrength,
+        MeleeDamage = itemDef.MeleeDamage,
+        HealHealthPips = itemDef.HealHealthPips,
+    })
 end
 
 local function normalizeItemEntry(rawItemEntry)
-    if type(rawItemEntry) ~= 'table' or type(rawItemEntry.InstanceId) ~= 'number' then
-        return nil
-    end
-
-    local normalized = copyItemFields(rawItemEntry, {
-        InstanceId = rawItemEntry.InstanceId,
-    })
-    normalized.Weight = rawItemEntry.Weight or 0
-    normalized.Value = rawItemEntry.Value or 0
-    return normalized
+    return ItemFields.normalizeItemEntryForLoad(rawItemEntry)
 end
 
 function Inventory:add(itemDef)

--- a/packages/shared/src/Session/CampMazeSessionContract.luau
+++ b/packages/shared/src/Session/CampMazeSessionContract.luau
@@ -1,3 +1,7 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local ItemFields = require(Packages:WaitForChild('Gameplay')).Config.ItemFields
+
 local CampMazeSessionContract = {}
 local SessionPhase = require(script.Parent.SessionPhase)
 
@@ -21,47 +25,8 @@ local function cloneTable(input)
     return table.clone(input or {})
 end
 
-local function cloneLightConfig(lightConfig)
-    if type(lightConfig) ~= 'table' then
-        return nil
-    end
-
-    return {
-        Brightness = lightConfig.Brightness,
-        Range = lightConfig.Range,
-        Color = lightConfig.Color,
-    }
-end
-
 local function cloneInventoryItem(itemEntry)
-    if type(itemEntry) ~= 'table' then
-        return nil
-    end
-
-    return {
-        InstanceId = itemEntry.InstanceId,
-        Id = itemEntry.Id,
-        Name = itemEntry.Name,
-        Weight = itemEntry.Weight,
-        Value = itemEntry.Value,
-        Color = itemEntry.Color,
-        Light = cloneLightConfig(itemEntry.Light),
-        Description = itemEntry.Description,
-        IconAssetId = itemEntry.IconAssetId,
-        ToolTemplateName = itemEntry.ToolTemplateName,
-        ToolCategory = itemEntry.ToolCategory,
-        StateModel = itemEntry.StateModel,
-        InitialState = itemEntry.InitialState,
-        CurrentState = itemEntry.CurrentState,
-        ConsumePerUse = itemEntry.ConsumePerUse,
-        CooldownSeconds = itemEntry.CooldownSeconds,
-        LastUsedAt = itemEntry.LastUsedAt,
-        SwingRange = itemEntry.SwingRange,
-        SwingArcDegrees = itemEntry.SwingArcDegrees,
-        KnockbackStrength = itemEntry.KnockbackStrength,
-        MeleeDamage = itemEntry.MeleeDamage,
-        HealHealthPips = itemEntry.HealHealthPips,
-    }
+    return ItemFields.copyItemEntry(itemEntry)
 end
 
 local function cloneInventorySummary(summary)

--- a/places/run/src/ServerScriptService/Run/ItemFunctionality.luau
+++ b/places/run/src/ServerScriptService/Run/ItemFunctionality.luau
@@ -1,0 +1,426 @@
+--!strict
+--#region Services
+
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local TweenService = game:GetService('TweenService')
+local CollectionService = game:GetService('CollectionService')
+
+--#endregion
+
+--#region Requires
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Shared = require(Packages:WaitForChild('Shared'))
+local Remotes = Shared.Network.Remotes.waitForScope(Shared.Network.Remotes.Scope.Run)
+
+local RunInventoryBridge = require(script.Parent.RunInventoryBridge)
+
+--#endregion
+
+--#region Module
+
+local ItemFunctionality = {}
+
+-- 玩家道具状态
+ItemFunctionality.ActiveEffects = {}
+
+local function heldMatchesToolCategory(player: Player, toolCategory: string): boolean
+    local session = RunInventoryBridge.get()
+    if not session or not session.IsLaunched then
+        return false
+    end
+
+    local held = session.InventoryService:getSummary(player).HeldItem
+    return held ~= nil and held.ToolCategory == toolCategory
+end
+
+-- ====================
+-- 道具 1: 手电筒
+-- ====================
+
+-- 切换手电筒开关
+function ItemFunctionality.toggleFlashlight(player: Player): boolean
+    if not heldMatchesToolCategory(player, 'Flashlight') then
+        return false
+    end
+
+    local character = player.Character
+    if not character then
+        return false
+    end
+
+    local head = character:FindFirstChild('Head')
+    if not head then
+        return false
+    end
+
+    -- 查找或创建手电筒光源
+    local flashlightLight = head:FindFirstChild('FlashlightLight')
+    local isNewLight = false
+
+    if flashlightLight then
+        flashlightLight.Enabled = not flashlightLight.Enabled
+    else
+        flashlightLight = Instance.new('SpotLight')
+        flashlightLight.Name = 'FlashlightLight'
+        flashlightLight.Color = Color3.fromRGB(255, 255, 240)
+        flashlightLight.Brightness = 2
+        flashlightLight.Range = 50
+        flashlightLight.Angle = 45
+        flashlightLight.Face = Enum.NormalId.Front
+        flashlightLight.Parent = head
+        isNewLight = true
+    end
+
+    if isNewLight then
+        -- 刚创建时默认开启
+        flashlightLight.Enabled = true
+    end
+
+    return flashlightLight.Enabled
+end
+
+-- ====================
+-- 道具 2: 绳索
+-- ====================
+
+-- 攀爬高处
+function ItemFunctionality.climbWithRope(player: Player, climbTarget: BasePart): boolean
+    if not heldMatchesToolCategory(player, 'Rope') then
+        return false
+    end
+
+    local character = player.Character
+    if not character then
+        return false
+    end
+
+    local humanoid = character:FindFirstChild('Humanoid')
+    if not humanoid then
+        return false
+    end
+
+    -- 验证距离(防止远程交互攻击)
+    local characterPosition = character.HumanoidRootPart.Position
+    local distance = (climbTarget.Position - characterPosition).Magnitude
+    local MAX_INTERACTION_DISTANCE = 15 -- 最大交互距离
+
+    if distance > MAX_INTERACTION_DISTANCE then
+        warn(player.Name .. ' 尝试从过远的距离使用绳索: ' .. tostring(distance))
+        return false
+    end
+
+    -- 获取攀爬高度(使用交互对象的属性而非硬编码)
+    local climbHeight = climbTarget:GetAttribute('Height') or 5
+
+    -- 攀爬动画效果
+    humanoid:ChangeState(Enum.HumanoidStateType.Climbing)
+
+    -- 使用 TweenService 实现平滑攀爬,保留原始朝向
+    local targetPosition = climbTarget.Position + Vector3.new(0, climbHeight, 0)
+    local targetCFrame = CFrame.new(targetPosition, character.HumanoidRootPart.Position)
+    local climbTween = TweenService:Create(
+        character.HumanoidRootPart,
+        TweenInfo.new(2, Enum.EasingStyle.Linear, Enum.EasingDirection.InOut),
+        { CFrame = targetCFrame }
+    )
+    climbTween:Play()
+
+    -- 2秒后恢复正常状态
+    task.delay(2, function()
+        humanoid:ChangeState(Enum.HumanoidStateType.Freefall)
+    end)
+
+    return true
+end
+
+-- 跨越断层
+function ItemFunctionality.crossWithRope(player: Player, crossTarget: CFrame): boolean
+    if not heldMatchesToolCategory(player, 'Rope') then
+        return false
+    end
+
+    local character = player.Character
+    if not character then
+        return false
+    end
+
+    -- 验证距离(防止远程交互攻击)
+    local characterPosition = character.HumanoidRootPart.Position
+    local targetPosition = crossTarget.Position
+    local distance = (targetPosition - characterPosition).Magnitude
+    local MAX_INTERACTION_DISTANCE = 20 -- 跨越距离可以稍大一些
+
+    if distance > MAX_INTERACTION_DISTANCE then
+        warn(player.Name .. ' 尝试从过远的距离使用绳索跨越: ' .. tostring(distance))
+        return false
+    end
+
+    -- 播放跨越动画
+    local humanoid = character:FindFirstChild('Humanoid')
+    if humanoid then
+        humanoid.PlatformStand = true
+    end
+
+    -- 使用 Tween 跨越,保留原始朝向
+    local currentLookVector = character.HumanoidRootPart.CFrame.LookVector
+    local targetCFrame = CFrame.new(crossTarget.Position, crossTarget.Position + currentLookVector)
+    local crossTween = TweenService:Create(
+        character.HumanoidRootPart,
+        TweenInfo.new(1.5, Enum.EasingStyle.Sine, Enum.EasingDirection.InOut),
+        { CFrame = targetCFrame }
+    )
+    crossTween:Play()
+
+    -- 1.5秒后恢复正常
+    task.delay(1.5, function()
+        if humanoid then
+            humanoid.PlatformStand = false
+        end
+    end)
+
+    return true
+end
+
+-- 套住怪物
+function ItemFunctionality.tetherMonster(player: Player, targetModel: Model): boolean
+    if not heldMatchesToolCategory(player, 'Rope') then
+        return false
+    end
+
+    local humanoid = targetModel:FindFirstChild('Humanoid')
+    if not humanoid then
+        return false
+    end
+
+    -- 创建绳索视觉效果
+    local character = player.Character
+    if not character then
+        return false
+    end
+
+    -- 验证距离(防止远程交互攻击)
+    local characterPosition = character.HumanoidRootPart.Position
+    local targetPosition = targetModel.HumanoidRootPart.Position
+    local distance = (targetPosition - characterPosition).Magnitude
+    local MAX_INTERACTION_DISTANCE = 25 -- 套怪物的距离可以稍大一些
+
+    if distance > MAX_INTERACTION_DISTANCE then
+        warn(player.Name .. ' 尝试从过远的距离套住怪物: ' .. tostring(distance))
+        return false
+    end
+
+    local ropeVisual = Instance.new('Part')
+    ropeVisual.Name = 'TetherRope'
+    ropeVisual.Size = Vector3.new(0.1, 0.1, 1)
+    ropeVisual.Color = Color3.fromRGB(139, 90, 43)
+    ropeVisual.Material = Enum.Material.Fabric
+    ropeVisual.Anchored = true
+    ropeVisual.CanCollide = false
+    ropeVisual.Parent = workspace -- 设置父级，使绳索可见
+
+    -- 绳索两端的位置
+    -- 使用约束连接玩家和目标
+    local ropeConstraint = Instance.new('RopeConstraint')
+    ropeConstraint.Name = 'TetherConstraint'
+    ropeConstraint.Visible = true
+    ropeConstraint.Length = 0
+    ropeConstraint.Restitution = 0
+    ropeConstraint.Thickness = 0.1
+    ropeConstraint.Color = Color3.fromRGB(139, 90, 43)
+
+    local attachment1 = Instance.new('Attachment')
+    attachment1.Parent = character.HumanoidRootPart
+
+    local attachment2 = Instance.new('Attachment')
+    attachment2.Parent = targetModel.HumanoidRootPart
+
+    ropeConstraint.Attachment0 = attachment1
+    ropeConstraint.Attachment1 = attachment2
+    ropeConstraint.Parent = character.HumanoidRootPart
+
+    -- 固定怪物 2 秒
+    local originalWalkSpeed = humanoid.WalkSpeed
+    humanoid.PlatformStand = true
+    humanoid.WalkSpeed = 0
+
+    -- 2 秒后释放
+    task.delay(2, function()
+        humanoid.PlatformStand = false
+        humanoid.WalkSpeed = originalWalkSpeed -- 恢复原始速度
+        ropeConstraint:Destroy()
+        attachment1:Destroy()
+        attachment2:Destroy()
+        ropeVisual:Destroy()
+    end)
+
+    return true
+end
+
+-- ====================
+-- 道具 3: 撬棍
+-- ====================
+
+-- 撬开箱子/门
+function ItemFunctionality.pryOpen(player: Player, targetPart: BasePart): boolean
+    if not heldMatchesToolCategory(player, 'Crowbar') then
+        return false
+    end
+
+    -- 验证距离(防止远程交互攻击)
+    local character = player.Character
+    if not character or not character.HumanoidRootPart then
+        return false
+    end
+
+    local characterPosition = character.HumanoidRootPart.Position
+    local targetPosition = targetPart.Position
+    local distance = (targetPosition - characterPosition).Magnitude
+    local MAX_INTERACTION_DISTANCE = 10 -- 撬开的距离需要比较近
+
+    if distance > MAX_INTERACTION_DISTANCE then
+        warn(player.Name .. ' 尝试从过远的距离撬开: ' .. tostring(distance))
+        return false
+    end
+
+    -- 检查目标是否已被撬开
+    if targetPart:GetAttribute('PriedOpen') then
+        return false
+    end
+
+    -- 撬棍动画
+    -- 创建撬棍视觉提示
+    local crowbarVisual = Instance.new('Part')
+    crowbarVisual.Name = 'CrowbarAnimation'
+    crowbarVisual.Size = Vector3.new(0.2, 4, 0.2)
+    crowbarVisual.Color = Color3.fromRGB(120, 120, 120)
+    crowbarVisual.Material = Enum.Material.Metal
+    crowbarVisual.CanCollide = false
+    crowbarVisual.Anchored = true
+
+    local pryTargetPosition = targetPart.Position + Vector3.new(0, 1, 0)
+    crowbarVisual.CFrame = CFrame.new(pryTargetPosition) * CFrame.Angles(math.rad(45), 0, 0)
+    crowbarVisual.Parent = workspace
+
+    -- 撬动动画
+    local pryTween = TweenService:Create(
+        crowbarVisual,
+        TweenInfo.new(0.5, Enum.EasingStyle.Back, Enum.EasingDirection.InOut),
+        { CFrame = crowbarVisual.CFrame * CFrame.Angles(math.rad(-30), 0, 0) }
+    )
+    pryTween:Play()
+
+    -- 撬开效果
+    task.delay(0.5, function()
+        -- 标记为已撬开
+        targetPart:SetAttribute('PriedOpen', true)
+
+        -- 移除目标(如果是锁)
+        local lock = targetPart:FindFirstChild('Lock')
+        if lock then
+            lock:Destroy()
+        end
+
+        -- 或者移动目标(如果是门/盖)
+        if targetPart.Name == 'ChestLid' then
+            local openTween = TweenService:Create(
+                targetPart,
+                TweenInfo.new(0.3, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+                {
+                    CFrame = targetPart.CFrame
+                        * CFrame.Angles(math.rad(-45), 0, 0)
+                        * CFrame.new(0, 0.5, 0.5),
+                }
+            )
+            openTween:Play()
+        end
+
+        -- 移除视觉提示
+        crowbarVisual:Destroy()
+    end)
+
+    return true
+end
+
+-- ====================
+-- 交互检测系统
+-- ====================
+
+-- 检测玩家周围的交互对象（优化版：使用标签系统）
+function ItemFunctionality.detectInteractableObjects(player: Player, range: number): { BasePart }
+    local interactables = {}
+    local character = player.Character
+
+    if not character or not character.HumanoidRootPart then
+        return interactables
+    end
+
+    local playerPos = character.HumanoidRootPart.Position
+
+    -- 使用CollectionService获取所有带有Interactable标签的对象，性能更好
+    for _, object in ipairs(CollectionService:GetTagged('Interactable')) do
+        if object:IsA('BasePart') then
+            local distance = (object.Position - playerPos).Magnitude
+            if distance <= range then
+                table.insert(interactables, object)
+            end
+        end
+    end
+
+    return interactables
+end
+
+-- 注册可交互对象
+function ItemFunctionality.registerInteractable(
+    part: BasePart,
+    interactionType: string,
+    options: { [string]: any }
+)
+    -- 使用标签系统而不是属性，提升性能
+    CollectionService:AddTag(part, 'Interactable')
+    CollectionService:AddTag(part, interactionType)
+
+    if options then
+        for key, value in pairs(options) do
+            part:SetAttribute(key, value)
+        end
+    end
+end
+
+-- ====================
+-- 网络事件处理
+-- ====================
+
+-- 使用道具功能
+Remotes.UseItemFunction.OnServerEvent:Connect(
+    function(player: Player, itemName: string, target: any, actionType: string)
+        local success = false
+
+        if itemName == 'Flashlight' and actionType == 'toggle' then
+            success = ItemFunctionality.toggleFlashlight(player)
+        elseif itemName == 'Rope' then
+            if actionType == 'climb' and target then
+                success = ItemFunctionality.climbWithRope(player, target)
+            elseif actionType == 'cross' and target then
+                success = ItemFunctionality.crossWithRope(player, target)
+            elseif actionType == 'tether' and target then
+                success = ItemFunctionality.tetherMonster(player, target)
+            end
+        elseif itemName == 'Crowbar' and actionType == 'pry' and target then
+            success = ItemFunctionality.pryOpen(player, target)
+        end
+
+        if success then
+            print(player.Name .. ' 使用了 ' .. itemName .. ' 功能: ' .. actionType)
+        else
+            warn(player.Name .. ' 使用 ' .. itemName .. ' 功能失败: ' .. actionType)
+        end
+    end
+)
+
+-- 查询附近的可交互对象
+Remotes.GetInteractables.OnServerInvoke = function(player: Player, range: number): { BasePart }
+    return ItemFunctionality.detectInteractableObjects(player, range or 10)
+end
+
+return ItemFunctionality

--- a/places/run/src/ServerScriptService/Run/RunInventoryBridge.luau
+++ b/places/run/src/ServerScriptService/Run/RunInventoryBridge.luau
@@ -1,0 +1,22 @@
+--!strict
+-- Binds the active RunSessionService for Run-local modules (e.g. ItemFunctionality) that need InventoryService.
+
+export type BoundService = {
+    IsLaunched: boolean,
+    InventoryService: any,
+    _broadcastSnapshot: (self: BoundService) -> (),
+}
+
+local bound: BoundService? = nil
+
+local RunInventoryBridge = {}
+
+function RunInventoryBridge.bind(service: BoundService)
+    bound = service
+end
+
+function RunInventoryBridge.get(): BoundService?
+    return bound
+end
+
+return RunInventoryBridge

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -23,6 +23,7 @@ local RunSnapshotBuilder = require(script.Parent.RunSnapshotBuilder)
 local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
 local RunToMazeTransition = require(script.Parent.RunToMazeTransition)
 local RunWorldBuilder = require(script.Parent.RunWorldBuilder)
+local RunInventoryBridge = require(script.Parent.RunInventoryBridge)
 
 local RunSessionService = {}
 RunSessionService.__index = RunSessionService
@@ -33,6 +34,11 @@ local MAZE_ENTRY_REQUEST_COOLDOWN_SECONDS = 0.35
 local MAZE_ENTRY_DISTANCE_BUFFER = 2
 local TERMINAL_INTERACTION_DISTANCE_BUFFER = 2
 local SNAPSHOT_INTERVAL_SECONDS = 0.25
+local LEGACY_TOOL_CATEGORY = table.freeze({
+    Flashlight = 'Flashlight',
+    Rope = 'Rope',
+    Crowbar = 'Crowbar',
+})
 local RUN_MAZE_GATE_RETURN_REASONS = table.freeze({
     early_return = true,
     extracted = true,
@@ -1378,10 +1384,108 @@ function RunSessionService:_ensureAuthoritativeSessionSeed()
     end
 end
 
+function RunSessionService:_emptyInventorySummary()
+    return {
+        Capacity = self.SessionData.InventoryCapacity,
+        Weight = 0,
+        Count = 0,
+        BackpackCount = 0,
+        HeldCount = 0,
+        Value = 0,
+        BackpackItems = {},
+        HeldItem = nil,
+    }
+end
+
+function RunSessionService:_inventorySummaryFor(player)
+    if not self.IsLaunched then
+        return self:_emptyInventorySummary()
+    end
+
+    return self.InventoryService:getSummary(player)
+end
+
+function RunSessionService:_getLegacyHeldItemShim(player, legacyToolName)
+    if type(legacyToolName) ~= 'string' then
+        return nil
+    end
+
+    local expectedCategory = LEGACY_TOOL_CATEGORY[legacyToolName]
+    if not expectedCategory then
+        return nil
+    end
+
+    local held = self:_inventorySummaryFor(player).HeldItem
+    if not held or held.ToolCategory ~= expectedCategory then
+        return nil
+    end
+
+    return {
+        Name = held.Name,
+        Type = 'Tool',
+        Description = held.Description or '',
+        IsEquipped = true,
+        IsActive = false,
+        IconAssetId = held.IconAssetId or '',
+        Color = held.Color,
+    }
+end
+
+function RunSessionService:_bindItemRemotes()
+    self.Remotes.GetInventory.OnServerInvoke = function(player: Player)
+        return self:_inventorySummaryFor(player)
+    end
+
+    self.Remotes.GetItemData.OnServerInvoke = function(player: Player, legacyToolName: string)
+        return self:_getLegacyHeldItemShim(player, legacyToolName)
+    end
+
+    self.Remotes.EquipItem.OnServerEvent:Connect(
+        function(player: Player, itemInstanceId: any, equip: any)
+            if type(itemInstanceId) ~= 'number' then
+                return
+            end
+
+            if equip == true then
+                self:_equipItem(player, itemInstanceId)
+            else
+                self:_unequipItem(player)
+            end
+
+            self:_broadcastSnapshot()
+        end
+    )
+
+    self.Remotes.UseItem.OnServerEvent:Connect(function(player: Player, legacyToolName: string)
+        if type(legacyToolName) ~= 'string' then
+            return
+        end
+
+        if not self:_canManageInventory(player) then
+            return
+        end
+
+        local expectedCategory = LEGACY_TOOL_CATEGORY[legacyToolName]
+        if not expectedCategory then
+            return
+        end
+
+        local held = self.InventoryService:getSummary(player).HeldItem
+        if not held or held.ToolCategory ~= expectedCategory then
+            return
+        end
+
+        self.InventoryService:consumeHeldItemState(player, os.clock())
+        self:_broadcastSnapshot()
+    end)
+end
+
 function RunSessionService:start()
     warn(string.format('[run-session] build=%s', self.BuildFingerprint))
     self:_loadSessionDataFromJoin()
     self:_ensureAuthoritativeSessionSeed()
+    RunInventoryBridge.bind(self)
+    self:_bindItemRemotes()
     Players.CharacterAutoLoads = false
 
     for _, player in ipairs(Players:GetPlayers()) do

--- a/tests/src/Shared/CampMazeSessionContract.spec.luau
+++ b/tests/src/Shared/CampMazeSessionContract.spec.luau
@@ -191,6 +191,10 @@ return function()
                 ToolTemplateName = 'ToolPotion',
                 Description = 'Contract potion row',
                 HealHealthPips = 2,
+                SwingRange = 4,
+                SwingArcDegrees = 50,
+                KnockbackStrength = 9,
+                MeleeDamage = 2,
             },
         },
         PendingUgcMonsterPayload = nil,
@@ -207,6 +211,10 @@ return function()
     assert(
         toolHoldInventory.HeldItem.HealHealthPips == 2,
         'Run -> maze inventory clone should preserve HealHealthPips for potion tools'
+    )
+    assert(
+        toolHoldInventory.HeldItem.MeleeDamage == 2,
+        'Run -> maze inventory clone should preserve MeleeDamage for tool entries'
     )
 
     local earlyReturn = contract.buildReturnSummary({

--- a/tests/src/Shared/Inventory.spec.luau
+++ b/tests/src/Shared/Inventory.spec.luau
@@ -2,6 +2,8 @@ return function()
     local ReplicatedStorage = game:GetService('ReplicatedStorage')
     local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
     local sharedPackage = ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared')
+    local shared = require(sharedPackage)
+    local contract = shared.Session.CampMazeSessionContract
     local items = gameplay.Config.Items
     local inventory = gameplay.Inventory.new(7)
     local inventoryService =
@@ -211,6 +213,80 @@ return function()
     assert(
         potionSummary.HeldItem.HealHealthPips == 2,
         'HealHealthPips should round-trip on held potion summaries'
+    )
+
+    local durableUser = {
+        UserId = 205,
+    }
+    inventoryService:addPlayer(durableUser)
+    local durableDef = {
+        Id = 'spec-durable',
+        Name = 'Durable',
+        Weight = 1,
+        Value = 0,
+        Color = Color3.fromRGB(90, 90, 90),
+        ToolCategory = 'Pry',
+        StateModel = 'Durability',
+        InitialState = 5,
+        ConsumePerUse = 1,
+        CooldownSeconds = 0,
+    }
+    local durablePickupOk, durableEntry = inventoryService:pickup(durableUser, durableDef)
+    assert(durablePickupOk == true, 'Runtime inventory should pick up durable consumable defs')
+    assert(
+        inventoryService:equip(durableUser, durableEntry.InstanceId) == true,
+        'Runtime inventory should equip durable consumable tools'
+    )
+    local durableConsumeOk, durableHeld = inventoryService:consumeHeldItemState(durableUser, 200)
+    assert(durableConsumeOk == true, 'consumeHeldItemState should succeed for held durable tools')
+    assert(
+        durableHeld.CurrentState == 4,
+        'Held durable tool CurrentState should decrement by ConsumePerUse'
+    )
+
+    local durableSummary = inventoryService:getSummary(durableUser)
+    local campForRoundTrip = contract.newCampSession({
+        SessionId = 'inv-contract-rt',
+        CampAccessCode = 'inv-contract-rt',
+    })
+    local enteredRoundTrip = contract.markPlayerEntered(campForRoundTrip, {
+        UserId = durableUser.UserId,
+        Name = 'RoundTrip',
+    })
+    enteredRoundTrip.MazeAccessCode = 'inv-contract-rt-maze'
+    local roundTripTeleport = contract.buildRunToMazeTeleportData({
+        SessionConfig = {
+            Seed = 42,
+            Quota = 10,
+            RunDurationSeconds = 120,
+            InventoryCapacity = 7,
+        },
+        CampSession = enteredRoundTrip,
+        EnteringPlayer = {
+            UserId = durableUser.UserId,
+            Name = 'RoundTrip',
+        },
+        EntryReason = 'maze_gate',
+        PlayerInventory = durableSummary,
+        PendingUgcMonsterPayload = nil,
+    })
+    local clonedSummary = contract.findPlayerInventory(roundTripTeleport, durableUser.UserId)
+    assert(
+        clonedSummary ~= nil and clonedSummary.HeldItem ~= nil,
+        'Contract teleport shaping should carry the durable inventory summary'
+    )
+    assert(
+        clonedSummary.HeldItem.CurrentState == 4,
+        'Contract clone should preserve CurrentState across maze teleport shaping'
+    )
+    local inventoryAfterContract = gameplay.Inventory.new(7)
+    assert(
+        inventoryAfterContract:loadSummary(clonedSummary) == true,
+        'Inventory should hydrate summaries produced by contract cloning'
+    )
+    assert(
+        inventoryAfterContract:getSummary().HeldItem.CurrentState == 4,
+        'Hydrated inventory should preserve contract-cloned CurrentState'
     )
 
     local cooldownToolPlayer = {

--- a/tests/src/Shared/ItemEntryFields.spec.luau
+++ b/tests/src/Shared/ItemEntryFields.spec.luau
@@ -1,0 +1,104 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
+    local shared = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared'))
+    local ItemFields = gameplay.Config.ItemFields
+    local contract = shared.Session.CampMazeSessionContract
+
+    local fixture = {
+        InstanceId = 99,
+        Id = 'tool-spec-all-fields',
+        Name = 'Spec Tool',
+        Weight = 2,
+        Value = 5,
+        Color = Color3.fromRGB(10, 20, 30),
+        Light = {
+            Brightness = 1.5,
+            Range = 20,
+            Color = Color3.fromRGB(40, 50, 60),
+        },
+        Description = 'Spec entry',
+        IconAssetId = '123',
+        ToolTemplateName = 'ToolSpec',
+        ToolCategory = 'SpecCat',
+        StateModel = 'Durability',
+        InitialState = 10,
+        CurrentState = 7,
+        ConsumePerUse = 1,
+        CooldownSeconds = 0.25,
+        LastUsedAt = 1000,
+        SwingRange = 5,
+        SwingArcDegrees = 60,
+        KnockbackStrength = 8,
+        MeleeDamage = 2,
+        HealHealthPips = 3,
+    }
+
+    local copy = ItemFields.copyItemEntry(fixture)
+    assert(copy ~= nil, 'copyItemEntry should accept a full fixture')
+    for _, fieldName in ipairs(ItemFields.ENTRY_FIELD_NAMES) do
+        if fieldName == 'Light' then
+            assert(
+                copy.Light ~= nil and copy.Light.Brightness == fixture.Light.Brightness,
+                'Light should be deep-copied for contract parity'
+            )
+        else
+            assert(
+                copy[fieldName] == fixture[fieldName],
+                string.format('Field %s should round-trip through copyItemEntry', fieldName)
+            )
+        end
+    end
+
+    local campSession = contract.newCampSession({
+        SessionId = 'item-fields-spec',
+        CampAccessCode = 'item-fields-spec',
+    })
+    local entered = contract.markPlayerEntered(campSession, {
+        UserId = 501,
+        Name = 'SpecRunner',
+    })
+    entered.MazeAccessCode = 'maze-access-item-fields'
+
+    local summary = {
+        Capacity = 8,
+        Weight = fixture.Weight,
+        Count = 1,
+        BackpackCount = 0,
+        HeldCount = 1,
+        Value = fixture.Value,
+        BackpackItems = {},
+        HeldItem = fixture,
+    }
+
+    local teleportPayload = contract.buildRunToMazeTeleportData({
+        SessionConfig = {
+            Seed = 1,
+            Quota = 10,
+            RunDurationSeconds = 60,
+            InventoryCapacity = 8,
+        },
+        CampSession = entered,
+        EnteringPlayer = {
+            UserId = 501,
+            Name = 'SpecRunner',
+        },
+        EntryReason = 'maze_gate',
+        PlayerInventory = summary,
+        PendingUgcMonsterPayload = nil,
+    })
+
+    local viaContract = contract.findPlayerInventory(teleportPayload, 501)
+    assert(
+        viaContract ~= nil and viaContract.HeldItem ~= nil,
+        'Teleport shaping should carry inventory'
+    )
+    assert(
+        ItemFields.copyItemEntry(fixture).MeleeDamage == viaContract.HeldItem.MeleeDamage,
+        'Contract clone should match ItemFields for MeleeDamage'
+    )
+    assert(
+        ItemFields.copyItemEntry(fixture).HealHealthPips == viaContract.HeldItem.HealHealthPips,
+        'Contract clone should match ItemFields for HealHealthPips'
+    )
+end


### PR DESCRIPTION
Run: remove ItemService; wire GetInventory/GetItemData/EquipItem/UseItem via RunSessionService + RunInventoryBridge
Shared: CampMazeSessionContract uses Gameplay.Config.ItemFields for cloneInventoryItem
Gameplay: add ItemFields; Inventory uses it for copy/normalize
Tests: ItemEntryFields.spec; extend Inventory + CampMazeSessionContract specs
Closes / Ref:  Refs #229 #232

## Summary

- What changed?
- Why is this change needed?
- Any prototype-only exceptions or follow-up work?

## Roblox Integration Checklist

- [ ] The change updates the active runtime source under `packages/**`, or I explained why another source path had to change.
- [ ] If Studio tree structure changed, I updated the relevant `default.project.json` in the same PR.
- [ ] If I changed Remote names, replicated schema, or visibility behavior, I updated all linked producers/consumers/tests in the same PR.
- [ ] If I changed non-trivial shared/gameplay behavior, I added or updated deterministic coverage under `tests/src/Shared`, or I explained why no test change was needed.
- [ ] If I touched `SessionConfig.PlaceIds` or any other real-environment configuration, I documented the required rollout or environment follow-up.
- [ ] If this PR includes `.rbxl`, generated output, or other non-source artifacts, I explained why they are required.

## Validation

- [ ] `stylua --check .`
- [ ] `selene .`
- [ ] Additional verification steps are listed below if this PR needs more than static checks.

## Notes

- Manual test notes:
- Risks / follow-ups:
