### PR TITLE
fix(shared): wire attack queuing + propagate effects for SprintSuppressed

### DIFF
--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -802,6 +802,7 @@ function MonsterService:_resolveAttackHitContext(pendingAttack)
         Hit = true,
         Reason = 'HitConfirmed',
         Distance = distance,
+        Effects = pendingAttack.Effects,
     }
 end
 
@@ -1112,6 +1113,17 @@ function MonsterService:_runLogicStep(dt)
         self:_emitDecisionLog('AttackQueued', {
             MonsterId = self.Definition.Id,
         })
+        local target = self.EnemyRuntime.Blackboard.CurrentTarget
+        if target then
+            self:_queueAttackIntent({
+                TargetPlayer = target,
+                DamagePips = self.ComponentConfig.Attack.DamagePips,
+                Range = self.ComponentConfig.Attack.Range,
+                ArcDegrees = self.ComponentConfig.Attack.ArcDegrees,
+                MarkerName = self.ComponentConfig.Attack.HitMarkerName,
+                Effects = self.Definition.Effects,
+            })
+        end
     end
 
     local nextPosition = decision.NextPosition


### PR DESCRIPTION
## Summary

Two related changes for the monster effect pipeline:

1. **Attack queuing fix** — `decision.AttackQueued` from EnemyRuntime was logged but `_queueAttackIntent` was never called. `PendingAttack` was never created and `OnAttackHit` never fired. Monsters could not deal damage.

2. **Effects propagation** — `Effects` from `self.Definition` now flows through `PendingAttack` → `hitContext` → `OnAttackHit` callback. `hitContext.Effects` is now available for consumers (e.g. SprintSuppressed).

### Changes in `packages/shared/src/Runtime/MonsterService.luau`

| Location | Change |
|---|---|
| `_runLogicStep` | Call `_queueAttackIntent` with target + attack params when `AttackQueued` |
| `PendingAttack` | Now includes `Effects = self.Definition.Effects` |
| `hitContext` | Now includes `Effects = pendingAttack.Effects` |

### Verification
- [ ] CI (luau-quality + roblox-tests) passes
- [ ] Playtest: monster in expedition attacks player, `OnAttackHit` fires and `hitContext.Effects` is populated

### Related
- Fixes: regression from `feat(run): integrate MonsterService with Expedition trigger` (PR #255)
- Enables: #183 SprintSuppressed effect pipeline