### PR TITLE
feat(shared): implement SprintSuppressed effect pipeline

### DIFF
--- a/packages/gameplay/src/ControlState.luau
+++ b/packages/gameplay/src/ControlState.luau
@@ -45,6 +45,15 @@ function ControlState:requestSprintStart(playerStateSummary)
         return false, 'StaminaDepleted'
     end
 
+    if
+        playerStateSummary.ActiveEffects
+        and playerStateSummary.ActiveEffects['SprintSuppressed']
+    then
+        self.SprintRequested = false
+        self.Mode = MODE.Walk
+        return false, 'SprintSuppressed'
+    end
+
     self.SprintRequested = true
     self.Mode = MODE.Sprint
     return true, self:getSummary()
@@ -70,6 +79,15 @@ function ControlState:syncPlayerState(playerStateSummary)
     end
 
     if playerStateSummary.CanSprint ~= true then
+        self.SprintRequested = false
+        self.Mode = MODE.Walk
+        return self:getSummary()
+    end
+
+    if
+        playerStateSummary.ActiveEffects
+        and playerStateSummary.ActiveEffects['SprintSuppressed']
+    then
         self.SprintRequested = false
         self.Mode = MODE.Walk
         return self:getSummary()

--- a/packages/gameplay/src/PlayerState.luau
+++ b/packages/gameplay/src/PlayerState.luau
@@ -49,6 +49,7 @@ function PlayerState.new(config)
         CanSprint = true,
         CorpseActive = false,
         IsSprinting = false,
+        ActiveEffects = {}, -- {[effectId] = remainingSeconds}
     }, PlayerState)
 end
 
@@ -61,6 +62,7 @@ function PlayerState:getSummary()
         IsDead = self.IsDead,
         CanSprint = self.CanSprint,
         CorpseActive = self.CorpseActive,
+        ActiveEffects = self.ActiveEffects,
     }
 end
 
@@ -96,12 +98,43 @@ function PlayerState:applyDamage(damageKind)
     return true, self:getSummary()
 end
 
+function PlayerState:applyEffect(effectId, durationSeconds)
+    if type(effectId) ~= 'string' or effectId == '' then
+        return
+    end
+    local duration = if type(durationSeconds) == 'number' and durationSeconds > 0
+        then durationSeconds
+        else math.huge
+    local currentRemaining = self.ActiveEffects[effectId]
+    if currentRemaining == nil or duration > currentRemaining then
+        self.ActiveEffects[effectId] = duration
+    end
+end
+
+function PlayerState:hasEffect(effectId)
+    if type(effectId) ~= 'string' then
+        return false
+    end
+    return self.ActiveEffects[effectId] ~= nil
+end
+
 function PlayerState:step(dt)
     if self.IsDead then
         return self:getSummary()
     end
 
     local deltaTime = math.max(0, dt or 0)
+
+    -- Tick down active effects
+    for effectId, remaining in pairs(self.ActiveEffects) do
+        local nextRemaining = remaining - deltaTime
+        if nextRemaining <= 0 then
+            self.ActiveEffects[effectId] = nil
+        else
+            self.ActiveEffects[effectId] = nextRemaining
+        end
+    end
+
     if self.IsSprinting and self.CanSprint then
         self.CurrentStamina =
             clamp(self.CurrentStamina - self.StaminaDrainPerSecond * deltaTime, 0, self.MaxStamina)

--- a/packages/shared/src/Runtime/PlayerStateService.luau
+++ b/packages/shared/src/Runtime/PlayerStateService.luau
@@ -52,6 +52,24 @@ function PlayerStateService:applyDamage(player, damageKind)
     return state:applyDamage(damageKind)
 end
 
+function PlayerStateService:applyEffect(player, effectId, durationSeconds)
+    local state = self:get(player)
+    if not state then
+        return
+    end
+
+    state:applyEffect(effectId, durationSeconds)
+end
+
+function PlayerStateService:hasEffect(player, effectId)
+    local state = self:get(player)
+    if not state then
+        return false
+    end
+
+    return state:hasEffect(effectId)
+end
+
 function PlayerStateService:setSprinting(player, isSprinting)
     local state = self:get(player)
     if not state then

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -286,13 +286,18 @@ end
 function MazeSessionService:_buildMonsterRuntimeOptions(randomSeed)
     return {
         RandomSeed = randomSeed,
-        OnAttackHit = function(player, damagePips)
+        OnAttackHit = function(player, damagePips, hitContext)
             local damageKind = damageKindFromPips(damagePips)
             if damageKind == nil then
                 return
             end
 
             self:_applyPlayerDamage(player, damageKind)
+            if hitContext and hitContext.Effects then
+                for _, effect in ipairs(hitContext.Effects) do
+                    self.PlayerStateService:applyEffect(player, effect.Id, effect.DurationSeconds)
+                end
+            end
         end,
     }
 end

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -1320,8 +1320,17 @@ function RunSessionService:_createMonsterService()
         {
             RandomSeed = self.SessionData.Seed,
             RandomSource = randomSource,
-            OnAttackHit = function(player, damagePips, _hitContext)
+            OnAttackHit = function(player, damagePips, hitContext)
                 self:_applyPlayerDamage(player, damagePips)
+                if hitContext and hitContext.Effects then
+                    for _, effect in ipairs(hitContext.Effects) do
+                        self.PlayerStateService:applyEffect(
+                            player,
+                            effect.Id,
+                            effect.DurationSeconds
+                        )
+                    end
+                end
             end,
         }
     )


### PR DESCRIPTION
Completes the SprintSuppressed effect pipeline from monster attack to player state.

PlayerState: add ActiveEffects, applyEffect/hasEffect, tick in step()
PlayerStateService: delegate applyEffect/hasEffect
ControlState: block sprint when SprintSuppressed active in requestSprintStart and syncPlayerState
RunSessionService and MazeSessionService: apply effects from hitContext.Effects on attack hit

CI (luau-quality + roblox-tests) must pass. Playtest: monster attacks player, player sprint is suppressed for configured duration.

Closes #183