### PR TITLE
[codex] fix run startup flow and return markers

### DIFF
--- a/places/run/FEATURES.md
+++ b/places/run/FEATURES.md
@@ -75,7 +75,7 @@
 
 | 名称 | 状态 | 文件 | description |
 |------|------|------|-------------|
-| start-menu | active | RunClient.client.luau | "Enter the Temple"全屏菜单 |
+| startup-sync-banner | active | RunClient.client.luau | 非阻塞启动提示条；已移除 "Enter the Temple" 全屏入口页 |
 | camp-panel | active | RunClient.client.luau | C键切换，440x620状态面板 |
 | shop/sell/objective-modals | active | RunClient.client.luau | 三个Modal面板 |
 | ocean-overlay | active | RunClient.client.luau | Splash闪屏+Slowdown蓝色滤镜 |

--- a/places/run/STARTUP_ACCEPTANCE_AUDIT.md
+++ b/places/run/STARTUP_ACCEPTANCE_AUDIT.md
@@ -1,0 +1,41 @@
+# Run Startup Acceptance Audit
+
+> audited-on: 2026-04-16
+> live-instance: `roblox-experience-run` (`placeId=97218919641911`)
+> related-pr: [#265](https://github.com/Gazerrr03/roblox_experience/pull/265) `feat(run): remove Lobby place, add host-based in-ship start system`
+
+This audit keeps two baselines in view:
+
+- Baseline A: current repo feature contract in `places/run/FEATURES.md`
+- Baseline B: target startup UX for this fix series
+
+## Acceptance Matrix
+
+| Item | Current doc promise | Live instance / current code reality | Covered by PR #265 |
+|------|---------------------|--------------------------------------|--------------------|
+| `spawn-points` | Active; `Spawn/Return/MazeReturn` all available | Live MCP audit found `ReturnMarker` and `MazeReturnMarker` at `(0,0,0)`, which is a blocker against the documented contract. Source `default.project.json` also left both return markers at default origin before this fix. | No. PR #265 changes host startup flow, not return-marker authoring or validation. |
+| `start-menu` | Previously documented as active fullscreen `Enter the Temple` menu | Repo code previously still rendered the fullscreen page. This fix removes the blocking fullscreen entry page and replaces it with a small informational sync banner. | Partial only. PR #265 disables the launch click path, but it keeps the fullscreen menu shell and does not count as removing the page. |
+| `ship-doors` | Active ship-door interaction and gate opening | Runtime still exposes `GateSwitch` and ship-door prompts. No blocker found in this audit. | Yes, indirectly. PR #265 leans on world-prompt startup, which is compatible with ship-door driven flow. |
+| `run→maze-transition` | Active ReserveServer + TeleportAsync path | Code path remains intact in `RunToMazeTransition.luau`; no direct regression found in this audit. | No direct change. |
+| `maze-portal` | Active in-world prompt after gate open | Live instance still exposes `MazeGateMarker.Prompt`; no direct regression found in this audit. | No direct change. |
+
+## Target-Baseline Conclusions
+
+### Startup / spawn quality
+
+- Players should not visibly free-fall from an obviously wrong startup location before settling.
+- Players returning from maze must not land at default origin or any un-authored fallback shell.
+- `RunStaticWorldValidator` now treats all three markers as floor-backed spawn markers, and explicitly rejects `ReturnMarker` / `MazeReturnMarker` left at default origin.
+- Source authoring now places all three markers on the ship-deck cluster instead of leaving return markers at the Rojo default.
+
+### UI / flow quality
+
+- `Enter the Temple` is no longer accepted as a fullscreen startup page.
+- Startup may show read-only sync status, but that status must not masquerade as a clickable “enter” step.
+- PR #265 is still useful as a host-start direction, but it is not sufficient evidence that the fullscreen startup page was removed.
+
+## Immediate Follow-Ups Worth Tracking
+
+- Re-audit the live Studio place after Rojo/source sync to confirm the updated return-marker coordinates have propagated out of source.
+- If host-start from PR #265 lands, verify the world-prompt path remains the only startup entry and no fullscreen entry UI returns.
+- If players still report a visible first-frame drop after these marker and pivot fixes, inspect the ship deck collision shell versus authored marker height in Studio and tighten the spawn timing again.

--- a/places/run/STATIC_WORLD.md
+++ b/places/run/STATIC_WORLD.md
@@ -41,8 +41,9 @@ Rules:
 - `Collision/Ship`, when authored, must also contain invisible anchored collision shells.
 - Collision shell parts must use `Anchored=true`, `CanCollide=true`, `CanTouch=false`, `CanQuery=true`, and `Transparency=1`.
 - `Triggers/Ocean` must contain invisible anchored non-collidable trigger parts for water-entry feedback.
-- Missing required markers, prompts, or root attributes must fail loudly at runtime so content issues are fixed in Studio instead of hidden in code.
-- `SpawnMarker` must have a collidable authored floor within 32 studs below it.
+- Missing required markers, prompts, doors, or root attributes must fail loudly at runtime so content issues are fixed in Studio instead of hidden in code.
+- `SpawnMarker`, `ReturnMarker`, and `MazeReturnMarker` must each have a collidable authored floor within 32 studs below them.
+- `ReturnMarker` and `MazeReturnMarker` must not remain at the default origin `(0, 0, 0)` in source or Studio.
 - `MazeGateMarker` is the run-to-maze transition object. Scene code only identifies it; cross-place teleport is handled by the dedicated transition layer.
 - `GateSwitch` only advances gate-open state; the run place no longer depends on top-level `DoorLeft` / `DoorRight` parts for temple-door animation.
 - Flyship door interaction is provided by `ServerScriptService/Run/ShipDoors.luau`; do not keep a separate embedded `ShipDoors` Workspace script under the dropship model.

--- a/places/run/default.project.json
+++ b/places/run/default.project.json
@@ -36,7 +36,12 @@
             "Anchored": true,
             "CanCollide": false,
             "CanTouch": false,
-            "CanQuery": true
+            "CanQuery": true,
+            "Position": [
+              50.842907,
+              18.44950485,
+              300.177368
+            ]
           }
         },
         "ReturnMarker": {
@@ -45,7 +50,12 @@
             "Anchored": true,
             "CanCollide": false,
             "CanTouch": false,
-            "CanQuery": true
+            "CanQuery": true,
+            "Position": [
+              44.842907,
+              18.44950485,
+              300.177368
+            ]
           }
         },
         "MazeReturnMarker": {
@@ -54,7 +64,12 @@
             "Anchored": true,
             "CanCollide": false,
             "CanTouch": false,
-            "CanQuery": true
+            "CanQuery": true,
+            "Position": [
+              56.842907,
+              18.44950485,
+              300.177368
+            ]
           }
         },
         "Collision": {

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -113,22 +113,31 @@ end
 
 local function bindCharacterTeleport(self, player)
     player.CharacterAdded:Connect(function(character)
-        task.wait()
-        if not character.Parent then
-            return
-        end
+        task.defer(function()
+            local rootPart = character:FindFirstChild('HumanoidRootPart')
+                or character:WaitForChild('HumanoidRootPart', 5)
+            if rootPart == nil then
+                return
+            end
 
-        if not self.World then
-            return
-        end
+            if not character.Parent then
+                return
+            end
 
-        local pendingSpawnValue = self.PendingSpawnByUserId[player.UserId]
-        local targetCFrame = pendingSpawnValue
-                and resolvePendingSpawnCFrame(self, pendingSpawnValue)
-            or self.World.SpawnCFrame
-        self.PendingSpawnByUserId[player.UserId] = nil
-        character:PivotTo(targetCFrame)
-        self:_applyMovementMode(player)
+            if not self.World then
+                return
+            end
+
+            local pendingSpawnValue = self.PendingSpawnByUserId[player.UserId]
+            local targetCFrame = pendingSpawnValue
+                    and resolvePendingSpawnCFrame(self, pendingSpawnValue)
+                or self.World.SpawnCFrame
+            self.PendingSpawnByUserId[player.UserId] = nil
+            character:PivotTo(targetCFrame)
+            rootPart.AssemblyLinearVelocity = Vector3.zero
+            rootPart.AssemblyAngularVelocity = Vector3.zero
+            self:_applyMovementMode(player)
+        end)
     end)
 end
 

--- a/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
+++ b/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
@@ -268,14 +268,20 @@ local function buildSpawnGroundSampleOffsets(spawnMarker)
     }
 end
 
-local function assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, terrainMesh, spawnMarker)
+local function assertMarkerHasGround(
+    sceneCollisionRoot,
+    shipCollisionRoot,
+    terrainMesh,
+    markerName,
+    markerPart
+)
     local raycastParams = buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot, terrainMesh)
-    local sampleOffsets = buildSpawnGroundSampleOffsets(spawnMarker)
+    local sampleOffsets = buildSpawnGroundSampleOffsets(markerPart)
     local raycastDistance = Vector3.new(0, -RunStaticWorldContract.SpawnGroundCheckDepth, 0)
-    local raycastStartHeight = (spawnMarker.Size.Y * 0.5) + 2
+    local raycastStartHeight = (markerPart.Size.Y * 0.5) + 2
 
     for _, offset in ipairs(sampleOffsets) do
-        local origin = spawnMarker.Position + Vector3.new(offset.X, raycastStartHeight, offset.Z)
+        local origin = markerPart.Position + Vector3.new(offset.X, raycastStartHeight, offset.Z)
         local result = Workspace:Raycast(origin, raycastDistance, raycastParams)
         if result and result.Instance and result.Instance.CanCollide and result.Normal.Y > 0.5 then
             return
@@ -284,11 +290,25 @@ local function assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, terra
 
     error(
         string.format(
-            'RunStaticWorld SpawnMarker must raycast onto Collision/Scene, optional Collision/Ship, or terrain mesh within %d studs below it.',
+            'RunStaticWorld marker "%s" must raycast onto Collision/Scene, Collision/Ship, or terrain mesh within %d studs below it.',
+            markerName,
             RunStaticWorldContract.SpawnGroundCheckDepth
         ),
         0
     )
+end
+
+local function assertMarkerNotAtOrigin(markerName, markerPart)
+    local position = markerPart.Position
+    if position:FuzzyEq(Vector3.zero) then
+        error(
+            string.format(
+                'RunStaticWorld marker "%s" must not stay at the default origin (0, 0, 0). Author a real return point in Studio/source.',
+                markerName
+            ),
+            0
+        )
+    end
 end
 
 function RunStaticWorldValidator.validate(root)
@@ -337,7 +357,7 @@ function RunStaticWorldValidator.validate(root)
         'RunStaticWorld Triggers/Ocean'
     )
 
-    local spawnMarker = nil
+    local markersByName = {}
     for _, markerName in ipairs(REQUIRED_MARKER_NAMES) do
         local markerPart = root:FindFirstChild(markerName, true)
         if markerPart == nil or not markerPart:IsA('BasePart') then
@@ -345,10 +365,7 @@ function RunStaticWorldValidator.validate(root)
         end
 
         validateMarkerPart(markerPart, string.format('RunStaticWorld marker "%s"', markerName))
-
-        if markerName == 'SpawnMarker' then
-            spawnMarker = markerPart
-        end
+        markersByName[markerName] = markerPart
     end
 
     -- Find terrain mesh: RunTerrain_Main.Scene.RunTerrain_OriginalHigh.RunTerrain_OriginalHighMesh
@@ -364,7 +381,18 @@ function RunStaticWorldValidator.validate(root)
         end
     end
 
-    assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, terrainMesh, spawnMarker)
+    for markerName, markerPart in pairs(markersByName) do
+        if markerName ~= 'SpawnMarker' then
+            assertMarkerNotAtOrigin(markerName, markerPart)
+        end
+        assertMarkerHasGround(
+            sceneCollisionRoot,
+            shipCollisionRoot,
+            terrainMesh,
+            markerName,
+            markerPart
+        )
+    end
 end
 
 return RunStaticWorldValidator

--- a/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
+++ b/places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau
@@ -382,9 +382,7 @@ function RunStaticWorldValidator.validate(root)
     end
 
     for markerName, markerPart in pairs(markersByName) do
-        if markerName ~= 'SpawnMarker' then
-            assertMarkerNotAtOrigin(markerName, markerPart)
-        end
+        assertMarkerNotAtOrigin(markerName, markerPart)
         assertMarkerHasGround(
             sceneCollisionRoot,
             shipCollisionRoot,

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -336,7 +336,7 @@ local menuBackdrop = Instance.new('Frame')
 menuBackdrop.Name = 'StartupBanner'
 menuBackdrop.AnchorPoint = Vector2.new(0.5, 0)
 menuBackdrop.Position = UDim2.fromScale(0.5, 0.03)
-menuBackdrop.Size = UDim2.new(0.92, 0, 0, 140)
+menuBackdrop.Size = UDim2.new(0.92, 0, 0, 180)
 menuBackdrop.BackgroundColor3 = Theme.Surface
 menuBackdrop.BorderSizePixel = 0
 menuBackdrop.Visible = false
@@ -366,7 +366,7 @@ menuBody.Text =
     'Startup is now informational only. You will spawn directly onto the ship deck once the run session is ready.'
 
 local menuStatusLabel =
-    makeTextLabel(menuBackdrop, UDim2.new(1, 0, 0, 44), Theme.SubtleText, 15, false)
+    makeTextLabel(menuBackdrop, UDim2.new(1, 0, 0, 80), Theme.SubtleText, 15, false)
 menuStatusLabel.Text = string.format('Preparing %s session...', TEMPLE_LABEL)
 
 local panel = Instance.new('Frame')

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -333,113 +333,41 @@ end
 updateWatchHud()
 
 local menuBackdrop = Instance.new('Frame')
-menuBackdrop.Name = 'StartMenu'
-menuBackdrop.Size = UDim2.fromScale(1, 1)
-menuBackdrop.BackgroundColor3 = Theme.Background
+menuBackdrop.Name = 'StartupBanner'
+menuBackdrop.AnchorPoint = Vector2.new(0.5, 0)
+menuBackdrop.Position = UDim2.fromScale(0.5, 0.03)
+menuBackdrop.Size = UDim2.new(0.92, 0, 0, 140)
+menuBackdrop.BackgroundColor3 = Theme.Surface
+menuBackdrop.BorderSizePixel = 0
+menuBackdrop.Visible = false
 menuBackdrop.Parent = screenGui
 
-local menuBackdropGradient = Instance.new('UIGradient')
-menuBackdropGradient.Rotation = 120
-menuBackdropGradient.Color = ColorSequence.new({
-    ColorSequenceKeypoint.new(0, Theme.Background:Lerp(Color3.new(1, 1, 1), 0.02)),
-    ColorSequenceKeypoint.new(1, Theme.Background:Lerp(Color3.new(0, 0, 0), 0.12)),
-})
-menuBackdropGradient.Parent = menuBackdrop
-
-local menuPanel = Instance.new('Frame')
-menuPanel.Name = 'Panel'
-menuPanel.AnchorPoint = Vector2.new(0.5, 0.5)
-menuPanel.Position = UDim2.fromScale(0.5, 0.5)
-menuPanel.Size = UDim2.fromOffset(520, 360)
-menuPanel.BackgroundColor3 = Theme.Surface
-menuPanel.BorderSizePixel = 0
-menuPanel.Parent = menuBackdrop
-
-applyPanelStyle(menuPanel, 18, 0.8)
+applyPanelStyle(menuBackdrop, 16, 0.82)
 
 local menuPadding = Instance.new('UIPadding')
-menuPadding.PaddingTop = UDim.new(0, 28)
-menuPadding.PaddingLeft = UDim.new(0, 28)
-menuPadding.PaddingRight = UDim.new(0, 28)
-menuPadding.PaddingBottom = UDim.new(0, 28)
-menuPadding.Parent = menuPanel
+menuPadding.PaddingTop = UDim.new(0, 18)
+menuPadding.PaddingLeft = UDim.new(0, 20)
+menuPadding.PaddingRight = UDim.new(0, 20)
+menuPadding.PaddingBottom = UDim.new(0, 18)
+menuPadding.Parent = menuBackdrop
 
 local menuList = Instance.new('UIListLayout')
-menuList.Padding = UDim.new(0, 14)
-menuList.Parent = menuPanel
+menuList.Padding = UDim.new(0, 8)
+menuList.Parent = menuBackdrop
 
-local eyebrow = makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 20), Theme.Accent, 16, true)
-eyebrow.Text = 'TEMPLE DIRECT ENTRY'
+local eyebrow = makeTextLabel(menuBackdrop, UDim2.new(1, 0, 0, 18), Theme.Accent, 15, true)
+eyebrow.Text = 'RUN SYNC'
 
-local menuTitle = makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 72), Theme.Text, 34, true)
-menuTitle.Text = string.format('Enter the %s', TEMPLE_LABEL)
+local menuTitle = makeTextLabel(menuBackdrop, UDim2.new(1, 0, 0, 28), Theme.Text, 24, true)
+menuTitle.Text = 'Camp session syncing'
 
-local menuBody = makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 78), Theme.SubtleText, 18, false)
+local menuBody = makeTextLabel(menuBackdrop, UDim2.new(1, 0, 0, 30), Theme.SubtleText, 15, false)
 menuBody.Text =
-    'Run now boots directly into the temple flow. Hold while the camp session syncs, then regroup inside before opening the gate to the wilderness and the shared maze.'
-
-local singlePlayerButton = Instance.new('TextButton')
-singlePlayerButton.Size = UDim2.new(1, 0, 0, 52)
-singlePlayerButton.BackgroundColor3 = Theme.Accent
-singlePlayerButton.TextColor3 = Theme.Background
-singlePlayerButton.Font = Enum.Font.GothamBold
-singlePlayerButton.TextSize = 20
-singlePlayerButton.Text = string.format('Syncing %s...', TEMPLE_LABEL)
-singlePlayerButton.Parent = menuPanel
-singlePlayerButton.Active = false
-singlePlayerButton.AutoButtonColor = false
-
-local singlePlayerCorner = Instance.new('UICorner')
-singlePlayerCorner.CornerRadius = UDim.new(0, 12)
-singlePlayerCorner.Parent = singlePlayerButton
-
-local singlePlayerStroke = Instance.new('UIStroke')
-singlePlayerStroke.Color = Theme.Background
-singlePlayerStroke.Transparency = 0.55
-singlePlayerStroke.Thickness = 1
-singlePlayerStroke.Parent = singlePlayerButton
-
-local singlePlayerGradient = Instance.new('UIGradient')
-singlePlayerGradient.Rotation = 90
-singlePlayerGradient.Color = ColorSequence.new({
-    ColorSequenceKeypoint.new(0, Theme.Accent:Lerp(Color3.new(1, 1, 1), 0.1)),
-    ColorSequenceKeypoint.new(1, Theme.Accent:Lerp(Color3.new(0, 0, 0), 0.12)),
-})
-singlePlayerGradient.Parent = singlePlayerButton
+    'Startup is now informational only. You will spawn directly onto the ship deck once the run session is ready.'
 
 local menuStatusLabel =
-    makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 52), Theme.SubtleText, 16, false)
-menuStatusLabel.Text = string.format('Preparing %s access...', TEMPLE_LABEL)
-
-local placeholders = Instance.new('Frame')
-placeholders.Size = UDim2.new(1, 0, 0, 78)
-placeholders.BackgroundTransparency = 1
-placeholders.Parent = menuPanel
-
-local placeholderList = Instance.new('UIListLayout')
-placeholderList.Padding = UDim.new(0, 10)
-placeholderList.FillDirection = Enum.FillDirection.Horizontal
-placeholderList.Parent = placeholders
-
-local function makePlaceholder(text)
-    local button = Instance.new('TextButton')
-    button.Size = UDim2.new(0.5, -5, 1, 0)
-    button.BackgroundColor3 = Theme.Background
-    button.TextColor3 = Theme.SubtleText
-    button.Font = Theme.Font
-    button.TextSize = 16
-    button.Text = text
-    button.AutoButtonColor = false
-    button.Active = false
-    button.Parent = placeholders
-
-    local corner = Instance.new('UICorner')
-    corner.CornerRadius = UDim.new(0, 12)
-    corner.Parent = button
-end
-
-makePlaceholder('Temple Shop (Soon)')
-makePlaceholder('Shared Maze Gate')
+    makeTextLabel(menuBackdrop, UDim2.new(1, 0, 0, 44), Theme.SubtleText, 15, false)
+menuStatusLabel.Text = string.format('Preparing %s session...', TEMPLE_LABEL)
 
 local panel = Instance.new('Frame')
 panel.Name = 'CampPanel'
@@ -1236,9 +1164,6 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
             buildWaitingHostText(snapshot),
             buildMazeEntryText(snapshot)
         )
-        singlePlayerButton.Active = false
-        singlePlayerButton.AutoButtonColor = false
-        singlePlayerButton.Text = string.format('Syncing %s...', TEMPLE_LABEL)
         inventoryLabel.Text = 'Inventory: --'
         inventoryDetailLabel.Text = ''
         playerStateLabel.Text = 'Health: --\nStamina: --\nState: --\nMovement: --'

--- a/tests/src/Shared/RunScene.spec.luau
+++ b/tests/src/Shared/RunScene.spec.luau
@@ -19,6 +19,10 @@ return function()
     sceneCollisionRoot.Name = 'Scene'
     sceneCollisionRoot.Parent = collisionRoot
 
+    local shipCollisionRoot = Instance.new('Folder')
+    shipCollisionRoot.Name = 'Ship'
+    shipCollisionRoot.Parent = collisionRoot
+
     local triggersRoot = Instance.new('Folder')
     triggersRoot.Name = 'Triggers'
     triggersRoot.Parent = root
@@ -58,14 +62,14 @@ return function()
     returnMarker.CFrame = CFrame.new(0, 4, 8)
     returnMarker.Parent = root
 
-    local mazeReturnMarker = Instance.new('Part')
-    mazeReturnMarker.Name = 'MazeReturnMarker'
-    mazeReturnMarker.Anchored = true
-    mazeReturnMarker.CanCollide = false
-    mazeReturnMarker.CanTouch = false
-    mazeReturnMarker.CanQuery = true
-    mazeReturnMarker.CFrame = CFrame.new(0, 4, 64)
-    mazeReturnMarker.Parent = root
+    local mazeReturnPart = Instance.new('Part')
+    mazeReturnPart.Name = 'MazeReturnMarker'
+    mazeReturnPart.Anchored = true
+    mazeReturnPart.CanCollide = false
+    mazeReturnPart.CanTouch = false
+    mazeReturnPart.CanQuery = true
+    mazeReturnPart.CFrame = CFrame.new(0, 4, 64)
+    mazeReturnPart.Parent = root
 
     local sceneFloor = Instance.new('Part')
     sceneFloor.Name = 'SceneFloor'
@@ -75,6 +79,28 @@ return function()
     sceneFloor.CanQuery = true
     sceneFloor.Transparency = 1
     sceneFloor.Parent = sceneCollisionRoot
+
+    local shipDeck = Instance.new('Part')
+    shipDeck.Name = 'ShipDeck'
+    shipDeck.Anchored = true
+    shipDeck.CanCollide = true
+    shipDeck.CanTouch = false
+    shipDeck.CanQuery = true
+    shipDeck.Transparency = 1
+    shipDeck.CFrame = CFrame.new(0, 0, 0)
+    shipDeck.Size = Vector3.new(24, 1, 24)
+    shipDeck.Parent = shipCollisionRoot
+
+    local mazeReturnFloor = Instance.new('Part')
+    mazeReturnFloor.Name = 'MazeReturnFloor'
+    mazeReturnFloor.Anchored = true
+    mazeReturnFloor.CanCollide = true
+    mazeReturnFloor.CanTouch = false
+    mazeReturnFloor.CanQuery = true
+    mazeReturnFloor.Transparency = 1
+    mazeReturnFloor.CFrame = CFrame.new(mazeReturnPart.Position.X, 0, mazeReturnPart.Position.Z)
+    mazeReturnFloor.Size = Vector3.new(24, 1, 24)
+    mazeReturnFloor.Parent = sceneCollisionRoot
 
     local oceanTrigger = Instance.new('Part')
     oceanTrigger.Name = 'OceanSurface'
@@ -104,8 +130,8 @@ return function()
         'RunScene should also ground return markers when collision exists beneath them'
     )
     assert(
-        scene:getSpawnCFrame(RunSpawnPoint.Kind.MazeReturn) == mazeReturnMarker.CFrame,
-        'RunScene should fall back to the authored marker when no collision shell exists beneath it'
+        math.abs(scene:getSpawnCFrame(RunSpawnPoint.Kind.MazeReturn).Position.Y - 4.5) < 0.001,
+        'RunScene should also ground maze return markers when collision exists beneath them'
     )
     assert(
         scene:getAreaForPosition(Vector3.new(0, 0, 80)) == 'Wilderness',

--- a/tests/src/Shared/RunWorldBuilderStaticWorld.spec.luau
+++ b/tests/src/Shared/RunWorldBuilderStaticWorld.spec.luau
@@ -115,8 +115,9 @@ return function()
     local validWorld = createRunStaticWorldRoot(88)
     createMarker(validWorld.Root, 'SpawnMarker', CFrame.new(10, 4, -3))
     createMarker(validWorld.Root, 'ReturnMarker', CFrame.new(11, 4, -1))
-    local mazeReturnMarker =
-        createMarker(validWorld.Root, 'MazeReturnMarker', CFrame.new(3, 4, 120))
+    createMarker(validWorld.Root, 'MazeReturnMarker', CFrame.new(3, 4, 120))
+    local _doorLeft = createMarker(validWorld.Root, 'DoorLeft', CFrame.new(8, 4, 16))
+    local _doorRight = createMarker(validWorld.Root, 'DoorRight', CFrame.new(12, 4, 16))
     local validPrompts = createRequiredPromptParts(validWorld.Root, 10, 20)
     local _, startGamePrompt =
         createPromptPart(validWorld.Root, 'StartGamePrompt', CFrame.new(14, 4, 12))
@@ -151,6 +152,18 @@ return function()
         CFrame.new(10, 0, -3),
         Vector3.new(24, 1, 24)
     )
+    createCollisionPart(
+        validWorld.SceneCollisionRoot,
+        'MazeReturnFloor',
+        CFrame.new(3, 0, 120),
+        Vector3.new(24, 1, 24)
+    )
+    createCollisionPart(
+        validWorld.ShipCollisionRoot,
+        'ShipDeck',
+        CFrame.new(24, 6, 12),
+        Vector3.new(16, 1, 16)
+    )
     createOceanTrigger(validWorld.OceanTriggerRoot, 'OceanSurface', CFrame.new(10, -8, -3))
 
     local world = builder.build()
@@ -167,8 +180,9 @@ return function()
         'Run static world should also lift grounded return markers above collision shells'
     )
     assert(
-        world.MazeReturnCFrame == mazeReturnMarker.CFrame,
-        'Run static world should expose the authored maze return marker'
+        math.abs(world.MazeReturnCFrame.Position.Y - (0.5 + RunStaticWorldContract.SpawnLiftStuds))
+            < 0.001,
+        'Run static world should ground maze return markers above authored collision shells'
     )
     assert(
         world.OutdoorThresholdZ == 88,
@@ -272,7 +286,8 @@ return function()
         'Run static world should fail loudly when SpawnMarker has no authored floor below it'
     )
     assert(
-        string.find(tostring(missingFloorErr), 'SpawnMarker must raycast onto', 1, true) ~= nil,
+        string.find(tostring(missingFloorErr), 'marker "SpawnMarker" must raycast onto', 1, true)
+            ~= nil,
         'Missing spawn floor failures should mention the authored collision floor requirement'
     )
 
@@ -307,7 +322,8 @@ return function()
         'Run static world should reject ordinary root-level collidable parts as spawn floors'
     )
     assert(
-        string.find(tostring(strayColliderErr), 'SpawnMarker must raycast onto', 1, true) ~= nil,
+        string.find(tostring(strayColliderErr), 'marker "SpawnMarker" must raycast onto', 1, true)
+            ~= nil,
         'Ordinary root-level blockers should not satisfy the authored collision floor requirement'
     )
 
@@ -334,7 +350,7 @@ return function()
         'Run static world should reject a spawn floor that only supports the center point'
     )
     assert(
-        string.find(tostring(edgeGapErr), 'SpawnMarker must raycast onto', 1, true) ~= nil,
+        string.find(tostring(edgeGapErr), 'marker "SpawnMarker" must raycast onto', 1, true) ~= nil,
         'Edge-gap failures should mention the authored collision floor requirement'
     )
 
@@ -370,4 +386,90 @@ return function()
     )
 
     collidableMarkerWorld.Root:Destroy()
+
+    local originReturnWorld = createRunStaticWorldRoot(72)
+    createMarker(originReturnWorld.Root, 'SpawnMarker', CFrame.new(0, 8, 0))
+    createMarker(originReturnWorld.Root, 'ReturnMarker', CFrame.new(0, 0, 0))
+    createMarker(originReturnWorld.Root, 'MazeReturnMarker', CFrame.new(8, 8, 0))
+    createMarker(originReturnWorld.Root, 'DoorLeft', CFrame.new(0, 2, 10))
+    createMarker(originReturnWorld.Root, 'DoorRight', CFrame.new(4, 2, 10))
+    createRequiredPromptParts(originReturnWorld.Root, 40, 10)
+    createCollisionPart(
+        originReturnWorld.SceneCollisionRoot,
+        'SceneFloor',
+        CFrame.new(0, 2, 0),
+        Vector3.new(24, 1, 24)
+    )
+    createCollisionPart(
+        originReturnWorld.SceneCollisionRoot,
+        'MazeReturnFloor',
+        CFrame.new(8, 2, 0),
+        Vector3.new(24, 1, 24)
+    )
+    createCollisionPart(
+        originReturnWorld.ShipCollisionRoot,
+        'ShipDeck',
+        CFrame.new(30, 2, 30),
+        Vector3.new(16, 1, 16)
+    )
+    createOceanTrigger(originReturnWorld.OceanTriggerRoot)
+
+    local originReturnOk, originReturnErr = pcall(function()
+        builder.build()
+    end)
+    assert(
+        originReturnOk == false,
+        'Run static world should reject ReturnMarker left at the default origin'
+    )
+    assert(
+        string.find(
+            tostring(originReturnErr),
+            'marker "ReturnMarker" must not stay at the default origin',
+            1,
+            true
+        ) ~= nil,
+        'Return-marker origin failures should point back to source authoring'
+    )
+
+    originReturnWorld.Root:Destroy()
+
+    local unsupportedMazeReturnWorld = createRunStaticWorldRoot(76)
+    createMarker(unsupportedMazeReturnWorld.Root, 'SpawnMarker', CFrame.new(0, 8, 0))
+    createMarker(unsupportedMazeReturnWorld.Root, 'ReturnMarker', CFrame.new(4, 8, 0))
+    createMarker(unsupportedMazeReturnWorld.Root, 'MazeReturnMarker', CFrame.new(8, 8, 48))
+    createMarker(unsupportedMazeReturnWorld.Root, 'DoorLeft', CFrame.new(0, 2, 10))
+    createMarker(unsupportedMazeReturnWorld.Root, 'DoorRight', CFrame.new(4, 2, 10))
+    createRequiredPromptParts(unsupportedMazeReturnWorld.Root, 40, 10)
+    createCollisionPart(
+        unsupportedMazeReturnWorld.SceneCollisionRoot,
+        'SceneFloor',
+        CFrame.new(0, 2, 0),
+        Vector3.new(24, 1, 24)
+    )
+    createCollisionPart(
+        unsupportedMazeReturnWorld.ShipCollisionRoot,
+        'ShipDeck',
+        CFrame.new(30, 2, 30),
+        Vector3.new(16, 1, 16)
+    )
+    createOceanTrigger(unsupportedMazeReturnWorld.OceanTriggerRoot)
+
+    local unsupportedMazeReturnOk, unsupportedMazeReturnErr = pcall(function()
+        builder.build()
+    end)
+    assert(
+        unsupportedMazeReturnOk == false,
+        'Run static world should reject MazeReturnMarker when no authored floor exists beneath it'
+    )
+    assert(
+        string.find(
+            tostring(unsupportedMazeReturnErr),
+            'marker "MazeReturnMarker" must raycast onto',
+            1,
+            true
+        ) ~= nil,
+        'Maze-return floor failures should mention the authored collision floor requirement'
+    )
+
+    unsupportedMazeReturnWorld.Root:Destroy()
 end


### PR DESCRIPTION
## What changed

- remove the fullscreen `Enter the Temple` startup page and replace it with a small read-only sync banner
- tighten run spawn handling so characters are pivoted onto the authored spawn point earlier and have residual velocity cleared
- validate `ReturnMarker` and `MazeReturnMarker` the same way as `SpawnMarker`, including rejecting default-origin return markers
- update run source authoring and tests so return markers are backed by real authored positions and collision floors
- add a startup acceptance audit doc that compares the live run instance, current feature contract, and PR #265 coverage

## Why

Players were seeing two startup regressions:

1. the run flow still showed a misleading fullscreen `Enter the Temple` page even though the desired UX is direct spawn + passive sync status
2. return markers could remain at `(0,0,0)`, which makes startup and maze-return behavior brittle and can lead to visibly wrong landings

This patch makes those failures explicit in validation/tests and aligns the startup UX with the target flow.

## Impact

- players no longer get a fake entry screen before startup completes
- run static world authoring now fails fast when return markers are left at default origin or unsupported by collision
- the repo includes a documented acceptance matrix for the startup flow and a written conclusion that PR #265 is host-start related, but not a full startup-screen removal

## Validation

- `stylua places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau places/run/src/ServerScriptService/Run/RunSessionService.luau places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau tests/src/Shared/RunScene.spec.luau tests/src/Shared/RunWorldBuilderStaticWorld.spec.luau`
- `selene places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau places/run/src/ServerScriptService/Run/RunSessionService.luau places/run/src/ServerScriptService/Run/RunStaticWorldValidator.luau tests/src/Shared/RunScene.spec.luau tests/src/Shared/RunWorldBuilderStaticWorld.spec.luau`
- `rojo build places/run/default.project.json -o /tmp/run-startup-pr.rbxlx`
- `rojo build tests/default.project.json -o /tmp/roblox_experience-tests-startup-pr.rbxlx`
- `run-in-roblox --place /tmp/roblox_experience-tests-startup-pr.rbxlx --script tests/run-in-roblox.lua`
