### PR TITLE
feat(monsters): add BaseEnemy inheritance + HealthComponent + death pipeline

### DIFF
--- a/packages/gameplay/src/Config/Monsters.luau
+++ b/packages/gameplay/src/Config/Monsters.luau
@@ -19,6 +19,9 @@ return {
                 Tool = 'No dedicated suppression tool in v1',
             },
         },
+        Health = {
+            MaxHp = 3,
+        },
         Tuning = {
             AttackCooldownSeconds = 1,
             AttackDamagePips = 1,

--- a/packages/gameplay/src/Monsters/BaseEnemy.luau
+++ b/packages/gameplay/src/Monsters/BaseEnemy.luau
@@ -1,0 +1,71 @@
+local BaseEnemy = {}
+
+function BaseEnemy.setupHealth(self, componentConfig)
+    local maxHp = 1
+    if type(componentConfig) == 'table' and type(componentConfig.Health) == 'table' then
+        local hp = componentConfig.Health.MaxHp
+        if type(hp) == 'number' and hp >= 1 then
+            maxHp = math.floor(hp)
+        end
+    end
+
+    if not self.Components then
+        self.Components = {}
+    end
+
+    local HealthComponent = require(script.Parent.Components.HealthComponent)
+    self.Components.Health = HealthComponent.new(maxHp)
+end
+
+function BaseEnemy.applyDamage(self, amount, source)
+    local health = self.Components and self.Components.Health
+    if not health then
+        return
+    end
+
+    if type(amount) ~= 'number' or amount <= 0 then
+        return
+    end
+
+    local damageSource = source or 'unknown'
+    health:applyDamage(amount, damageSource)
+
+    if self.Blackboard and health:isDead() then
+        self.Blackboard.Transient.DeathEvent = {
+            MonsterId = if self.Blackboard.Definition then self.Blackboard.Definition.Id else nil,
+            KilledBy = damageSource,
+        }
+    end
+end
+
+function BaseEnemy.heal(self, amount)
+    local health = self.Components and self.Components.Health
+    if not health then
+        return
+    end
+
+    if type(amount) ~= 'number' or amount <= 0 then
+        return
+    end
+
+    health:heal(amount)
+end
+
+function BaseEnemy.getHealth(self)
+    local health = self.Components and self.Components.Health
+    if not health then
+        return {
+            CurrentHp = 0,
+            MaxHp = 0,
+            IsDead = true,
+        }
+    end
+
+    return {
+        CurrentHp = health.CurrentHp,
+        MaxHp = health.MaxHp,
+        IsDead = health:isDead(),
+    }
+end
+
+return BaseEnemy

--- a/packages/gameplay/src/Monsters/BaseEnemy.luau
+++ b/packages/gameplay/src/Monsters/BaseEnemy.luau
@@ -1,3 +1,5 @@
+local HealthComponent = require(script.Parent.Components.HealthComponent)
+
 local BaseEnemy = {}
 
 function BaseEnemy.setupHealth(self, componentConfig)
@@ -13,7 +15,6 @@ function BaseEnemy.setupHealth(self, componentConfig)
         self.Components = {}
     end
 
-    local HealthComponent = require(script.Parent.Components.HealthComponent)
     self.Components.Health = HealthComponent.new(maxHp)
 end
 

--- a/packages/gameplay/src/Monsters/Components/HealthComponent.luau
+++ b/packages/gameplay/src/Monsters/Components/HealthComponent.luau
@@ -1,0 +1,49 @@
+local HealthComponent = {}
+HealthComponent.__index = HealthComponent
+
+function HealthComponent.new(maxHp)
+    local hp = 1
+    if type(maxHp) == 'number' and maxHp >= 1 then
+        hp = math.floor(maxHp)
+    end
+
+    return setmetatable({
+        MaxHp = hp,
+        CurrentHp = hp,
+    }, HealthComponent)
+end
+
+function HealthComponent:init(_blackboard)
+    -- No-op: initialization is done in the constructor.
+end
+
+function HealthComponent:applyDamage(amount, _source)
+    if type(amount) ~= 'number' or amount <= 0 then
+        return
+    end
+
+    self.CurrentHp = math.max(0, self.CurrentHp - amount)
+end
+
+function HealthComponent:heal(amount)
+    if type(amount) ~= 'number' or amount <= 0 then
+        return
+    end
+
+    self.CurrentHp = math.min(self.MaxHp, self.CurrentHp + amount)
+end
+
+function HealthComponent:isDead()
+    return self.CurrentHp <= 0
+end
+
+function HealthComponent:update(_blackboard, _dt)
+    -- No-op: HealthComponent is driven by explicit applyDamage / heal calls,
+    -- not by a per-tick update tick.
+end
+
+function HealthComponent:destroy(_blackboard)
+    -- No-op: no external resources to release.
+end
+
+return HealthComponent

--- a/packages/gameplay/src/Monsters/Enemy.luau
+++ b/packages/gameplay/src/Monsters/Enemy.luau
@@ -1,3 +1,4 @@
+local BaseEnemy = require(script.Parent.BaseEnemy)
 local EnemyBlackboard = require(script.Parent.EnemyBlackboard)
 local EnemyStateMachine = require(script.Parent.EnemyStateMachine)
 
@@ -7,6 +8,7 @@ local PerceptionComponent = require(script.Parent.Components.PerceptionComponent
 
 local Enemy = {}
 Enemy.__index = Enemy
+setmetatable(Enemy, { __index = BaseEnemy })
 
 local UPDATE_ORDER = table.freeze({
     'Perception',
@@ -33,13 +35,16 @@ function Enemy.new(definition, options)
     local stateMachine = enemyOptions.StateMachine or EnemyStateMachine.new()
     local components = enemyOptions.Components or defaultComponents()
 
-    return setmetatable({
+    local self = setmetatable({
         Blackboard = blackboard,
         ComponentConfig = enemyOptions.ComponentConfig or {},
         StateMachine = stateMachine,
         Components = components,
         StageObserver = enemyOptions.StageObserver,
     }, Enemy)
+
+    self:setupHealth(self.ComponentConfig)
+    return self
 end
 
 function Enemy:_emitStage(stageName)
@@ -74,6 +79,10 @@ function Enemy:update(dt, context)
     self:_emitStage('Attack')
     self.Components.Attack:update(self.Blackboard, dt)
 
+    if self.Components.Health then
+        self.Components.Health:update(self.Blackboard, dt)
+    end
+
     return {
         AttackIntent = self.Blackboard.Transient.AttackIntent,
         State = self.Blackboard:getState(),
@@ -84,6 +93,8 @@ function Enemy:update(dt, context)
         DesiredAnimationSpeed = self.Blackboard.Transient.DesiredAnimationSpeed or 1,
         ShouldPlayChaseLoop = self.Blackboard.Transient.ShouldPlayChaseLoop == true,
         TravelOffset = self.Blackboard.Transient.TravelOffset or Vector3.zero,
+        IsDead = self.Components.Health and self.Components.Health:isDead() or false,
+        DeathEvent = self.Blackboard.Transient.DeathEvent,
     }
 end
 

--- a/packages/gameplay/src/Monsters/MonsterAuthorProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterAuthorProfile.luau
@@ -37,6 +37,7 @@ local BOUNDARY_REASONS = table.freeze({
     BoundarySemanticsContainsNonSemanticField = true,
     BoundaryTuningContainsNonTuningField = true,
     BoundaryExecutableContainsNonExecutableField = true,
+    BoundaryHealthContainsNonHealthField = true,
 })
 
 MonsterAuthorProfile.ErrorCategory = ERROR_CATEGORY
@@ -157,11 +158,27 @@ local function normalizeSections(profile)
         return nil, 'BoundaryExecutableContainsNonExecutableField'
     end
 
+    local health = profile.Health
+    if health ~= nil and type(health) ~= 'table' then
+        return nil, 'InvalidHealth'
+    end
+
+    if health ~= nil then
+        if
+            hasAnyField(health, SEMANTIC_FIELDS)
+            or hasAnyField(health, TUNING_FIELDS)
+            or hasAnyField(health, EXECUTABLE_FIELDS)
+        then
+            return nil, 'BoundaryHealthContainsNonHealthField'
+        end
+    end
+
     return {
         SchemaMode = SCHEMA_MODE.Layered,
         Semantics = semantics,
         Tuning = tuning,
         Executable = executable,
+        Health = health,
     }
 end
 

--- a/packages/gameplay/src/Monsters/MonsterCompiler.luau
+++ b/packages/gameplay/src/Monsters/MonsterCompiler.luau
@@ -94,6 +94,7 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
         PatrolSpeedMultiplier = normalizedProfile.Tuning.PatrolSpeedMultiplier,
         SpawnOffset = normalizedProfile.Tuning.SpawnOffset or DEFAULT_SPAWN_OFFSET,
         CombatHitPoints = combatHitPoints,
+        Health = normalizedProfile.Health,
         Behaviors = table.freeze(behaviors),
         Effects = table.freeze(runtimeEffects),
     }

--- a/packages/gameplay/src/Monsters/MonsterComponentConfig.luau
+++ b/packages/gameplay/src/Monsters/MonsterComponentConfig.luau
@@ -78,6 +78,17 @@ function MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)
                 else DEFAULT_ATTACK_HIT_MARKER_NAME,
             Range = getPositiveNumber(attack.Range, profile.AttackRange, DEFAULT_ATTACK_RANGE),
         }),
+        Health = table.freeze({
+            MaxHp = getPositiveNumber(
+                components.Health and components.Health.MaxHp,
+                getPositiveNumber(
+                    profile.Health and profile.Health.MaxHp,
+                    profile.CombatHitPoints,
+                    1
+                ),
+                1
+            ),
+        }),
     }
 
     return table.freeze(componentConfig)

--- a/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
@@ -86,6 +86,10 @@ function MonsterRuntimeProfile.validate(profile)
     if attackConfigErr then
         return false, attackConfigErr
     end
+    local healthConfig, healthConfigErr = readComponentTable(profile, 'Health')
+    if healthConfigErr then
+        return false, healthConfigErr
+    end
 
     if
         perceptionConfig
@@ -132,6 +136,18 @@ function MonsterRuntimeProfile.validate(profile)
         if attackConfig.DamagePips ~= nil and not isValidDamagePips(attackConfig.DamagePips) then
             return false, 'InvalidRuntimeComponentAttackDamagePips'
         end
+    end
+
+    if
+        healthConfig
+        and healthConfig.MaxHp ~= nil
+        and (
+            type(healthConfig.MaxHp) ~= 'number'
+            or healthConfig.MaxHp < 1
+            or math.floor(healthConfig.MaxHp) ~= healthConfig.MaxHp
+        )
+    then
+        return false, 'InvalidRuntimeComponentHealthMaxHp'
     end
 
     local runtimeSpeed = profile.Speed

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -1036,15 +1036,12 @@ function MonsterService:tryApplyPlayerMeleeHit(player, meleeOptions)
         TargetUserId = player.UserId,
     })
 
+    if self.EnemyRuntime then
+        self.EnemyRuntime:applyDamage(damagePips, 'player')
+    end
+
     if killed then
-        if self.EnemyRuntime then
-            self.EnemyRuntime:applyDamage(damagePips, 'player')
-        end
         self:destroy()
-    else
-        if self.EnemyRuntime then
-            self.EnemyRuntime:applyDamage(damagePips, 'player')
-        end
     end
 
     return true, {

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -1037,7 +1037,14 @@ function MonsterService:tryApplyPlayerMeleeHit(player, meleeOptions)
     })
 
     if killed then
+        if self.EnemyRuntime then
+            self.EnemyRuntime:applyDamage(damagePips, 'player')
+        end
         self:destroy()
+    else
+        if self.EnemyRuntime then
+            self.EnemyRuntime:applyDamage(damagePips, 'player')
+        end
     end
 
     return true, {
@@ -1096,6 +1103,15 @@ function MonsterService:_runLogicStep(dt)
 
     local decision = self.EnemyRuntime:update(dt)
     self.PatrolIndex = self.EnemyRuntime.Context.PatrolIndex
+
+    if decision.IsDead then
+        self:_recordDecisionEvent('Died', {
+            MonsterId = self.Definition.Id,
+            DeathEvent = decision.DeathEvent,
+        })
+        self:destroy()
+        return
+    end
 
     if decision.TargetChanged then
         self:_emitDecisionLog('TargetChanged', {


### PR DESCRIPTION
## Summary

- Add `BaseEnemy` (metatable parent class) with shared methods: `setupHealth()`, `applyDamage()`, `heal()`, `getHealth()`
- Add `HealthComponent` that tracks `MaxHp`/`CurrentHp`, exposes `isDead()`, `applyDamage()`, `heal()`
- `Enemy` inherits `BaseEnemy` via `setmetatable`, calls `setupHealth()` in constructor, returns `IsDead` + `DeathEvent` from `update()`
- `MonsterService` calls `enemy:applyDamage()` on player melee hit and handles `decision.IsDead` in `_runLogicStep` to trigger `destroy()`
- `MonsterAuthorProfile`: accept `Health` as valid top-level section (alongside Semantics/Tuning/Executable)
- `MonsterCompiler`: propagate `Health` into `runtimeProfile`
- `MonsterComponentConfig`: build `Health` section from `Health.MaxHp` (falls back to `CombatHitPoints`)
- `Config/Monsters`: add `Health = { MaxHp = 3 }` to scrap-wisp

## Test plan

- [x] `selene .` + `stylua --check .` — 0 errors 0 warnings
- [ ] Playtest: 玩家攻击 scrap-wisp，验证 HP 扣减逻辑；HP=0 时怪物消失
- [ ] `scrap-wisp` 编译通过 `MonsterRuntimeProfile.validate()`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)