### PR TITLE
Populate ReplicatedStorage ToolTemplates for HeldToolVisual (issue #234)

### DIFF
--- a/assets/ToolTemplates/ToolCrowbar.rbxmx
+++ b/assets/ToolTemplates/ToolCrowbar.rbxmx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
+  <Meta name="ExplicitAutoJoints">true</Meta>
+  <External>null</External>
+  <External>nil</External>
+  <Item class="Model" referent="RBXToolCrowbarRoot">
+    <Properties>
+      <string name="Name">ToolCrowbar</string>
+    </Properties>
+    <Item class="Part" referent="RBXToolCrowbarHandle">
+      <Properties>
+        <string name="Name">Handle</string>
+        <bool name="Anchored">true</bool>
+        <bool name="CanCollide">false</bool>
+        <Vector3 name="Size">
+          <X>0.15</X>
+          <Y>0.55</Y>
+          <Z>0.12</Z>
+        </Vector3>
+        <CoordinateFrame name="CFrame">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <Color3 name="Color">
+          <R>0.7843137383460999</R>
+          <G>0.7843137383460999</G>
+          <B>0.7843137383460999</B>
+        </Color3>
+      </Properties>
+    </Item>
+  </Item>
+</roblox>

--- a/assets/ToolTemplates/ToolFlashlight.rbxmx
+++ b/assets/ToolTemplates/ToolFlashlight.rbxmx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
+  <Meta name="ExplicitAutoJoints">true</Meta>
+  <External>null</External>
+  <External>nil</External>
+  <Item class="Model" referent="RBXToolFlashlightRoot">
+    <Properties>
+      <string name="Name">ToolFlashlight</string>
+    </Properties>
+    <Item class="Part" referent="RBXToolFlashlightHandle">
+      <Properties>
+        <string name="Name">Handle</string>
+        <bool name="Anchored">true</bool>
+        <bool name="CanCollide">false</bool>
+        <Vector3 name="Size">
+          <X>0.2</X>
+          <Y>0.35</Y>
+          <Z>0.2</Z>
+        </Vector3>
+        <CoordinateFrame name="CFrame">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <Color3 name="Color">
+          <R>0.5803921818733215</R>
+          <G>0.6392157077789307</G>
+          <B>0.7215686440467834</B>
+        </Color3>
+      </Properties>
+    </Item>
+  </Item>
+</roblox>

--- a/assets/ToolTemplates/ToolPotion.rbxmx
+++ b/assets/ToolTemplates/ToolPotion.rbxmx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
+  <Meta name="ExplicitAutoJoints">true</Meta>
+  <External>null</External>
+  <External>nil</External>
+  <Item class="Model" referent="RBXToolPotionRoot">
+    <Properties>
+      <string name="Name">ToolPotion</string>
+    </Properties>
+    <Item class="Part" referent="RBXToolPotionHandle">
+      <Properties>
+        <string name="Name">Handle</string>
+        <bool name="Anchored">true</bool>
+        <bool name="CanCollide">false</bool>
+        <Vector3 name="Size">
+          <X>0.25</X>
+          <Y>0.45</Y>
+          <Z>0.25</Z>
+        </Vector3>
+        <CoordinateFrame name="CFrame">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <Color3 name="Color">
+          <R>0.9254902005195618</R>
+          <G>0.2823529541492462</G>
+          <B>0.6000000238418579</B>
+        </Color3>
+      </Properties>
+    </Item>
+  </Item>
+</roblox>

--- a/packages/shared/src/Client/HeldToolVisual.luau
+++ b/packages/shared/src/Client/HeldToolVisual.luau
@@ -7,6 +7,7 @@ local ItemPresentation = Gameplay.Config.ItemPresentation
 local CLONE_NAME = 'HeldToolVisualClone'
 
 local HeldToolVisual = {}
+HeldToolVisual.CLONE_NAME = CLONE_NAME
 
 local function getHandPart(character: Model): BasePart?
     local hand = character:FindFirstChild('RightHand') or character:FindFirstChild('Right Arm')

--- a/packages/shared/src/Client/init.luau
+++ b/packages/shared/src/Client/init.luau
@@ -1,4 +1,5 @@
 return {
     FirstPersonController = require(script.FirstPersonController),
     HeldItemController = require(script.HeldItemController),
+    HeldToolVisual = require(script.HeldToolVisual),
 }

--- a/places/maze/default.project.json
+++ b/places/maze/default.project.json
@@ -19,7 +19,16 @@
       "Assets": {
         "$className": "Folder",
         "ToolTemplates": {
-          "$className": "Folder"
+          "$className": "Folder",
+          "ToolFlashlight": {
+            "$path": "../../assets/ToolTemplates/ToolFlashlight.rbxmx"
+          },
+          "ToolCrowbar": {
+            "$path": "../../assets/ToolTemplates/ToolCrowbar.rbxmx"
+          },
+          "ToolPotion": {
+            "$path": "../../assets/ToolTemplates/ToolPotion.rbxmx"
+          }
         }
       }
     },

--- a/places/run/default.project.json
+++ b/places/run/default.project.json
@@ -19,7 +19,16 @@
       "Assets": {
         "$className": "Folder",
         "ToolTemplates": {
-          "$className": "Folder"
+          "$className": "Folder",
+          "ToolFlashlight": {
+            "$path": "../../assets/ToolTemplates/ToolFlashlight.rbxmx"
+          },
+          "ToolCrowbar": {
+            "$path": "../../assets/ToolTemplates/ToolCrowbar.rbxmx"
+          },
+          "ToolPotion": {
+            "$path": "../../assets/ToolTemplates/ToolPotion.rbxmx"
+          }
         }
       }
     },

--- a/places/run/harness/run.rbxlx
+++ b/places/run/harness/run.rbxlx
@@ -11,6 +11,114 @@
         <Properties>
           <string name="Name">ToolTemplates</string>
         </Properties>
+        <Item class="Model" referent="RBXHarnessToolFlashlight">
+          <Properties>
+            <string name="Name">ToolFlashlight</string>
+          </Properties>
+          <Item class="Part" referent="RBXHarnessToolFlashlightHandle">
+            <Properties>
+              <string name="Name">Handle</string>
+              <bool name="Anchored">true</bool>
+              <bool name="CanCollide">false</bool>
+              <Vector3 name="Size">
+                <X>0.2</X>
+                <Y>0.35</Y>
+                <Z>0.2</Z>
+              </Vector3>
+              <CoordinateFrame name="CFrame">
+                <X>0</X>
+                <Y>0</Y>
+                <Z>0</Z>
+                <R00>1</R00>
+                <R01>0</R01>
+                <R02>0</R02>
+                <R10>0</R10>
+                <R11>1</R11>
+                <R12>0</R12>
+                <R20>0</R20>
+                <R21>0</R21>
+                <R22>1</R22>
+              </CoordinateFrame>
+              <Color3 name="Color">
+                <R>0.5803921818733215</R>
+                <G>0.6392157077789307</G>
+                <B>0.7215686440467834</B>
+              </Color3>
+            </Properties>
+          </Item>
+        </Item>
+        <Item class="Model" referent="RBXHarnessToolCrowbar">
+          <Properties>
+            <string name="Name">ToolCrowbar</string>
+          </Properties>
+          <Item class="Part" referent="RBXHarnessToolCrowbarHandle">
+            <Properties>
+              <string name="Name">Handle</string>
+              <bool name="Anchored">true</bool>
+              <bool name="CanCollide">false</bool>
+              <Vector3 name="Size">
+                <X>0.15</X>
+                <Y>0.55</Y>
+                <Z>0.12</Z>
+              </Vector3>
+              <CoordinateFrame name="CFrame">
+                <X>0</X>
+                <Y>0</Y>
+                <Z>0</Z>
+                <R00>1</R00>
+                <R01>0</R01>
+                <R02>0</R02>
+                <R10>0</R10>
+                <R11>1</R11>
+                <R12>0</R12>
+                <R20>0</R20>
+                <R21>0</R21>
+                <R22>1</R22>
+              </CoordinateFrame>
+              <Color3 name="Color">
+                <R>0.7843137383460999</R>
+                <G>0.7843137383460999</G>
+                <B>0.7843137383460999</B>
+              </Color3>
+            </Properties>
+          </Item>
+        </Item>
+        <Item class="Model" referent="RBXHarnessToolPotion">
+          <Properties>
+            <string name="Name">ToolPotion</string>
+          </Properties>
+          <Item class="Part" referent="RBXHarnessToolPotionHandle">
+            <Properties>
+              <string name="Name">Handle</string>
+              <bool name="Anchored">true</bool>
+              <bool name="CanCollide">false</bool>
+              <Vector3 name="Size">
+                <X>0.25</X>
+                <Y>0.45</Y>
+                <Z>0.25</Z>
+              </Vector3>
+              <CoordinateFrame name="CFrame">
+                <X>0</X>
+                <Y>0</Y>
+                <Z>0</Z>
+                <R00>1</R00>
+                <R01>0</R01>
+                <R02>0</R02>
+                <R10>0</R10>
+                <R11>1</R11>
+                <R12>0</R12>
+                <R20>0</R20>
+                <R21>0</R21>
+                <R22>1</R22>
+              </CoordinateFrame>
+              <Color3 name="Color">
+                <R>0.9254902005195618</R>
+                <G>0.2823529541492462</G>
+                <B>0.6000000238418579</B>
+              </Color3>
+            </Properties>
+          </Item>
+        </Item>
       </Item>
     </Item>
     <Item class="Folder" referent="3">
@@ -6532,6 +6640,7 @@ return SessionStateMachine
             <string name="Source"><![CDATA[return {
     FirstPersonController = require(script.FirstPersonController),
     HeldItemController = require(script.HeldItemController),
+    HeldToolVisual = require(script.HeldToolVisual),
 }
 ]]></string>
           </Properties>

--- a/places/run/harness/run.rbxlx
+++ b/places/run/harness/run.rbxlx
@@ -11,20 +11,15 @@
         <Properties>
           <string name="Name">ToolTemplates</string>
         </Properties>
-        <Item class="Model" referent="RBXHarnessToolFlashlight">
+        <Item class="Model" referent="3">
           <Properties>
-            <string name="Name">ToolFlashlight</string>
+            <string name="Name">ToolCrowbar</string>
+            <bool name="NeedsPivotMigration">false</bool>
           </Properties>
-          <Item class="Part" referent="RBXHarnessToolFlashlightHandle">
+          <Item class="Part" referent="4">
             <Properties>
               <string name="Name">Handle</string>
               <bool name="Anchored">true</bool>
-              <bool name="CanCollide">false</bool>
-              <Vector3 name="Size">
-                <X>0.2</X>
-                <Y>0.35</Y>
-                <Z>0.2</Z>
-              </Vector3>
               <CoordinateFrame name="CFrame">
                 <X>0</X>
                 <Y>0</Y>
@@ -39,28 +34,25 @@
                 <R21>0</R21>
                 <R22>1</R22>
               </CoordinateFrame>
-              <Color3 name="Color">
-                <R>0.5803921818733215</R>
-                <G>0.6392157077789307</G>
-                <B>0.7215686440467834</B>
-              </Color3>
-            </Properties>
-          </Item>
-        </Item>
-        <Item class="Model" referent="RBXHarnessToolCrowbar">
-          <Properties>
-            <string name="Name">ToolCrowbar</string>
-          </Properties>
-          <Item class="Part" referent="RBXHarnessToolCrowbarHandle">
-            <Properties>
-              <string name="Name">Handle</string>
-              <bool name="Anchored">true</bool>
               <bool name="CanCollide">false</bool>
-              <Vector3 name="Size">
+              <Color3uint8 name="Color3uint8">13158600</Color3uint8>
+              <Vector3 name="size">
                 <X>0.15</X>
                 <Y>0.55</Y>
                 <Z>0.12</Z>
               </Vector3>
+            </Properties>
+          </Item>
+        </Item>
+        <Item class="Model" referent="5">
+          <Properties>
+            <string name="Name">ToolFlashlight</string>
+            <bool name="NeedsPivotMigration">false</bool>
+          </Properties>
+          <Item class="Part" referent="6">
+            <Properties>
+              <string name="Name">Handle</string>
+              <bool name="Anchored">true</bool>
               <CoordinateFrame name="CFrame">
                 <X>0</X>
                 <Y>0</Y>
@@ -75,57 +67,56 @@
                 <R21>0</R21>
                 <R22>1</R22>
               </CoordinateFrame>
-              <Color3 name="Color">
-                <R>0.7843137383460999</R>
-                <G>0.7843137383460999</G>
-                <B>0.7843137383460999</B>
-              </Color3>
+              <bool name="CanCollide">false</bool>
+              <Color3uint8 name="Color3uint8">9741240</Color3uint8>
+              <Vector3 name="size">
+                <X>0.2</X>
+                <Y>0.35</Y>
+                <Z>0.2</Z>
+              </Vector3>
             </Properties>
           </Item>
         </Item>
-        <Item class="Model" referent="RBXHarnessToolPotion">
+        <Item class="Model" referent="7">
           <Properties>
             <string name="Name">ToolPotion</string>
+            <bool name="NeedsPivotMigration">false</bool>
           </Properties>
-          <Item class="Part" referent="RBXHarnessToolPotionHandle">
+          <Item class="Part" referent="8">
             <Properties>
               <string name="Name">Handle</string>
               <bool name="Anchored">true</bool>
+              <CoordinateFrame name="CFrame">
+                <X>0</X>
+                <Y>0</Y>
+                <Z>0</Z>
+                <R00>1</R00>
+                <R01>0</R01>
+                <R02>0</R02>
+                <R10>0</R10>
+                <R11>1</R11>
+                <R12>0</R12>
+                <R20>0</R20>
+                <R21>0</R21>
+                <R22>1</R22>
+              </CoordinateFrame>
               <bool name="CanCollide">false</bool>
-              <Vector3 name="Size">
+              <Color3uint8 name="Color3uint8">15485081</Color3uint8>
+              <Vector3 name="size">
                 <X>0.25</X>
                 <Y>0.45</Y>
                 <Z>0.25</Z>
               </Vector3>
-              <CoordinateFrame name="CFrame">
-                <X>0</X>
-                <Y>0</Y>
-                <Z>0</Z>
-                <R00>1</R00>
-                <R01>0</R01>
-                <R02>0</R02>
-                <R10>0</R10>
-                <R11>1</R11>
-                <R12>0</R12>
-                <R20>0</R20>
-                <R21>0</R21>
-                <R22>1</R22>
-              </CoordinateFrame>
-              <Color3 name="Color">
-                <R>0.9254902005195618</R>
-                <G>0.2823529541492462</G>
-                <B>0.6000000238418579</B>
-              </Color3>
             </Properties>
           </Item>
         </Item>
       </Item>
     </Item>
-    <Item class="Folder" referent="3">
+    <Item class="Folder" referent="9">
       <Properties>
         <string name="Name">Packages</string>
       </Properties>
-      <Item class="ModuleScript" referent="4">
+      <Item class="ModuleScript" referent="10">
         <Properties>
           <string name="Name">Gameplay</string>
           <string name="Source"><![CDATA[return {
@@ -142,7 +133,7 @@
 }
 ]]></string>
         </Properties>
-        <Item class="ModuleScript" referent="5">
+        <Item class="ModuleScript" referent="11">
           <Properties>
             <string name="Name">Combat</string>
             <string name="Source"><![CDATA[return {
@@ -150,7 +141,7 @@
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="6">
+          <Item class="ModuleScript" referent="12">
             <Properties>
               <string name="Name">PlayerMonsterMelee</string>
               <string name="Source"><![CDATA[-- Pure geometry for player crowbar / melee vs a monster anchor position (tests + runtime).
@@ -227,7 +218,7 @@ return PlayerMonsterMelee
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="7">
+        <Item class="ModuleScript" referent="13">
           <Properties>
             <string name="Name">Config</string>
             <string name="Source"><![CDATA[return {
@@ -241,7 +232,7 @@ return PlayerMonsterMelee
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="8">
+          <Item class="ModuleScript" referent="14">
             <Properties>
               <string name="Name">ItemFields</string>
               <string name="Source"><![CDATA[--!strict
@@ -353,7 +344,7 @@ return ItemFields
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="9">
+          <Item class="ModuleScript" referent="15">
             <Properties>
               <string name="Name">ItemPresentation</string>
               <string name="Source"><![CDATA[-- Shared presentation hints for items (2D icons, 3D template names).
@@ -383,7 +374,7 @@ return ItemPresentation
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="10">
+          <Item class="ModuleScript" referent="16">
             <Properties>
               <string name="Name">Items</string>
               <string name="Source"><![CDATA[local Config = script.Parent
@@ -446,7 +437,7 @@ return FinalItems
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="11">
+          <Item class="ModuleScript" referent="17">
             <Properties>
               <string name="Name">Monsters</string>
               <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.Parent.Monsters.MonsterBehaviorCatalog)
@@ -469,6 +460,9 @@ return {
                 Summary = 'Break line of sight around corners and use distance to reset its route.',
                 Tool = 'No dedicated suppression tool in v1',
             },
+        },
+        Health = {
+            MaxHp = 3,
         },
         Tuning = {
             AttackCooldownSeconds = 1,
@@ -517,7 +511,7 @@ return {
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="12">
+          <Item class="ModuleScript" referent="18">
             <Properties>
               <string name="Name">Players</string>
               <string name="Source"><![CDATA[local Players = {}
@@ -552,7 +546,7 @@ return Players
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="13">
+          <Item class="ModuleScript" referent="19">
             <Properties>
               <string name="Name">Roles</string>
               <string name="Source"><![CDATA[return {
@@ -584,7 +578,7 @@ return Players
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="14">
+          <Item class="ModuleScript" referent="20">
             <Properties>
               <string name="Name">ToolItems</string>
               <string name="Source"><![CDATA[-- ExplorationToolItems Config v0.1
@@ -678,7 +672,7 @@ return ToolItems
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="15">
+        <Item class="ModuleScript" referent="21">
           <Properties>
             <string name="Name">ControlState</string>
             <string name="Source"><![CDATA[local MODE = table.freeze({
@@ -728,6 +722,15 @@ function ControlState:requestSprintStart(playerStateSummary)
         return false, 'StaminaDepleted'
     end
 
+    if
+        playerStateSummary.ActiveEffects
+        and playerStateSummary.ActiveEffects['SprintSuppressed']
+    then
+        self.SprintRequested = false
+        self.Mode = MODE.Walk
+        return false, 'SprintSuppressed'
+    end
+
     self.SprintRequested = true
     self.Mode = MODE.Sprint
     return true, self:getSummary()
@@ -758,6 +761,15 @@ function ControlState:syncPlayerState(playerStateSummary)
         return self:getSummary()
     end
 
+    if
+        playerStateSummary.ActiveEffects
+        and playerStateSummary.ActiveEffects['SprintSuppressed']
+    then
+        self.SprintRequested = false
+        self.Mode = MODE.Walk
+        return self:getSummary()
+    end
+
     if self.SprintRequested and playerStateSummary.CanSprint then
         self.Mode = MODE.Sprint
     else
@@ -771,7 +783,7 @@ return ControlState
 ]]></string>
           </Properties>
         </Item>
-        <Item class="ModuleScript" referent="16">
+        <Item class="ModuleScript" referent="22">
           <Properties>
             <string name="Name">Inventory</string>
             <string name="Source"><![CDATA[local ItemFields = require(script.Parent.Config.ItemFields)
@@ -1068,7 +1080,7 @@ return Inventory
 ]]></string>
           </Properties>
         </Item>
-        <Item class="ModuleScript" referent="17">
+        <Item class="ModuleScript" referent="23">
           <Properties>
             <string name="Name">Monsters</string>
             <string name="Source"><![CDATA[local MonsterCompiler = require(script.MonsterCompiler)
@@ -1093,11 +1105,89 @@ return {
 }
 ]]></string>
           </Properties>
-          <Item class="Folder" referent="18">
+          <Item class="ModuleScript" referent="24">
+            <Properties>
+              <string name="Name">BaseEnemy</string>
+              <string name="Source"><![CDATA[local HealthComponent = require(script.Parent.Components.HealthComponent)
+
+local BaseEnemy = {}
+
+function BaseEnemy.setupHealth(self, componentConfig)
+    local maxHp = 1
+    if type(componentConfig) == 'table' and type(componentConfig.Health) == 'table' then
+        local hp = componentConfig.Health.MaxHp
+        if type(hp) == 'number' and hp >= 1 then
+            maxHp = math.floor(hp)
+        end
+    end
+
+    if not self.Components then
+        self.Components = {}
+    end
+
+    self.Components.Health = HealthComponent.new(maxHp)
+end
+
+function BaseEnemy.applyDamage(self, amount, source)
+    local health = self.Components and self.Components.Health
+    if not health then
+        return
+    end
+
+    if type(amount) ~= 'number' or amount <= 0 then
+        return
+    end
+
+    local damageSource = source or 'unknown'
+    health:applyDamage(amount, damageSource)
+
+    if self.Blackboard and health:isDead() then
+        self.Blackboard.Transient.DeathEvent = {
+            MonsterId = if self.Blackboard.Definition then self.Blackboard.Definition.Id else nil,
+            KilledBy = damageSource,
+        }
+    end
+end
+
+function BaseEnemy.heal(self, amount)
+    local health = self.Components and self.Components.Health
+    if not health then
+        return
+    end
+
+    if type(amount) ~= 'number' or amount <= 0 then
+        return
+    end
+
+    health:heal(amount)
+end
+
+function BaseEnemy.getHealth(self)
+    local health = self.Components and self.Components.Health
+    if not health then
+        return {
+            CurrentHp = 0,
+            MaxHp = 0,
+            IsDead = true,
+        }
+    end
+
+    return {
+        CurrentHp = health.CurrentHp,
+        MaxHp = health.MaxHp,
+        IsDead = health:isDead(),
+    }
+end
+
+return BaseEnemy
+]]></string>
+            </Properties>
+          </Item>
+          <Item class="Folder" referent="25">
             <Properties>
               <string name="Name">Components</string>
             </Properties>
-            <Item class="ModuleScript" referent="19">
+            <Item class="ModuleScript" referent="26">
               <Properties>
                 <string name="Name">AttackComponent</string>
                 <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
@@ -1182,7 +1272,62 @@ return AttackComponent
 ]]></string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="20">
+            <Item class="ModuleScript" referent="27">
+              <Properties>
+                <string name="Name">HealthComponent</string>
+                <string name="Source"><![CDATA[local HealthComponent = {}
+HealthComponent.__index = HealthComponent
+
+function HealthComponent.new(maxHp)
+    local hp = 1
+    if type(maxHp) == 'number' and maxHp >= 1 then
+        hp = math.floor(maxHp)
+    end
+
+    return setmetatable({
+        MaxHp = hp,
+        CurrentHp = hp,
+    }, HealthComponent)
+end
+
+function HealthComponent:init(_blackboard)
+    -- No-op: initialization is done in the constructor.
+end
+
+function HealthComponent:applyDamage(amount, _source)
+    if type(amount) ~= 'number' or amount <= 0 then
+        return
+    end
+
+    self.CurrentHp = math.max(0, self.CurrentHp - amount)
+end
+
+function HealthComponent:heal(amount)
+    if type(amount) ~= 'number' or amount <= 0 then
+        return
+    end
+
+    self.CurrentHp = math.min(self.MaxHp, self.CurrentHp + amount)
+end
+
+function HealthComponent:isDead()
+    return self.CurrentHp <= 0
+end
+
+function HealthComponent:update(_blackboard, _dt)
+    -- No-op: HealthComponent is driven by explicit applyDamage / heal calls,
+    -- not by a per-tick update tick.
+end
+
+function HealthComponent:destroy(_blackboard)
+    -- No-op: no external resources to release.
+end
+
+return HealthComponent
+]]></string>
+              </Properties>
+            </Item>
+            <Item class="ModuleScript" referent="28">
               <Properties>
                 <string name="Name">MovementComponent</string>
                 <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
@@ -1271,7 +1416,7 @@ return MovementComponent
 ]]></string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="21">
+            <Item class="ModuleScript" referent="29">
               <Properties>
                 <string name="Name">PerceptionComponent</string>
                 <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
@@ -1328,10 +1473,11 @@ return PerceptionComponent
               </Properties>
             </Item>
           </Item>
-          <Item class="ModuleScript" referent="22">
+          <Item class="ModuleScript" referent="30">
             <Properties>
               <string name="Name">Enemy</string>
-              <string name="Source"><![CDATA[local EnemyBlackboard = require(script.Parent.EnemyBlackboard)
+              <string name="Source"><![CDATA[local BaseEnemy = require(script.Parent.BaseEnemy)
+local EnemyBlackboard = require(script.Parent.EnemyBlackboard)
 local EnemyStateMachine = require(script.Parent.EnemyStateMachine)
 
 local AttackComponent = require(script.Parent.Components.AttackComponent)
@@ -1340,6 +1486,7 @@ local PerceptionComponent = require(script.Parent.Components.PerceptionComponent
 
 local Enemy = {}
 Enemy.__index = Enemy
+setmetatable(Enemy, { __index = BaseEnemy })
 
 local UPDATE_ORDER = table.freeze({
     'Perception',
@@ -1366,13 +1513,16 @@ function Enemy.new(definition, options)
     local stateMachine = enemyOptions.StateMachine or EnemyStateMachine.new()
     local components = enemyOptions.Components or defaultComponents()
 
-    return setmetatable({
+    local self = setmetatable({
         Blackboard = blackboard,
         ComponentConfig = enemyOptions.ComponentConfig or {},
         StateMachine = stateMachine,
         Components = components,
         StageObserver = enemyOptions.StageObserver,
     }, Enemy)
+
+    self:setupHealth(self.ComponentConfig)
+    return self
 end
 
 function Enemy:_emitStage(stageName)
@@ -1407,6 +1557,10 @@ function Enemy:update(dt, context)
     self:_emitStage('Attack')
     self.Components.Attack:update(self.Blackboard, dt)
 
+    if self.Components.Health then
+        self.Components.Health:update(self.Blackboard, dt)
+    end
+
     return {
         AttackIntent = self.Blackboard.Transient.AttackIntent,
         State = self.Blackboard:getState(),
@@ -1417,6 +1571,8 @@ function Enemy:update(dt, context)
         DesiredAnimationSpeed = self.Blackboard.Transient.DesiredAnimationSpeed or 1,
         ShouldPlayChaseLoop = self.Blackboard.Transient.ShouldPlayChaseLoop == true,
         TravelOffset = self.Blackboard.Transient.TravelOffset or Vector3.zero,
+        IsDead = self.Components.Health and self.Components.Health:isDead() or false,
+        DeathEvent = self.Blackboard.Transient.DeathEvent,
     }
 end
 
@@ -1434,7 +1590,7 @@ return Enemy
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="23">
+          <Item class="ModuleScript" referent="31">
             <Properties>
               <string name="Name">EnemyBlackboard</string>
               <string name="Source"><![CDATA[local EnemyBlackboard = {}
@@ -1479,7 +1635,7 @@ return EnemyBlackboard
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="24">
+          <Item class="ModuleScript" referent="32">
             <Properties>
               <string name="Name">EnemyStateMachine</string>
               <string name="Source"><![CDATA[local EnemyStateMachine = {}
@@ -1540,7 +1696,7 @@ return EnemyStateMachine
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="25">
+          <Item class="ModuleScript" referent="33">
             <Properties>
               <string name="Name">MazeMonsterSpawnPolicy</string>
               <string name="Source"><![CDATA[local MazeMonsterSpawnPolicy = {}
@@ -1652,7 +1808,7 @@ return MazeMonsterSpawnPolicy
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="26">
+          <Item class="ModuleScript" referent="34">
             <Properties>
               <string name="Name">MonsterAssetIds</string>
               <string name="Source"><![CDATA[local MonsterAssetIds = table.freeze({
@@ -1664,7 +1820,7 @@ return MonsterAssetIds
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="27">
+          <Item class="ModuleScript" referent="35">
             <Properties>
               <string name="Name">MonsterAuthorProfile</string>
               <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
@@ -1706,6 +1862,7 @@ local BOUNDARY_REASONS = table.freeze({
     BoundarySemanticsContainsNonSemanticField = true,
     BoundaryTuningContainsNonTuningField = true,
     BoundaryExecutableContainsNonExecutableField = true,
+    BoundaryHealthContainsNonHealthField = true,
 })
 
 MonsterAuthorProfile.ErrorCategory = ERROR_CATEGORY
@@ -1826,11 +1983,27 @@ local function normalizeSections(profile)
         return nil, 'BoundaryExecutableContainsNonExecutableField'
     end
 
+    local health = profile.Health
+    if health ~= nil and type(health) ~= 'table' then
+        return nil, 'InvalidHealth'
+    end
+
+    if health ~= nil then
+        if
+            hasAnyField(health, SEMANTIC_FIELDS)
+            or hasAnyField(health, TUNING_FIELDS)
+            or hasAnyField(health, EXECUTABLE_FIELDS)
+        then
+            return nil, 'BoundaryHealthContainsNonHealthField'
+        end
+    end
+
     return {
         SchemaMode = SCHEMA_MODE.Layered,
         Semantics = semantics,
         Tuning = tuning,
         Executable = executable,
+        Health = health,
     }
 end
 
@@ -1982,7 +2155,7 @@ return MonsterAuthorProfile
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="28">
+          <Item class="ModuleScript" referent="36">
             <Properties>
               <string name="Name">MonsterBehaviorCatalog</string>
               <string name="Source"><![CDATA[local BEHAVIOR = table.freeze({
@@ -2014,7 +2187,7 @@ return MonsterBehaviorCatalog
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="29">
+          <Item class="ModuleScript" referent="37">
             <Properties>
               <string name="Name">MonsterCompiler</string>
               <string name="Source"><![CDATA[local MonsterAuthorProfile = require(script.Parent.MonsterAuthorProfile)
@@ -2113,6 +2286,7 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
         PatrolSpeedMultiplier = normalizedProfile.Tuning.PatrolSpeedMultiplier,
         SpawnOffset = normalizedProfile.Tuning.SpawnOffset or DEFAULT_SPAWN_OFFSET,
         CombatHitPoints = combatHitPoints,
+        Health = normalizedProfile.Health,
         Behaviors = table.freeze(behaviors),
         Effects = table.freeze(runtimeEffects),
     }
@@ -2140,7 +2314,7 @@ return MonsterCompiler
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="30">
+          <Item class="ModuleScript" referent="38">
             <Properties>
               <string name="Name">MonsterComponentConfig</string>
               <string name="Source"><![CDATA[local DEFAULT_ATTACK_COOLDOWN_SECONDS = 1
@@ -2223,6 +2397,17 @@ function MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)
                 else DEFAULT_ATTACK_HIT_MARKER_NAME,
             Range = getPositiveNumber(attack.Range, profile.AttackRange, DEFAULT_ATTACK_RANGE),
         }),
+        Health = table.freeze({
+            MaxHp = getPositiveNumber(
+                components.Health and components.Health.MaxHp,
+                getPositiveNumber(
+                    profile.Health and profile.Health.MaxHp,
+                    profile.CombatHitPoints,
+                    1
+                ),
+                1
+            ),
+        }),
     }
 
     return table.freeze(componentConfig)
@@ -2232,7 +2417,7 @@ return MonsterComponentConfig
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="31">
+          <Item class="ModuleScript" referent="39">
             <Properties>
               <string name="Name">MonsterEffectCatalog</string>
               <string name="Source"><![CDATA[local CATEGORY = table.freeze({
@@ -2295,7 +2480,7 @@ return table.freeze(MonsterEffectCatalog)
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="32">
+          <Item class="ModuleScript" referent="40">
             <Properties>
               <string name="Name">MonsterLogic</string>
               <string name="Source"><![CDATA[local MonsterLogic = {}
@@ -2331,7 +2516,7 @@ return MonsterLogic
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="33">
+          <Item class="ModuleScript" referent="41">
             <Properties>
               <string name="Name">MonsterPresentationCatalog</string>
               <string name="Source"><![CDATA[local MonsterPresentationCatalog = {}
@@ -2356,7 +2541,7 @@ return MonsterPresentationCatalog
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="34">
+          <Item class="ModuleScript" referent="42">
             <Properties>
               <string name="Name">MonsterRuntimeProfile</string>
               <string name="Source"><![CDATA[local MonsterPresentationCatalog = require(script.Parent.MonsterPresentationCatalog)
@@ -2447,6 +2632,10 @@ function MonsterRuntimeProfile.validate(profile)
     if attackConfigErr then
         return false, attackConfigErr
     end
+    local healthConfig, healthConfigErr = readComponentTable(profile, 'Health')
+    if healthConfigErr then
+        return false, healthConfigErr
+    end
 
     if
         perceptionConfig
@@ -2493,6 +2682,18 @@ function MonsterRuntimeProfile.validate(profile)
         if attackConfig.DamagePips ~= nil and not isValidDamagePips(attackConfig.DamagePips) then
             return false, 'InvalidRuntimeComponentAttackDamagePips'
         end
+    end
+
+    if
+        healthConfig
+        and healthConfig.MaxHp ~= nil
+        and (
+            type(healthConfig.MaxHp) ~= 'number'
+            or healthConfig.MaxHp < 1
+            or math.floor(healthConfig.MaxHp) ~= healthConfig.MaxHp
+        )
+    then
+        return false, 'InvalidRuntimeComponentHealthMaxHp'
     end
 
     local runtimeSpeed = profile.Speed
@@ -2584,7 +2785,7 @@ return MonsterRuntimeProfile
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="35">
+          <Item class="ModuleScript" referent="43">
             <Properties>
               <string name="Name">MonsterUgcPipeline</string>
               <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
@@ -3467,7 +3668,7 @@ return MonsterUgcPipeline
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="36">
+          <Item class="ModuleScript" referent="44">
             <Properties>
               <string name="Name">MonsterUgcReviewQueue</string>
               <string name="Source"><![CDATA[local MonsterUgcReviewQueue = {}
@@ -3622,7 +3823,7 @@ return MonsterUgcReviewQueue
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="37">
+        <Item class="ModuleScript" referent="45">
           <Properties>
             <string name="Name">Player</string>
             <string name="Source"><![CDATA[return {
@@ -3637,11 +3838,11 @@ return MonsterUgcReviewQueue
 }
 ]]></string>
           </Properties>
-          <Item class="Folder" referent="38">
+          <Item class="Folder" referent="46">
             <Properties>
               <string name="Name">Components</string>
             </Properties>
-            <Item class="ModuleScript" referent="39">
+            <Item class="ModuleScript" referent="47">
               <Properties>
                 <string name="Name">HealthComponent</string>
                 <string name="Source"><![CDATA[local HealthComponent = {}
@@ -3726,7 +3927,7 @@ return HealthComponent
 ]]></string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="40">
+            <Item class="ModuleScript" referent="48">
               <Properties>
                 <string name="Name">InventoryComponent</string>
                 <string name="Source"><![CDATA[local InventoryComponent = {}
@@ -3773,7 +3974,7 @@ return InventoryComponent
 ]]></string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="41">
+            <Item class="ModuleScript" referent="49">
               <Properties>
                 <string name="Name">MovementComponent</string>
                 <string name="Source"><![CDATA[local MovementComponent = {}
@@ -3861,7 +4062,7 @@ return MovementComponent
 ]]></string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="42">
+            <Item class="ModuleScript" referent="50">
               <Properties>
                 <string name="Name">StaminaComponent</string>
                 <string name="Source"><![CDATA[local StaminaComponent = {}
@@ -3983,7 +4184,7 @@ return StaminaComponent
               </Properties>
             </Item>
           </Item>
-          <Item class="ModuleScript" referent="43">
+          <Item class="ModuleScript" referent="51">
             <Properties>
               <string name="Name">Player</string>
               <string name="Source"><![CDATA[local PlayerBlackboard = require(script.Parent.PlayerBlackboard)
@@ -4101,7 +4302,7 @@ return Player
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="44">
+          <Item class="ModuleScript" referent="52">
             <Properties>
               <string name="Name">PlayerBlackboard</string>
               <string name="Source"><![CDATA[local PlayerBlackboard = {}
@@ -4146,7 +4347,7 @@ return PlayerBlackboard
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="45">
+          <Item class="ModuleScript" referent="53">
             <Properties>
               <string name="Name">PlayerComponentConfig</string>
               <string name="Source"><![CDATA[local PlayerComponentConfig = {}
@@ -4246,7 +4447,7 @@ return PlayerComponentConfig
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="46">
+          <Item class="ModuleScript" referent="54">
             <Properties>
               <string name="Name">PlayerStateMachine</string>
               <string name="Source"><![CDATA[local PlayerStateMachine = {}
@@ -4312,7 +4513,7 @@ return PlayerStateMachine
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="47">
+        <Item class="ModuleScript" referent="55">
           <Properties>
             <string name="Name">PlayerState</string>
             <string name="Source"><![CDATA[local DEFAULT_MAX_HEALTH_PIPS = 2
@@ -4366,6 +4567,7 @@ function PlayerState.new(config)
         CanSprint = true,
         CorpseActive = false,
         IsSprinting = false,
+        ActiveEffects = {}, -- {[effectId] = remainingSeconds}
     }, PlayerState)
 end
 
@@ -4378,6 +4580,7 @@ function PlayerState:getSummary()
         IsDead = self.IsDead,
         CanSprint = self.CanSprint,
         CorpseActive = self.CorpseActive,
+        ActiveEffects = self.ActiveEffects,
     }
 end
 
@@ -4413,12 +4616,43 @@ function PlayerState:applyDamage(damageKind)
     return true, self:getSummary()
 end
 
+function PlayerState:applyEffect(effectId, durationSeconds)
+    if type(effectId) ~= 'string' or effectId == '' then
+        return
+    end
+    local duration = if type(durationSeconds) == 'number' and durationSeconds > 0
+        then durationSeconds
+        else math.huge
+    local currentRemaining = self.ActiveEffects[effectId]
+    if currentRemaining == nil or duration > currentRemaining then
+        self.ActiveEffects[effectId] = duration
+    end
+end
+
+function PlayerState:hasEffect(effectId)
+    if type(effectId) ~= 'string' then
+        return false
+    end
+    return self.ActiveEffects[effectId] ~= nil
+end
+
 function PlayerState:step(dt)
     if self.IsDead then
         return self:getSummary()
     end
 
     local deltaTime = math.max(0, dt or 0)
+
+    -- Tick down active effects
+    for effectId, remaining in pairs(self.ActiveEffects) do
+        local nextRemaining = remaining - deltaTime
+        if nextRemaining <= 0 then
+            self.ActiveEffects[effectId] = nil
+        else
+            self.ActiveEffects[effectId] = nextRemaining
+        end
+    end
+
     if self.IsSprinting and self.CanSprint then
         self.CurrentStamina =
             clamp(self.CurrentStamina - self.StaminaDrainPerSecond * deltaTime, 0, self.MaxStamina)
@@ -4447,7 +4681,7 @@ return PlayerState
 ]]></string>
           </Properties>
         </Item>
-        <Item class="ModuleScript" referent="48">
+        <Item class="ModuleScript" referent="56">
           <Properties>
             <string name="Name">ProcGen</string>
             <string name="Source"><![CDATA[return {
@@ -4459,7 +4693,7 @@ return PlayerState
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="49">
+          <Item class="ModuleScript" referent="57">
             <Properties>
               <string name="Name">HexRoomPrefabs</string>
               <string name="Source"><![CDATA[local HexRoomPrefabs = {}
@@ -4644,7 +4878,7 @@ return HexRoomPrefabs
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="50">
+          <Item class="ModuleScript" referent="58">
             <Properties>
               <string name="Name">MazeBuilder</string>
               <string name="Source"><![CDATA[local MazeBuilder = {}
@@ -5944,7 +6178,7 @@ return MazeBuilder
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="51">
+          <Item class="ModuleScript" referent="59">
             <Properties>
               <string name="Name">MazePassageTemplates</string>
               <string name="Source"><![CDATA[local MazePassageTemplates = {}
@@ -6053,7 +6287,7 @@ return MazePassageTemplates
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="52">
+          <Item class="ModuleScript" referent="60">
             <Properties>
               <string name="Name">MazeRoomArchetypes</string>
               <string name="Source"><![CDATA[local MazeRoomTemplates = require(script.Parent.MazeRoomTemplates)
@@ -6150,7 +6384,7 @@ return MazeRoomArchetypes
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="53">
+          <Item class="ModuleScript" referent="61">
             <Properties>
               <string name="Name">MazeRoomTemplates</string>
               <string name="Source"><![CDATA[local MazePassageTemplates = require(script.Parent.MazePassageTemplates)
@@ -6379,7 +6613,7 @@ return MazeRoomTemplates
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="54">
+        <Item class="ModuleScript" referent="62">
           <Properties>
             <string name="Name">Roles</string>
             <string name="Source"><![CDATA[return {
@@ -6387,7 +6621,7 @@ return MazeRoomTemplates
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="55">
+          <Item class="ModuleScript" referent="63">
             <Properties>
               <string name="Name">RoleAllocator</string>
               <string name="Source"><![CDATA[local RoleAllocator = {}
@@ -6420,7 +6654,7 @@ return RoleAllocator
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="56">
+        <Item class="ModuleScript" referent="64">
           <Properties>
             <string name="Name">Session</string>
             <string name="Source"><![CDATA[return {
@@ -6429,7 +6663,7 @@ return RoleAllocator
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="57">
+          <Item class="ModuleScript" referent="65">
             <Properties>
               <string name="Name">MazeRunTracker</string>
               <string name="Source"><![CDATA[local SessionStateMachine = require(script.Parent.SessionStateMachine)
@@ -6572,7 +6806,7 @@ return MazeRunTracker
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="58">
+          <Item class="ModuleScript" referent="66">
             <Properties>
               <string name="Name">SessionStateMachine</string>
               <string name="Source"><![CDATA[local TRANSITIONS = {
@@ -6620,7 +6854,7 @@ return SessionStateMachine
           </Item>
         </Item>
       </Item>
-      <Item class="ModuleScript" referent="59">
+      <Item class="ModuleScript" referent="67">
         <Properties>
           <string name="Name">Shared</string>
           <string name="Source"><![CDATA[return {
@@ -6634,7 +6868,7 @@ return SessionStateMachine
 }
 ]]></string>
         </Properties>
-        <Item class="ModuleScript" referent="60">
+        <Item class="ModuleScript" referent="68">
           <Properties>
             <string name="Name">Client</string>
             <string name="Source"><![CDATA[return {
@@ -6644,7 +6878,7 @@ return SessionStateMachine
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="61">
+          <Item class="ModuleScript" referent="69">
             <Properties>
               <string name="Name">FirstPersonController</string>
               <string name="Source"><![CDATA[local FirstPersonController = {}
@@ -6707,7 +6941,7 @@ return FirstPersonController
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="62">
+          <Item class="ModuleScript" referent="70">
             <Properties>
               <string name="Name">HeldItemController</string>
               <string name="Source"><![CDATA[local HeldToolVisual = require(script.Parent.HeldToolVisual)
@@ -6829,7 +7063,7 @@ return HeldItemController
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="63">
+          <Item class="ModuleScript" referent="71">
             <Properties>
               <string name="Name">HeldToolVisual</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -6841,6 +7075,7 @@ local ItemPresentation = Gameplay.Config.ItemPresentation
 local CLONE_NAME = 'HeldToolVisualClone'
 
 local HeldToolVisual = {}
+HeldToolVisual.CLONE_NAME = CLONE_NAME
 
 local function getHandPart(character: Model): BasePart?
     local hand = character:FindFirstChild('RightHand') or character:FindFirstChild('Right Arm')
@@ -7001,7 +7236,7 @@ return HeldToolVisual
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="64">
+        <Item class="ModuleScript" referent="72">
           <Properties>
             <string name="Name">Config</string>
             <string name="Source"><![CDATA[return {
@@ -7009,19 +7244,20 @@ return HeldToolVisual
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="65">
+          <Item class="ModuleScript" referent="73">
             <Properties>
               <string name="Name">SessionConfig</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local DEFAULT_PLACE_IDS = {
+    Lobby = 99207062749924,
     Maze = 114148445477110,
     Run = 137478567439901,
     Library = 0, -- TODO: 替换为实际的图书馆 Place ID
 }
 local DEFAULT_DEBUG_LOCAL_MAZE_HANDOFF = false
 
-local PLACE_ID_KEYS = { 'Maze', 'Run', 'Library' }
+local PLACE_ID_KEYS = { 'Lobby', 'Maze', 'Run', 'Library' }
 
 local function coercePlaceId(value)
     local numericValue = tonumber(value)
@@ -7077,13 +7313,11 @@ local SessionConfig = {
     DefaultRunDurationSeconds = 180,
     SettlementDurationSeconds = 8,
     InventoryCapacity = 5,
-    TOD = {
+    TOD = table.freeze({
         RoundMinutes = 15,
         StartHour = 7,
         EndHour = 22,
-        StartClockTime = 7,
-        EndClockTime = 22,
-    },
+    }),
     ProcGen = {
         RoomCount = 20,
         ExitMin = 2,
@@ -7101,7 +7335,7 @@ return SessionConfig
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="66">
+        <Item class="ModuleScript" referent="74">
           <Properties>
             <string name="Name">Enums</string>
             <string name="Source"><![CDATA[return {
@@ -7109,7 +7343,7 @@ return SessionConfig
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="67">
+          <Item class="ModuleScript" referent="75">
             <Properties>
               <string name="Name">RunState</string>
               <string name="Source"><![CDATA[return {
@@ -7122,7 +7356,7 @@ return SessionConfig
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="68">
+        <Item class="ModuleScript" referent="76">
           <Properties>
             <string name="Name">Network</string>
             <string name="Source"><![CDATA[return {
@@ -7130,7 +7364,7 @@ return SessionConfig
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="69">
+          <Item class="ModuleScript" referent="77">
             <Properties>
               <string name="Name">Remotes</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -7144,19 +7378,19 @@ Remotes.Scope = table.freeze({
 })
 
 local REMOTE_NAMES_BY_SCOPE = table.freeze({
-    [Remotes.Scope.Run] = {
+    [Remotes.Scope.Run] = table.freeze({
         'RunAction',
         'RunState',
         'RunPrivateState',
-    },
-    [Remotes.Scope.Maze] = {
+    }),
+    [Remotes.Scope.Maze] = table.freeze({
         'MazeAction',
         'MazeState',
         'MazePrivateState',
-    },
+    }),
 })
 
-local ALL_REMOTE_NAMES = {
+local ALL_REMOTE_NAMES = table.freeze({
     'RunAction',
     'RunState',
     'RunPrivateState',
@@ -7164,7 +7398,7 @@ local ALL_REMOTE_NAMES = {
     'MazeState',
     'MazePrivateState',
     'TODState',
-}
+})
 
 local function assertServer(operationName)
     if RunService:IsClient() then
@@ -7297,7 +7531,7 @@ return Remotes
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="70">
+        <Item class="ModuleScript" referent="78">
           <Properties>
             <string name="Name">Runtime</string>
             <string name="Source"><![CDATA[return {
@@ -7315,13 +7549,14 @@ return Remotes
     MonsterService = require(script.MonsterService),
     PlayerService = require(script.PlayerService),
     PlayerStateService = require(script.PlayerStateService),
-    TeleportInventoryHydrator = require(script.TeleportInventoryHydrator),
+    RoundSignalBus = require(script.RoundSignalBus),
     TODProfile = require(script.TODProfile),
     TODService = require(script.TODService),
+    TeleportInventoryHydrator = require(script.TeleportInventoryHydrator),
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="71">
+          <Item class="ModuleScript" referent="79">
             <Properties>
               <string name="Name">ControlStateService</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -7403,7 +7638,7 @@ return ControlStateService
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="72">
+          <Item class="ModuleScript" referent="80">
             <Properties>
               <string name="Name">FormalLocomotion</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -7472,7 +7707,7 @@ return FormalLocomotion
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="73">
+          <Item class="ModuleScript" referent="81">
             <Properties>
               <string name="Name">HexMazeWorldRenderer</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -7681,25 +7916,28 @@ local function createConnectorAuthoringSockets(connectorFolder, connectorPivot)
     return authoringFolder
 end
 
+local function addDecorPart(parent, roomCenter, name, size, offset, color, material, transparency)
+    local part = Instance_new('Part')
+    part.Name = name
+    part.Anchored = true
+    part.Size = size
+    part.CFrame = CFrame_new(roomCenter + offset)
+    part.Color = color
+    part.Material = material or Enum.Material.SmoothPlastic
+    part.Transparency = transparency or 0
+    part.CanCollide = false
+    part.Parent = parent
+end
+
 local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem, surfacePalette)
     local decorFolder = Instance_new('Folder')
     decorFolder.Name = 'RoomTemplateDecor'
     decorFolder.Parent = roomFolder
 
-    local function addDecorPart(name, size, offset, color, material, transparency)
-        createPart({
-            Name = name,
-            Size = size,
-            CFrame = CFrame_new(roomCenter + offset),
-            Color = color,
-            Material = material,
-            Transparency = transparency or 0,
-            CanCollide = false,
-        }, decorFolder)
-    end
-
     if room.RoomTemplateId == 'EntrySafe' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'StagingPad',
             Vector3_new(roomApothem * 0.9, 0.4, roomApothem * 0.9),
             Vector3_new(0, 0.25, 0),
@@ -7707,6 +7945,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'OrientationPylon',
             Vector3_new(2, 9, 2),
             Vector3_new(0, 4.5, roomApothem * 0.22),
@@ -7718,6 +7958,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'TransitHall' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'TransitBeam',
             Vector3_new(roomApothem * 1.05, 1.2, 3),
             Vector3_new(0, 10, 0),
@@ -7725,6 +7967,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'TransitStripe',
             Vector3_new(roomApothem * 0.75, 0.15, 2),
             Vector3_new(0, 0.2, 0),
@@ -7737,6 +7981,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'SearchCluster' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'SearchCrateA',
             Vector3_new(5, 3, 4),
             Vector3_new(-roomApothem * 0.22, 1.5, 0),
@@ -7744,6 +7990,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.WoodPlanks
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'SearchCrateB',
             Vector3_new(4, 2.2, 3),
             Vector3_new(roomApothem * 0.2, 1.1, roomApothem * 0.1),
@@ -7755,6 +8003,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'HighValueRisk' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'VaultCore',
             Vector3_new(7, 6, 7),
             Vector3_new(0, 3, 0),
@@ -7762,6 +8012,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'HazardStrip',
             Vector3_new(roomApothem * 0.8, 0.2, 2),
             Vector3_new(0, 0.15, -roomApothem * 0.18),
@@ -7774,6 +8026,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'LandmarkFacility' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'LandmarkTower',
             Vector3_new(5, 12, 5),
             Vector3_new(0, 6, 0),
@@ -7781,6 +8035,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'LandmarkRing',
             Vector3_new(roomApothem * 0.95, 0.2, roomApothem * 0.95),
             Vector3_new(0, 0.2, 0),
@@ -7793,6 +8049,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'ExtractionReturn' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'ExtractionFrame',
             Vector3_new(roomApothem * 0.95, 0.25, roomApothem * 0.95),
             Vector3_new(0, 0.2, 0),
@@ -7801,6 +8059,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             0.35
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'ExtractionBeacon',
             Vector3_new(2.5, 10, 2.5),
             Vector3_new(0, 5, 0),
@@ -7812,6 +8072,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'BulkheadGate' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'BulkheadFrame',
             Vector3_new(roomApothem * 0.92, 7, 2),
             Vector3_new(0, 3.5, 0),
@@ -7819,6 +8081,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'BulkheadThreshold',
             Vector3_new(roomApothem * 0.9, 0.2, 3),
             Vector3_new(0, 0.2, 0),
@@ -7831,6 +8095,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'ShortcutLoop' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'ShortcutBrace',
             Vector3_new(roomApothem * 0.8, 1.2, 3),
             Vector3_new(0, 9, 0),
@@ -7838,6 +8104,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'ShortcutMarker',
             Vector3_new(roomApothem * 0.75, 0.15, 1.5),
             Vector3_new(0, 0.2, 0),
@@ -8069,11 +8337,6 @@ local function buildRoom(parent, room, roomCenter, roomApothem, options)
         }, roomFolder)
     end
 
-    local doorwayDirections = {}
-    for directionIndex in pairs(room.Neighbors) do
-        doorwayDirections[directionIndex] = true
-    end
-
     local sideLength = 2 * roomApothem * TAN_PI_6
     for directionIndex = 1, 6 do
         createHexSideWall(
@@ -8082,7 +8345,7 @@ local function buildRoom(parent, room, roomCenter, roomApothem, options)
             directionIndex,
             roomApothem,
             sideLength,
-            doorwayDirections[directionIndex] == true,
+            room.Neighbors[directionIndex] ~= nil,
             options.SurfacePalette
         )
     end
@@ -8456,11 +8719,12 @@ function HexMazeWorldRenderer.build(params)
             end
         end
 
+        local nearestDistance = math_sqrt(nearestDistanceSq)
         if nearestDistanceSq <= detectionRadiusSq then
-            return nearestRoom, math_sqrt(nearestDistanceSq)
+            return nearestRoom, nearestDistance
         end
 
-        return nil, math_sqrt(nearestDistanceSq)
+        return nil, nearestDistance
     end
 
     local function canTraverseBetweenPositions(fromPosition, toPosition)
@@ -8520,7 +8784,7 @@ return HexMazeWorldRenderer
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="74">
+          <Item class="ModuleScript" referent="82">
             <Properties>
               <string name="Name">InventoryService</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -8657,7 +8921,7 @@ return InventoryService
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="75">
+          <Item class="ModuleScript" referent="83">
             <Properties>
               <string name="Name">MazeDebugWorldComposer</string>
               <string name="Source"><![CDATA[local MazeWorldShellBuilder = require(script.Parent.MazeWorldShellBuilder)
@@ -8696,7 +8960,7 @@ return MazeDebugWorldComposer
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="76">
+          <Item class="ModuleScript" referent="84">
             <Properties>
               <string name="Name">MazeFormalWorldComposer</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -8985,7 +9249,7 @@ return MazeFormalWorldComposer
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="77">
+          <Item class="ModuleScript" referent="85">
             <Properties>
               <string name="Name">MazeInteractionPartFactory</string>
               <string name="Source"><![CDATA[local MazeInteractionPartFactory = {}
@@ -9039,7 +9303,7 @@ return MazeInteractionPartFactory
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="78">
+          <Item class="ModuleScript" referent="86">
             <Properties>
               <string name="Name">MazeLightingProfile</string>
               <string name="Source"><![CDATA[local MazeLightingProfile = {}
@@ -9358,7 +9622,7 @@ return MazeLightingProfile
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="79">
+          <Item class="ModuleScript" referent="87">
             <Properties>
               <string name="Name">MazeModuleAssetContract</string>
               <string name="Source"><![CDATA[local MazeModuleAssetContract = {}
@@ -9471,7 +9735,7 @@ return MazeModuleAssetContract
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="80">
+          <Item class="ModuleScript" referent="88">
             <Properties>
               <string name="Name">MazeWorldScanner</string>
               <string name="Source"><![CDATA[--[[
@@ -10093,7 +10357,7 @@ return MazeWorldScanner
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="81">
+          <Item class="ModuleScript" referent="89">
             <Properties>
               <string name="Name">MazeWorldShellBuilder</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -10155,7 +10419,7 @@ return MazeWorldShellBuilder
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="82">
+          <Item class="ModuleScript" referent="90">
             <Properties>
               <string name="Name">MonsterRuntime</string>
               <string name="Source"><![CDATA[return {
@@ -10169,7 +10433,7 @@ return MazeWorldShellBuilder
 }
 ]]></string>
             </Properties>
-            <Item class="ModuleScript" referent="83">
+            <Item class="ModuleScript" referent="91">
               <Properties>
                 <string name="Name">AttackComponent</string>
                 <string name="Source"><![CDATA[local AttackComponent = {}
@@ -10218,7 +10482,7 @@ return AttackComponent
 ]]></string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="84">
+            <Item class="ModuleScript" referent="92">
               <Properties>
                 <string name="Name">EnemyBlackboard</string>
                 <string name="Source"><![CDATA[local EnemyBlackboard = {}
@@ -10265,7 +10529,7 @@ return EnemyBlackboard
 ]]></string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="85">
+            <Item class="ModuleScript" referent="93">
               <Properties>
                 <string name="Name">EnemyRuntime</string>
                 <string name="Source"><![CDATA[local EnemyBlackboard = require(script.Parent.EnemyBlackboard)
@@ -10352,7 +10616,7 @@ return EnemyRuntime
 ]]></string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="86">
+            <Item class="ModuleScript" referent="94">
               <Properties>
                 <string name="Name">EnemyStateMachine</string>
                 <string name="Source"><![CDATA[local EnemyStateMachine = {}
@@ -10395,7 +10659,7 @@ return EnemyStateMachine
 ]]></string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="87">
+            <Item class="ModuleScript" referent="95">
               <Properties>
                 <string name="Name">HealthComponent</string>
                 <string name="Source"><![CDATA[local HealthComponent = {}
@@ -10425,7 +10689,7 @@ return HealthComponent
 ]]></string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="88">
+            <Item class="ModuleScript" referent="96">
               <Properties>
                 <string name="Name">MovementComponent</string>
                 <string name="Source"><![CDATA[local EnemyStateMachine = require(script.Parent.EnemyStateMachine)
@@ -10499,7 +10763,7 @@ return MovementComponent
 ]]></string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="89">
+            <Item class="ModuleScript" referent="97">
               <Properties>
                 <string name="Name">PerceptionComponent</string>
                 <string name="Source"><![CDATA[local PerceptionComponent = {}
@@ -10552,7 +10816,7 @@ return PerceptionComponent
               </Properties>
             </Item>
           </Item>
-          <Item class="ModuleScript" referent="90">
+          <Item class="ModuleScript" referent="98">
             <Properties>
               <string name="Name">MonsterService</string>
               <string name="Source"><![CDATA[local InsertService = game:GetService('InsertService')
@@ -11359,6 +11623,7 @@ function MonsterService:_resolveAttackHitContext(pendingAttack)
         Hit = true,
         Reason = 'HitConfirmed',
         Distance = distance,
+        Effects = pendingAttack.Effects,
     }
 end
 
@@ -11592,6 +11857,10 @@ function MonsterService:tryApplyPlayerMeleeHit(player, meleeOptions)
         TargetUserId = player.UserId,
     })
 
+    if self.EnemyRuntime then
+        self.EnemyRuntime:applyDamage(damagePips, 'player')
+    end
+
     if killed then
         self:destroy()
     end
@@ -11653,6 +11922,15 @@ function MonsterService:_runLogicStep(dt)
     local decision = self.EnemyRuntime:update(dt)
     self.PatrolIndex = self.EnemyRuntime.Context.PatrolIndex
 
+    if decision.IsDead then
+        self:_recordDecisionEvent('Died', {
+            MonsterId = self.Definition.Id,
+            DeathEvent = decision.DeathEvent,
+        })
+        self:destroy()
+        return
+    end
+
     if decision.TargetChanged then
         self:_emitDecisionLog('TargetChanged', {
             MonsterId = self.Definition.Id,
@@ -11669,6 +11947,17 @@ function MonsterService:_runLogicStep(dt)
         self:_emitDecisionLog('AttackQueued', {
             MonsterId = self.Definition.Id,
         })
+        local target = self.EnemyRuntime.Blackboard.CurrentTarget
+        if target then
+            self:_queueAttackIntent({
+                TargetPlayer = target,
+                DamagePips = self.ComponentConfig.Attack.DamagePips,
+                Range = self.ComponentConfig.Attack.Range,
+                ArcDegrees = self.ComponentConfig.Attack.ArcDegrees,
+                MarkerName = self.ComponentConfig.Attack.HitMarkerName,
+                Effects = self.Definition.Effects,
+            })
+        end
     end
 
     local nextPosition = decision.NextPosition
@@ -11740,7 +12029,7 @@ return MonsterService
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="91">
+          <Item class="ModuleScript" referent="99">
             <Properties>
               <string name="Name">PlayerService</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -11887,7 +12176,7 @@ return PlayerService
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="92">
+          <Item class="ModuleScript" referent="100">
             <Properties>
               <string name="Name">PlayerStateService</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -11944,6 +12233,24 @@ function PlayerStateService:applyDamage(player, damageKind)
     return state:applyDamage(damageKind)
 end
 
+function PlayerStateService:applyEffect(player, effectId, durationSeconds)
+    local state = self:get(player)
+    if not state then
+        return
+    end
+
+    state:applyEffect(effectId, durationSeconds)
+end
+
+function PlayerStateService:hasEffect(player, effectId)
+    local state = self:get(player)
+    if not state then
+        return false
+    end
+
+    return state:hasEffect(effectId)
+end
+
 function PlayerStateService:setSprinting(player, isSprinting)
     local state = self:get(player)
     if not state then
@@ -11967,251 +12274,725 @@ return PlayerStateService
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="93">
+          <Item class="ModuleScript" referent="101">
             <Properties>
-              <string name="Name">TODProfile</string>
-              <string name="Source"><![CDATA[-- TODProfile.luau
--- Keyframe-based Time-of-Day profile for global lighting.
--- Drives Lighting.ClockTime + Atmosphere + ColorCorrectionEffect over a 15-hour
--- game-day (7:00 → 22:00) mapped to a configurable real-minute round.
+              <string name="Name">RoundSignalBus</string>
+              <string name="Source"><![CDATA[local MessagingService = game:GetService('MessagingService')
 
-local SessionConfig = require(script.Parent.Parent.Config.SessionConfig)
+local RoundSignalBus = {}
+RoundSignalBus.__index = RoundSignalBus
 
-local EFFECT_NAME_ATMOSPHERE = 'TODAtmosphere'
-local EFFECT_NAME_COLOR_CORRECTION = 'TODColorCorrection'
-
--- Hour → ClockTime is 1:1 (hour 7 → ClockTime 7, hour 12 → ClockTime 12, etc.)
--- Keyframes: hour, brightness, tintColor (RGB), atmosphereColor (RGB), atmosphereDensity
-local KEYFRAMES = table.freeze({
-    { hour = 7,  clockTime = 7,  brightness = 0.5,  tintColor = Color3.fromRGB(255, 235, 210), atmosphereColor = Color3.fromRGB(200, 175, 130), atmosphereDensity = 0.18 }, -- early morning, warm glow
-    { hour = 8,  clockTime = 8,  brightness = 0.7,  tintColor = Color3.fromRGB(255, 240, 220), atmosphereColor = Color3.fromRGB(210, 185, 145), atmosphereDensity = 0.15 }, -- morning
-    { hour = 9,  clockTime = 9,  brightness = 0.8,  tintColor = Color3.fromRGB(255, 245, 230), atmosphereColor = Color3.fromRGB(190, 175, 150), atmosphereDensity = 0.12 }, -- late morning
-    { hour = 10, clockTime = 10, brightness = 0.9,  tintColor = Color3.fromRGB(255, 250, 240), atmosphereColor = Color3.fromRGB(175, 170, 155), atmosphereDensity = 0.10 }, -- approaching noon
-    { hour = 11, clockTime = 11, brightness = 1.0,  tintColor = Color3.fromRGB(255, 255, 245), atmosphereColor = Color3.fromRGB(165, 165, 155), atmosphereDensity = 0.08 }, -- late morning
-    { hour = 12, clockTime = 12, brightness = 1.05, tintColor = Color3.fromRGB(255, 255, 250), atmosphereColor = Color3.fromRGB(155, 160, 160), atmosphereDensity = 0.07 }, -- noon, peak brightness
-    { hour = 13, clockTime = 13, brightness = 1.0,  tintColor = Color3.fromRGB(255, 252, 240), atmosphereColor = Color3.fromRGB(165, 165, 160), atmosphereDensity = 0.08 }, -- early afternoon
-    { hour = 14, clockTime = 14, brightness = 0.9,  tintColor = Color3.fromRGB(255, 248, 230), atmosphereColor = Color3.fromRGB(175, 170, 160), atmosphereDensity = 0.10 }, -- afternoon
-    { hour = 15, clockTime = 15, brightness = 0.75, tintColor = Color3.fromRGB(255, 240, 215), atmosphereColor = Color3.fromRGB(185, 170, 150), atmosphereDensity = 0.13 }, -- mid afternoon, warm
-    { hour = 16, clockTime = 16, brightness = 0.6,  tintColor = Color3.fromRGB(255, 225, 195), atmosphereColor = Color3.fromRGB(195, 165, 135), atmosphereDensity = 0.16 }, -- late afternoon
-    { hour = 17, clockTime = 17, brightness = 0.4,  tintColor = Color3.fromRGB(255, 205, 165), atmosphereColor = Color3.fromRGB(205, 155, 115), atmosphereDensity = 0.22 }, -- golden hour
-    { hour = 18, clockTime = 18, brightness = 0.2,  tintColor = Color3.fromRGB(255, 175, 130), atmosphereColor = Color3.fromRGB(215, 140, 100), atmosphereDensity = 0.30 }, -- dusk
-    { hour = 19, clockTime = 19, brightness = 0.0,  tintColor = Color3.fromRGB(255, 155, 110), atmosphereColor = Color3.fromRGB(130, 110, 140), atmosphereDensity = 0.35 }, -- sunset
-    { hour = 20, clockTime = 20, brightness = -0.2, tintColor = Color3.fromRGB(220, 150, 130), atmosphereColor = Color3.fromRGB(90, 95, 120), atmosphereDensity = 0.38 }, -- near night
-    { hour = 21, clockTime = 21, brightness = -0.3, tintColor = Color3.fromRGB(180, 140, 160), atmosphereColor = Color3.fromRGB(60, 70, 100), atmosphereDensity = 0.40 }, -- night
-    { hour = 22, clockTime = 22, brightness = -0.4, tintColor = Color3.fromRGB(140, 130, 170), atmosphereColor = Color3.fromRGB(40, 50, 90), atmosphereDensity = 0.45 }, -- deep night
+RoundSignalBus.MessageKind = table.freeze({
+    RoundClosure = 'RoundClosure',
+    MazePresence = 'MazePresence',
 })
 
-local TwilightTone = Color3.fromRGB(100, 80, 120)
+local DEFAULT_TOPIC_PREFIX = 'roblox-experience-round-v1'
 
-local function findKeyframePair(hour)
-    local startKF = KEYFRAMES[1]
-    local endKF = KEYFRAMES[#KEYFRAMES]
+local function resolveScopeKey(session)
+    if type(session) ~= 'table' then
+        return nil
+    end
 
-    for i = 1, #KEYFRAMES - 1 do
-        if KEYFRAMES[i].hour <= hour and KEYFRAMES[i + 1].hour >= hour then
-            startKF = KEYFRAMES[i]
-            endKF = KEYFRAMES[i + 1]
+    if type(session.SignalScope) == 'string' and session.SignalScope ~= '' then
+        return session.SignalScope
+    end
+
+    if type(session.SessionId) == 'string' and session.SessionId ~= '' then
+        return session.SessionId
+    end
+
+    return nil
+end
+
+function RoundSignalBus.new(options)
+    local resolved = options or {}
+
+    return setmetatable({
+        MessagingService = resolved.MessagingService or MessagingService,
+        TopicPrefix = resolved.TopicPrefix or DEFAULT_TOPIC_PREFIX,
+        Warn = resolved.Warn or warn,
+    }, RoundSignalBus)
+end
+
+function RoundSignalBus:_resolveTopic(session)
+    local scopeKey = resolveScopeKey(session)
+    if scopeKey == nil then
+        return nil
+    end
+
+    return string.format('%s:%s', self.TopicPrefix, scopeKey)
+end
+
+function RoundSignalBus:publish(session, payload)
+    local topic = self:_resolveTopic(session)
+    if topic == nil or type(payload) ~= 'table' then
+        return false, 'MissingSignalScope'
+    end
+
+    local ok, result = pcall(function()
+        self.MessagingService:PublishAsync(topic, payload)
+    end)
+
+    if not ok then
+        self.Warn(string.format('[RoundSignalBus] publish failed: %s', tostring(result)))
+        return false, tostring(result)
+    end
+
+    return true
+end
+
+function RoundSignalBus:subscribe(session, handler)
+    local topic = self:_resolveTopic(session)
+    if topic == nil or type(handler) ~= 'function' then
+        return nil, false, 'MissingSignalScope'
+    end
+
+    local ok, result = pcall(function()
+        return self.MessagingService:SubscribeAsync(topic, function(message)
+            local data = message and message.Data
+            if type(data) == 'table' then
+                handler(data)
+            end
+        end)
+    end)
+
+    if not ok then
+        self.Warn(string.format('[RoundSignalBus] subscribe failed: %s', tostring(result)))
+        return nil, false, tostring(result)
+    end
+
+    return result, true
+end
+
+return RoundSignalBus
+]]></string>
+            </Properties>
+          </Item>
+          <Item class="ModuleScript" referent="102">
+            <Properties>
+              <string name="Name">TODProfile</string>
+              <string name="Source"><![CDATA[local TODProfile = {}
+
+TODProfile.LightingPropertyNames = table.freeze({
+    'Brightness',
+    'ClockTime',
+    'ExposureCompensation',
+    'ShadowSoftness',
+    'Ambient',
+    'OutdoorAmbient',
+    'EnvironmentDiffuseScale',
+    'EnvironmentSpecularScale',
+})
+
+TODProfile.AtmospherePropertyNames = table.freeze({
+    'Color',
+    'Decay',
+    'Density',
+    'Glare',
+    'Haze',
+    'Offset',
+})
+
+TODProfile.ColorGradingPropertyNames = table.freeze({
+    'Brightness',
+    'Contrast',
+    'Saturation',
+    'TintColor',
+})
+
+TODProfile.Keyframes = table.freeze({
+    {
+        Hour = 7,
+        Lighting = table.freeze({
+            Brightness = 1.9,
+            ClockTime = 7,
+            ExposureCompensation = -0.15,
+            ShadowSoftness = 0.2,
+            Ambient = Color3.fromRGB(70, 72, 76),
+            OutdoorAmbient = Color3.fromRGB(90, 94, 100),
+            EnvironmentDiffuseScale = 0.45,
+            EnvironmentSpecularScale = 0.25,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(199, 171, 140),
+            Decay = Color3.fromRGB(111, 94, 80),
+            Density = 0.28,
+            Glare = 0.05,
+            Haze = 1.8,
+            Offset = -0.15,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = -0.02,
+            Contrast = 0.06,
+            Saturation = -0.08,
+            TintColor = Color3.fromRGB(255, 232, 214),
+        }),
+    },
+    {
+        Hour = 10,
+        Lighting = table.freeze({
+            Brightness = 2.05,
+            ClockTime = 10,
+            ExposureCompensation = -0.02,
+            ShadowSoftness = 0.24,
+            Ambient = Color3.fromRGB(94, 98, 106),
+            OutdoorAmbient = Color3.fromRGB(124, 132, 142),
+            EnvironmentDiffuseScale = 0.5,
+            EnvironmentSpecularScale = 0.3,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(182, 196, 216),
+            Decay = Color3.fromRGB(116, 130, 154),
+            Density = 0.22,
+            Glare = 0.08,
+            Haze = 1.1,
+            Offset = -0.08,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = 0.01,
+            Contrast = 0.1,
+            Saturation = -0.02,
+            TintColor = Color3.fromRGB(238, 244, 255),
+        }),
+    },
+    {
+        Hour = 13,
+        Lighting = table.freeze({
+            Brightness = 2.2,
+            ClockTime = 13,
+            ExposureCompensation = 0.08,
+            ShadowSoftness = 0.28,
+            Ambient = Color3.fromRGB(110, 116, 128),
+            OutdoorAmbient = Color3.fromRGB(148, 160, 174),
+            EnvironmentDiffuseScale = 0.58,
+            EnvironmentSpecularScale = 0.34,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(166, 198, 235),
+            Decay = Color3.fromRGB(127, 155, 191),
+            Density = 0.18,
+            Glare = 0.12,
+            Haze = 0.65,
+            Offset = -0.04,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = 0.03,
+            Contrast = 0.14,
+            Saturation = 0.02,
+            TintColor = Color3.fromRGB(255, 255, 255),
+        }),
+    },
+    {
+        Hour = 16,
+        Lighting = table.freeze({
+            Brightness = 2.08,
+            ClockTime = 16,
+            ExposureCompensation = 0.02,
+            ShadowSoftness = 0.3,
+            Ambient = Color3.fromRGB(102, 100, 108),
+            OutdoorAmbient = Color3.fromRGB(142, 136, 146),
+            EnvironmentDiffuseScale = 0.55,
+            EnvironmentSpecularScale = 0.31,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(214, 189, 156),
+            Decay = Color3.fromRGB(164, 128, 102),
+            Density = 0.21,
+            Glare = 0.09,
+            Haze = 0.95,
+            Offset = -0.08,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = 0.01,
+            Contrast = 0.12,
+            Saturation = -0.02,
+            TintColor = Color3.fromRGB(255, 238, 214),
+        }),
+    },
+    {
+        Hour = 19,
+        Lighting = table.freeze({
+            Brightness = 1.72,
+            ClockTime = 19,
+            ExposureCompensation = -0.22,
+            ShadowSoftness = 0.34,
+            Ambient = Color3.fromRGB(74, 64, 82),
+            OutdoorAmbient = Color3.fromRGB(104, 92, 118),
+            EnvironmentDiffuseScale = 0.42,
+            EnvironmentSpecularScale = 0.24,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(170, 125, 134),
+            Decay = Color3.fromRGB(84, 62, 97),
+            Density = 0.28,
+            Glare = 0.04,
+            Haze = 1.45,
+            Offset = -0.16,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = -0.03,
+            Contrast = 0.16,
+            Saturation = -0.08,
+            TintColor = Color3.fromRGB(238, 214, 255),
+        }),
+    },
+    {
+        Hour = 22,
+        Lighting = table.freeze({
+            Brightness = 1.34,
+            ClockTime = 22,
+            ExposureCompensation = -0.45,
+            ShadowSoftness = 0.38,
+            Ambient = Color3.fromRGB(36, 38, 56),
+            OutdoorAmbient = Color3.fromRGB(54, 58, 86),
+            EnvironmentDiffuseScale = 0.26,
+            EnvironmentSpecularScale = 0.18,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(88, 100, 136),
+            Decay = Color3.fromRGB(24, 28, 42),
+            Density = 0.34,
+            Glare = 0.02,
+            Haze = 2.1,
+            Offset = -0.22,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = -0.08,
+            Contrast = 0.18,
+            Saturation = -0.14,
+            TintColor = Color3.fromRGB(208, 220, 255),
+        }),
+    },
+})
+
+local function lerpValue(leftValue, rightValue, alpha)
+    local leftType = typeof(leftValue)
+    if leftType == 'Color3' then
+        return leftValue:Lerp(rightValue, alpha)
+    end
+
+    if leftType == 'number' then
+        return leftValue + ((rightValue - leftValue) * alpha)
+    end
+
+    if alpha >= 1 then
+        return rightValue
+    end
+
+    return leftValue
+end
+
+local function interpolateTable(leftTable, rightTable, alpha)
+    local resolved = {}
+
+    for propertyName, leftValue in pairs(leftTable) do
+        resolved[propertyName] = lerpValue(leftValue, rightTable[propertyName], alpha)
+    end
+
+    return resolved
+end
+
+function TODProfile.getDurationSeconds(config)
+    return math.max(0, math.floor((config.RoundMinutes or 0) * 60 + 0.5))
+end
+
+function TODProfile.evaluate(config, elapsedRoundSeconds)
+    local startHour = config.StartHour or 7
+    local endHour = config.EndHour or 22
+    local durationSeconds = TODProfile.getDurationSeconds(config)
+    local clampedElapsed = math.clamp(elapsedRoundSeconds or 0, 0, durationSeconds)
+    local progress = if durationSeconds <= 0 then 1 else clampedElapsed / durationSeconds
+    local currentHour = startHour + ((endHour - startHour) * progress)
+
+    local leftKeyframe = TODProfile.Keyframes[1]
+    local rightKeyframe = TODProfile.Keyframes[#TODProfile.Keyframes]
+
+    for keyframeIndex = 1, #TODProfile.Keyframes - 1 do
+        local candidateLeft = TODProfile.Keyframes[keyframeIndex]
+        local candidateRight = TODProfile.Keyframes[keyframeIndex + 1]
+
+        if currentHour <= candidateRight.Hour then
+            leftKeyframe = candidateLeft
+            rightKeyframe = candidateRight
             break
         end
     end
 
-    return startKF, endKF
-end
-
-local function lerpNumber(a, b, t)
-    return a + (b - a) * t
-end
-
-local function lerpColor(a, b, t)
-    return a:Lerp(b, t)
-end
-
-local TODProfile = {}
-
--- Interpolate a profile for a given game hour (float, 7.0 ~ 22.0)
-function TODProfile.interpolateForHour(hour)
-    local startKF, endKF = findKeyframePair(hour)
-    local span = endKF.hour - startKF.hour
-    local t = 0
-    if span > 0 then
-        t = math.clamp((hour - startKF.hour) / span, 0, 1)
-    end
+    local frameSpan = math.max(rightKeyframe.Hour - leftKeyframe.Hour, 0.0001)
+    local frameAlpha = math.clamp((currentHour - leftKeyframe.Hour) / frameSpan, 0, 1)
+    local lighting = interpolateTable(leftKeyframe.Lighting, rightKeyframe.Lighting, frameAlpha)
+    lighting.ClockTime = currentHour
 
     return {
-        clockTime = lerpNumber(startKF.clockTime, endKF.clockTime, t),
-        brightness = lerpNumber(startKF.brightness, endKF.brightness, t),
-        tintColor = lerpColor(startKF.tintColor, endKF.tintColor, t),
-        atmosphereColor = lerpColor(startKF.atmosphereColor, endKF.atmosphereColor, t),
-        atmosphereDensity = lerpNumber(startKF.atmosphereDensity, endKF.atmosphereDensity, t),
+        ClockTime = currentHour,
+        ElapsedRoundSeconds = clampedElapsed,
+        RoundTimeRemainingSeconds = math.max(0, durationSeconds - clampedElapsed),
+        Progress = progress,
+        Lighting = lighting,
+        Atmosphere = interpolateTable(
+            leftKeyframe.Atmosphere,
+            rightKeyframe.Atmosphere,
+            frameAlpha
+        ),
+        ColorGrading = interpolateTable(
+            leftKeyframe.ColorGrading,
+            rightKeyframe.ColorGrading,
+            frameAlpha
+        ),
     }
-end
-
--- Apply interpolated profile to Lighting + Atmosphere + ColorCorrection
-function TODProfile.apply(lighting, profile)
-    lighting.ClockTime = profile.clockTime
-
-    local atmosphere = lighting:FindFirstChild(EFFECT_NAME_ATMOSPHERE)
-    if not atmosphere then
-        atmosphere = Instance.new('Atmosphere')
-        atmosphere.Name = EFFECT_NAME_ATMOSPHERE
-        atmosphere.Parent = lighting
-    end
-    atmosphere.Color = profile.atmosphereColor
-    atmosphere.Density = profile.atmosphereDensity
-
-    local cc = lighting:FindFirstChild(EFFECT_NAME_COLOR_CORRECTION)
-    if not cc then
-        cc = Instance.new('ColorCorrectionEffect')
-        cc.Name = EFFECT_NAME_COLOR_CORRECTION
-        cc.Parent = lighting
-    end
-    cc.Brightness = profile.brightness
-    cc.TintColor = profile.tintColor
-    cc.Saturation = lerpNumber(-0.15, -0.25, (profile.clockTime - 7) / 15)
-    cc.Contrast = lerpNumber(0.1, 0.05, (profile.clockTime - 7) / 15)
-end
-
--- Given elapsed real minutes, return game hour (float, 7.0 ~ 22.0)
-function TODProfile.gameHourFromElapsedMinutes(elapsedMinutes)
-    local cfg = SessionConfig.TOD
-    local totalHours = cfg.EndHour - cfg.StartHour -- 15
-    local minuteFraction = elapsedMinutes / 60
-    local hour = cfg.StartHour + totalHours * minuteFraction
-    return math.clamp(hour, cfg.StartHour, cfg.EndHour)
-end
-
--- Given elapsed real minutes, return remaining real seconds
-function TODProfile.remainingSeconds(elapsedSeconds)
-    local cfg = SessionConfig.TOD
-    local totalSeconds = cfg.RoundMinutes * 60
-    return math.max(0, totalSeconds - elapsedSeconds)
 end
 
 return TODProfile
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="94">
+          <Item class="ModuleScript" referent="103">
             <Properties>
               <string name="Name">TODService</string>
-              <string name="Source"><![CDATA[-- TODService.luau
--- Server-side Time-of-Day service.
--- Manages the round timer and drives Lighting.ClockTime + Atmosphere + ColorCorrection
--- via TODProfile. Broadcasts RoundTimeRemaining + GameHour to clients each heartbeat.
+              <string name="Source"><![CDATA[local Lighting = game:GetService('Lighting')
 
-local RunService = game:GetService('RunService')
-local ReplicatedStorage = game:GetService('ReplicatedStorage')
-
-local SessionConfig = require(script.Parent.Parent.Config.SessionConfig)
-local TODProfile = require(script.Parent.Parent.Runtime.TODProfile)
-
-local REMOTE_NAME = 'TODState'
+local TODProfile = require(script.Parent.TODProfile)
 
 local TODService = {}
 TODService.__index = TODService
 
-function TODService.new()
-    return setmetatable({
-        elapsedSeconds = 0,
-        isRunning = false,
-        _heartbeat = nil,
-        _remote = nil,
-    }, TODService)
+TODService.ManagedNames = table.freeze({
+    Atmosphere = 'RunTODAtmosphere',
+    ColorGrading = 'RunTODColorGrading',
+})
+
+TODService.UpdateIntervalSeconds = 0.5
+
+local function getDisplayClockMinute(clockTime)
+    return math.floor(((clockTime or 0) % 24) * 60 + 0.5)
 end
 
-function TODService:_getOrCreateRemote()
-    if self._remote then
-        return self._remote
+local function getDisplayRemainingSeconds(remainingSeconds)
+    return math.max(0, math.floor((remainingSeconds or 0) + 0.5))
+end
+
+local function copyProperties(instance, propertyNames)
+    local snapshot = {}
+
+    if instance == nil then
+        return snapshot
     end
-    local container = ReplicatedStorage:FindFirstChild('Remotes')
-        or ReplicatedStorage:WaitForChild('Remotes', 5)
-    if not container then
-        warn('[TODService] Remotes container not found')
-        return nil
+
+    for _, propertyName in ipairs(propertyNames) do
+        local ok, value = pcall(function()
+            return instance[propertyName]
+        end)
+        if ok then
+            snapshot[propertyName] = value
+        end
     end
-    self._remote = container:FindFirstChild(REMOTE_NAME)
-    if not self._remote then
-        self._remote = Instance.new('RemoteEvent')
-        self._remote.Name = REMOTE_NAME
-        self._remote.Parent = container
+
+    return snapshot
+end
+
+local function applyProperties(instance, properties)
+    for propertyName, value in pairs(properties) do
+        pcall(function()
+            instance[propertyName] = value
+        end)
     end
-    return self._remote
+end
+
+local function destroyIfAlive(instance)
+    if instance and instance.Parent ~= nil then
+        instance:Destroy()
+    end
+end
+
+local function isColorGradingTarget(instance)
+    return instance:IsA('ColorGradingEffect') or instance:IsA('ColorCorrectionEffect')
+end
+
+local function createManagedColorGrading(name)
+    local created, instance = pcall(Instance.new, 'ColorGradingEffect')
+    if created and instance then
+        instance.Name = name
+        return instance
+    end
+
+    instance = Instance.new('ColorCorrectionEffect')
+    instance.Name = name
+    return instance
+end
+
+local function resolveAtmosphereTarget(lightingRoot, managedName)
+    local managed = lightingRoot:FindFirstChild(managedName)
+
+    for _, child in ipairs(lightingRoot:GetChildren()) do
+        if child:IsA('Atmosphere') and child.Name ~= managedName then
+            return child, false
+        end
+    end
+
+    if managed and managed:IsA('Atmosphere') then
+        return managed, false
+    end
+
+    local created = Instance.new('Atmosphere')
+    created.Name = managedName
+    created.Parent = lightingRoot
+    return created, true
+end
+
+local function resolveColorGradingTarget(lightingRoot, managedName)
+    local namedColorGrading = lightingRoot:FindFirstChild('ColorGrading')
+    if namedColorGrading and isColorGradingTarget(namedColorGrading) then
+        return namedColorGrading, false
+    end
+
+    for _, child in ipairs(lightingRoot:GetChildren()) do
+        if child.Name ~= managedName and isColorGradingTarget(child) then
+            return child, false
+        end
+    end
+
+    local managed = lightingRoot:FindFirstChild(managedName)
+    if managed and isColorGradingTarget(managed) then
+        return managed, false
+    end
+
+    local created = createManagedColorGrading(managedName)
+    created.Parent = lightingRoot
+    return created, true
+end
+
+function TODService.new(options)
+    local runtimeOptions = options or {}
+    local self = setmetatable({}, TODService)
+
+    self.Config = runtimeOptions.Config or {}
+    self.Lighting = runtimeOptions.Lighting or Lighting
+    self.Remote = runtimeOptions.Remote
+    self.Clock = runtimeOptions.Clock or os.clock
+    self.Profile = runtimeOptions.Profile or TODProfile
+    self.UpdateIntervalSeconds = runtimeOptions.UpdateIntervalSeconds
+        or TODService.UpdateIntervalSeconds
+    self.ManagedNames = runtimeOptions.ManagedNames or TODService.ManagedNames
+    self.Initialized = false
+    self.Baseline = nil
+    self.Targets = nil
+    self.CurrentState = nil
+    self.IsRunning = false
+    self.StartedAtClock = nil
+    self.LoopThread = nil
+    self.LoopToken = 0
+    self.LastBroadcastSignature = nil
+
+    return self
+end
+
+function TODService:_ensureTargets()
+    if self.Targets ~= nil then
+        return self.Targets
+    end
+
+    local atmosphere, createdAtmosphere =
+        resolveAtmosphereTarget(self.Lighting, self.ManagedNames.Atmosphere)
+    local colorGrading, createdColorGrading =
+        resolveColorGradingTarget(self.Lighting, self.ManagedNames.ColorGrading)
+
+    self.Targets = {
+        Atmosphere = atmosphere,
+        ColorGrading = colorGrading,
+        CreatedAtmosphere = createdAtmosphere,
+        CreatedColorGrading = createdColorGrading,
+    }
+
+    return self.Targets
+end
+
+function TODService:_captureBaseline()
+    if self.Baseline ~= nil then
+        return self.Baseline
+    end
+
+    local targets = self:_ensureTargets()
+    self.Baseline = {
+        Lighting = copyProperties(self.Lighting, self.Profile.LightingPropertyNames),
+        Atmosphere = copyProperties(targets.Atmosphere, self.Profile.AtmospherePropertyNames),
+        ColorGrading = copyProperties(targets.ColorGrading, self.Profile.ColorGradingPropertyNames),
+    }
+
+    return self.Baseline
+end
+
+function TODService:_restoreTargets()
+    if self.Targets == nil or self.Baseline == nil then
+        return
+    end
+
+    local targets = self.Targets
+
+    if targets.CreatedAtmosphere then
+        destroyIfAlive(targets.Atmosphere)
+    else
+        applyProperties(targets.Atmosphere, self.Baseline.Atmosphere)
+    end
+
+    if targets.CreatedColorGrading then
+        destroyIfAlive(targets.ColorGrading)
+    else
+        applyProperties(targets.ColorGrading, self.Baseline.ColorGrading)
+    end
+end
+
+function TODService:_buildPayload(snapshot, isRunning)
+    return {
+        ClockTime = snapshot.ClockTime,
+        RoundTimeRemainingSeconds = snapshot.RoundTimeRemainingSeconds,
+        ElapsedRoundSeconds = snapshot.ElapsedRoundSeconds,
+        IsRunning = isRunning,
+    }
+end
+
+function TODService:_applySnapshot(snapshot)
+    local targets = self:_ensureTargets()
+    applyProperties(self.Lighting, snapshot.Lighting)
+    applyProperties(targets.Atmosphere, snapshot.Atmosphere)
+    applyProperties(targets.ColorGrading, snapshot.ColorGrading)
+end
+
+function TODService:_buildDisplaySignature(payload)
+    return string.format(
+        '%d:%d:%s',
+        getDisplayClockMinute(payload.ClockTime),
+        getDisplayRemainingSeconds(payload.RoundTimeRemainingSeconds),
+        tostring(payload.IsRunning == true)
+    )
+end
+
+function TODService:_emit(payload, forceBroadcast)
+    self.CurrentState = payload
+
+    local shouldBroadcast = forceBroadcast == true
+    local nextSignature = self:_buildDisplaySignature(payload)
+    if not shouldBroadcast then
+        shouldBroadcast = self.LastBroadcastSignature ~= nextSignature
+    end
+
+    if shouldBroadcast and self.Remote and type(self.Remote.FireAllClients) == 'function' then
+        self.Remote:FireAllClients(payload)
+    end
+
+    if shouldBroadcast then
+        self.LastBroadcastSignature = nextSignature
+    end
+end
+
+function TODService:sendToPlayer(player)
+    if self.CurrentState == nil then
+        return
+    end
+
+    if self.Remote and type(self.Remote.FireClient) == 'function' then
+        self.Remote:FireClient(player, self.CurrentState)
+    end
+end
+
+function TODService:prime()
+    self:_captureBaseline()
+
+    local snapshot = self.Profile.evaluate(self.Config, 0)
+    self:_applySnapshot(snapshot)
+
+    local payload = self:_buildPayload(snapshot, false)
+    self:_emit(payload, true)
+    self.Initialized = true
+
+    return payload
 end
 
 function TODService:start()
-    if self.isRunning then
-        return
+    if self.IsRunning then
+        return self.CurrentState
     end
-    self.elapsedSeconds = 0
-    self.isRunning = true
 
-    self:_getOrCreateRemote()
+    if not self.Initialized then
+        self:prime()
+    end
 
-    -- Apply immediately at start
-    self:_applyTOD()
+    self.IsRunning = true
+    self.StartedAtClock = self.Clock()
+    self.LoopToken += 1
 
-    self._heartbeat = RunService.Heartbeat:Connect(function(dt)
-        if not self.isRunning then
-            return
+    local activeLoopToken = self.LoopToken
+    self:step(self.StartedAtClock)
+
+    self.LoopThread = task.spawn(function()
+        while self.IsRunning and self.LoopToken == activeLoopToken do
+            task.wait(self.UpdateIntervalSeconds)
+            self:step(self.Clock())
         end
-        self.elapsedSeconds += dt
-        self:_applyTOD()
-        self:_broadcast()
     end)
+
+    return self.CurrentState
+end
+
+function TODService:step(nowSeconds)
+    if not self.Initialized then
+        self:prime()
+    end
+
+    local effectiveNow = nowSeconds or self.Clock()
+    local elapsedSeconds = 0
+    if self.StartedAtClock ~= nil then
+        elapsedSeconds = math.max(0, effectiveNow - self.StartedAtClock)
+    end
+
+    local snapshot = self.Profile.evaluate(self.Config, elapsedSeconds)
+    self:_applySnapshot(snapshot)
+
+    local durationSeconds = self.Profile.getDurationSeconds(self.Config)
+    local isStillRunning = self.IsRunning and elapsedSeconds < durationSeconds
+    local payload = self:_buildPayload(snapshot, isStillRunning)
+    self:_emit(payload)
+
+    if self.IsRunning and not isStillRunning then
+        self.IsRunning = false
+        self.LoopToken += 1
+    end
+
+    return payload
 end
 
 function TODService:stop()
-    self.isRunning = false
-    if self._heartbeat then
-        self._heartbeat:Disconnect()
-        self._heartbeat = nil
-    end
+    self.IsRunning = false
+    self.LoopToken += 1
+    return self.CurrentState
 end
 
-function TODService:reset()
+function TODService:restore()
     self:stop()
-    self.elapsedSeconds = 0
-end
 
-function TODService:getElapsedSeconds()
-    return self.elapsedSeconds
-end
-
-function TODService:getGameHour()
-    local elapsedMinutes = self.elapsedSeconds / 60
-    return TODProfile.gameHourFromElapsedMinutes(elapsedMinutes)
-end
-
-function TODService:getRemainingSeconds()
-    return TODProfile.remainingSeconds(self.elapsedSeconds)
-end
-
-function TODService:_applyTOD()
-    local hour = self:getGameHour()
-    local profile = TODProfile.interpolateForHour(hour)
-    TODProfile.apply(game:GetService('Lighting'), profile)
-end
-
-function TODService:_broadcast()
-    local remote = self:_getOrCreateRemote()
-    if not remote then
+    if self.Baseline == nil then
         return
     end
-    local totalSeconds = SessionConfig.TOD.RoundMinutes * 60
-    local remaining = math.max(0, totalSeconds - self.elapsedSeconds)
-    local gameHour = self:getGameHour()
-    remote:FireAllClients({
-        GameHour = gameHour,
-        RoundTimeRemaining = remaining,
-        ElapsedSeconds = self.elapsedSeconds,
-    })
+
+    applyProperties(self.Lighting, self.Baseline.Lighting)
+    self:_restoreTargets()
+    self.Targets = nil
+    self.CurrentState = nil
+    self.Initialized = false
+    self.StartedAtClock = nil
+    self.Baseline = nil
+    self.LastBroadcastSignature = nil
+end
+
+function TODService:destroy()
+    self:restore()
 end
 
 return TODService
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="95">
+          <Item class="ModuleScript" referent="104">
             <Properties>
               <string name="Name">TeleportInventoryHydrator</string>
               <string name="Source"><![CDATA[local TeleportInventoryHydrator = {}
@@ -12236,7 +13017,7 @@ return TeleportInventoryHydrator
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="96">
+        <Item class="ModuleScript" referent="105">
           <Properties>
             <string name="Name">Session</string>
             <string name="Source"><![CDATA[return {
@@ -12247,7 +13028,7 @@ return TeleportInventoryHydrator
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="97">
+          <Item class="ModuleScript" referent="106">
             <Properties>
               <string name="Name">CampMazeSessionContract</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -12416,7 +13197,16 @@ function CampMazeSessionContract.normalizeCampSession(session)
     local normalized = {
         SessionId = session and session.SessionId or 'local-debug-camp',
         CampAccessCode = session and session.CampAccessCode or 'local-debug-camp',
+        SignalScope = session and session.SignalScope or nil,
+        HostUserId = session and session.HostUserId or nil,
         GateOpen = session ~= nil and session.GateOpen == true or false,
+        RoundStarted = session ~= nil and session.RoundStarted == true or false,
+        DangerActive = session ~= nil and session.DangerActive == true or false,
+        RoundStartTime = session and session.RoundStartTime or nil,
+        RoundEndTime = session and session.RoundEndTime or nil,
+        SettlementReason = session and session.SettlementReason or nil,
+        SettlementTriggeredByUserId = session and session.SettlementTriggeredByUserId or nil,
+        SettlementTriggeredByName = session and session.SettlementTriggeredByName or nil,
         MazeStatus = session and session.MazeStatus or MAZE_STATUS.Idle,
         MazeAccessCode = session and session.MazeAccessCode or nil,
         PlayersInMaze = cloneArray(session and session.PlayersInMaze or {}),
@@ -12426,7 +13216,7 @@ function CampMazeSessionContract.normalizeCampSession(session)
 
     sortPlayers(normalized.PlayersInMaze)
     sortSummaries(normalized.ReturnedPlayerSummaries)
-    normalized.SessionPhase = SessionPhase.resolveFromCampSession(session or normalized)
+    normalized.SessionPhase = SessionPhase.resolveFromCampSession(normalized)
 
     return normalized
 end
@@ -12482,7 +13272,47 @@ function CampMazeSessionContract.buildReturnSummary(params)
         Weight = params.Weight or 0,
         WasExtracted = params.WasExtracted == true,
         WasSettled = params.WasSettled == true,
+        CountedInSettlement = params.CountedInSettlement ~= false,
     }
+end
+
+function CampMazeSessionContract.assignHost(session, hostUserId)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    nextSession.HostUserId = if type(hostUserId) == 'number' then hostUserId else nil
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
+end
+
+function CampMazeSessionContract.markRoundStarted(session, params)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    local resolved = params or {}
+
+    nextSession.HostUserId = resolved.HostUserId or nextSession.HostUserId
+    nextSession.GateOpen = true
+    nextSession.RoundStarted = true
+    nextSession.DangerActive = resolved.DangerActive ~= false
+    nextSession.RoundStartTime = resolved.RoundStartTime
+    nextSession.RoundEndTime = resolved.RoundEndTime
+    nextSession.SettlementReason = nil
+    nextSession.SettlementTriggeredByUserId = nil
+    nextSession.SettlementTriggeredByName = nil
+    nextSession.SessionClosed = false
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
+end
+
+function CampMazeSessionContract.markSettlementTriggered(session, params)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    local resolved = params or {}
+
+    nextSession.GateOpen = false
+    nextSession.RoundStarted = false
+    nextSession.DangerActive = false
+    nextSession.SettlementReason = resolved.SettlementReason or 'settlement'
+    nextSession.SettlementTriggeredByUserId = resolved.TriggeredByUserId
+    nextSession.SettlementTriggeredByName = resolved.TriggeredByName
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
 end
 
 function CampMazeSessionContract.markPlayerEntered(session, player)
@@ -12512,6 +13342,7 @@ function CampMazeSessionContract.markPlayerEntered(session, player)
     nextSession.ReturnedPlayerSummaries = nextSummaries
 
     nextSession.MazeStatus = MAZE_STATUS.Active
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
 
     return nextSession
 end
@@ -12541,6 +13372,7 @@ function CampMazeSessionContract.prunePlayer(session, userId, options)
     sortSummaries(nextSummaries)
     nextSession.ReturnedPlayerSummaries = nextSummaries
     updateMazeStatus(nextSession)
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
 
     return nextSession
 end
@@ -12576,7 +13408,56 @@ function CampMazeSessionContract.applyReturn(session, summary, mazeCompleted)
         updateMazeStatus(nextSession)
     end
 
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+
     return nextSession
+end
+
+function CampMazeSessionContract.resetForNextRound(session)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+
+    nextSession.GateOpen = false
+    nextSession.RoundStarted = false
+    nextSession.DangerActive = false
+    nextSession.RoundStartTime = nil
+    nextSession.RoundEndTime = nil
+    nextSession.SettlementReason = nil
+    nextSession.SettlementTriggeredByUserId = nil
+    nextSession.SettlementTriggeredByName = nil
+    nextSession.MazeStatus = MAZE_STATUS.Idle
+    nextSession.MazeAccessCode = nil
+    nextSession.PlayersInMaze = {}
+    nextSession.ReturnedPlayerSummaries = {}
+    nextSession.SessionClosed = false
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+
+    return nextSession
+end
+
+function CampMazeSessionContract.buildLobbyToRunTeleportData(params)
+    return {
+        SessionConfig = cloneTable(params.SessionConfig),
+        CampSession = CampMazeSessionContract.newCampSession({
+            SessionId = params.SessionId,
+            CampAccessCode = params.CampAccessCode,
+            SignalScope = params.SignalScope,
+            GateOpen = false,
+            RoundStarted = false,
+            DangerActive = false,
+            MazeStatus = MAZE_STATUS.Idle,
+            MazeAccessCode = nil,
+            PlayersInMaze = {},
+            ReturnedPlayerSummaries = {},
+        }),
+        Entry = {
+            Kind = 'LobbyLaunch',
+        },
+        PlayerInventories = {},
+    }
+end
+
+function CampMazeSessionContract.buildLobbyToCampTeleportData(params)
+    return CampMazeSessionContract.buildLobbyToRunTeleportData(params)
 end
 
 function CampMazeSessionContract.closeCampSession(session)
@@ -12681,7 +13562,7 @@ return CampMazeSessionContract
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="98">
+          <Item class="ModuleScript" referent="107">
             <Properties>
               <string name="Name">MazeEntryAvailability</string>
               <string name="Source"><![CDATA[local MazeEntryAvailability = {}
@@ -12730,7 +13611,7 @@ return MazeEntryAvailability
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="99">
+          <Item class="ModuleScript" referent="108">
             <Properties>
               <string name="Name">SessionPhase</string>
               <string name="Source"><![CDATA[local SessionPhase = table.freeze({
@@ -12745,6 +13626,9 @@ function SessionPhase.resolveFromCampSession(session)
     local normalizedSession = if type(session) == 'table' then session else {}
     local mazeStatus = normalizedSession.MazeStatus
     local gateOpen = normalizedSession.GateOpen == true
+    local roundStarted = normalizedSession.RoundStarted == true
+    local dangerActive = normalizedSession.DangerActive == true
+    local settlementReason = normalizedSession.SettlementReason
     local returnedSummaries = normalizedSession.ReturnedPlayerSummaries or {}
     local playersInMaze = normalizedSession.PlayersInMaze or {}
 
@@ -12756,11 +13640,15 @@ function SessionPhase.resolveFromCampSession(session)
         return SessionPhase.MazeActive
     end
 
+    if type(settlementReason) == 'string' and settlementReason ~= '' then
+        return SessionPhase.Debrief
+    end
+
     if mazeStatus == 'completed' or #returnedSummaries > 0 then
         return SessionPhase.Debrief
     end
 
-    if gateOpen then
+    if gateOpen or roundStarted or dangerActive then
         return SessionPhase.RunField
     end
 
@@ -12771,7 +13659,7 @@ return SessionPhase
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="100">
+          <Item class="ModuleScript" referent="109">
             <Properties>
               <string name="Name">SessionSeedPolicy</string>
               <string name="Source"><![CDATA[local SessionSeedPolicy = {}
@@ -12807,61 +13695,56 @@ return SessionSeedPolicy
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="101">
+        <Item class="ModuleScript" referent="110">
           <Properties>
             <string name="Name">Util</string>
             <string name="Source"><![CDATA[return {
+    HostPolicy = require(script.HostPolicy),
     TeleportDiagnostics = require(script.TeleportDiagnostics),
     Visibility = require(script.Visibility),
-    HostPolicy = require(script.HostPolicy),
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="102">
+          <Item class="ModuleScript" referent="111">
             <Properties>
               <string name="Name">HostPolicy</string>
-              <string name="Source"><![CDATA[-- HostPolicy.luau
--- Deterministic host (party leader) assignment policy for a run session.
+              <string name="Source"><![CDATA[-- Deterministic host assignment for the run waiting phase.
 -- Rules:
---  1. First player to join becomes the initial host.
---  2. Host leaving → randomly reassign from remaining players.
---  3. Empty session → no host (nil).
+--  1. The first waiting player becomes host.
+--  2. If the host leaves, promote the next waiting player still present.
+--  3. An empty waiting roster has no host.
 
 local HostPolicy = {}
 
-function HostPolicy.assignHost(players, currentHostUserId)
-    if #players == 0 then
+function HostPolicy.assignHost(waitingPlayerOrderUserIds, currentHostUserId)
+    if #waitingPlayerOrderUserIds == 0 then
         return nil
     end
 
-    -- If current host is still present, keep them
-    if currentHostUserId ~= nil then
-        for _, player in ipairs(players) do
-            if player.UserId == currentHostUserId then
-                return currentHostUserId
-            end
+    if HostPolicy.isValidHost(currentHostUserId, waitingPlayerOrderUserIds) then
+        return currentHostUserId
+    end
+
+    for _, userId in ipairs(waitingPlayerOrderUserIds) do
+        if type(userId) == 'number' then
+            return userId
         end
     end
 
-    -- No valid host; pick deterministically by lowest UserId
-    local candidate = players[1]
-    for _, player in ipairs(players) do
-        if player.UserId < candidate.UserId then
-            candidate = player
-        end
-    end
-    return candidate.UserId
+    return nil
 end
 
-function HostPolicy.isValidHost(hostUserId, players)
+function HostPolicy.isValidHost(hostUserId, waitingPlayerOrderUserIds)
     if hostUserId == nil then
         return false
     end
-    for _, player in ipairs(players) do
-        if player.UserId == hostUserId then
+
+    for _, userId in ipairs(waitingPlayerOrderUserIds) do
+        if userId == hostUserId then
             return true
         end
     end
+
     return false
 end
 
@@ -12869,7 +13752,7 @@ return HostPolicy
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="103">
+          <Item class="ModuleScript" referent="112">
             <Properties>
               <string name="Name">TeleportDiagnostics</string>
               <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -12966,7 +13849,7 @@ return TeleportDiagnostics
 ]]></string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="104">
+          <Item class="ModuleScript" referent="113">
             <Properties>
               <string name="Name">Visibility</string>
               <string name="Source"><![CDATA[local Visibility = {}
@@ -13000,7 +13883,7 @@ return Visibility
           </Item>
         </Item>
       </Item>
-      <Item class="ModuleScript" referent="105">
+      <Item class="ModuleScript" referent="114">
         <Properties>
           <string name="Name">UI</string>
           <string name="Source"><![CDATA[return {
@@ -13008,7 +13891,7 @@ return Visibility
 }
 ]]></string>
         </Properties>
-        <Item class="ModuleScript" referent="106">
+        <Item class="ModuleScript" referent="115">
           <Properties>
             <string name="Name">Hud</string>
             <string name="Source"><![CDATA[return {
@@ -13016,7 +13899,7 @@ return Visibility
 }
 ]]></string>
           </Properties>
-          <Item class="ModuleScript" referent="107">
+          <Item class="ModuleScript" referent="116">
             <Properties>
               <string name="Name">Theme</string>
               <string name="Source"><![CDATA[return {
@@ -13035,11 +13918,11 @@ return Visibility
       </Item>
     </Item>
   </Item>
-  <Item class="ServerScriptService" referent="108">
+  <Item class="ServerScriptService" referent="117">
     <Properties>
       <string name="Name">ServerScriptService</string>
     </Properties>
-    <Item class="Script" referent="109">
+    <Item class="Script" referent="118">
       <Properties>
         <string name="Name">Bootstrap</string>
         <token name="RunContext">0</token>
@@ -13056,11 +13939,11 @@ RunSessionService.new():start()
 ]]></string>
       </Properties>
     </Item>
-    <Item class="Folder" referent="110">
+    <Item class="Folder" referent="119">
       <Properties>
         <string name="Name">Run</string>
       </Properties>
-      <Item class="ModuleScript" referent="111">
+      <Item class="ModuleScript" referent="120">
         <Properties>
           <string name="Name">ItemFunctionality</string>
           <string name="Source"><![CDATA[--!strict
@@ -13492,7 +14375,7 @@ return ItemFunctionality
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="112">
+      <Item class="ModuleScript" referent="121">
         <Properties>
           <string name="Name">RunAreaResolver</string>
           <string name="Source"><![CDATA[local RunAreaResolver = {}
@@ -13516,7 +14399,7 @@ return RunAreaResolver
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="113">
+      <Item class="ModuleScript" referent="122">
         <Properties>
           <string name="Name">RunDoor</string>
           <string name="Source"><![CDATA[local RunDoor = {}
@@ -13546,7 +14429,7 @@ return RunDoor
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="114">
+      <Item class="ModuleScript" referent="123">
         <Properties>
           <string name="Name">RunInteractionRegistry</string>
           <string name="Source"><![CDATA[local RunInteractionRegistry = {}
@@ -13566,21 +14449,17 @@ function RunInteractionRegistry:bindScene(scene, handlers)
     self:_track(scene.Terminals.Shop:bind(function(player)
         handlers.OnShop(player)
     end))
-    self:_track(scene.Terminals.Sell:bind(function(player)
-        handlers.OnSell(player)
-    end))
-    self:_track(scene.Terminals.Objective:bind(function(player)
-        handlers.OnObjective(player)
-    end))
-    self:_track(scene.Terminals.Loadout:bind(function(player)
-        handlers.OnLoadout(player)
-    end))
-    self:_track(scene.Terminals.UgcLab:bind(function(player)
-        handlers.OnUgcLab(player)
+    self:_track(scene.Terminals.Book:bind(function(player)
+        handlers.OnBook(player)
     end))
     self:_track(scene.Terminals.Gate:bind(function(player)
         handlers.OnGate(player)
     end))
+    if scene.Terminals.StartGame then
+        self:_track(scene.Terminals.StartGame:bind(function(player)
+            handlers.OnStartGame(player)
+        end))
+    end
     self:_track(scene.MazePortal:bind(function(player)
         handlers.OnMazePortal(player)
     end))
@@ -13609,7 +14488,7 @@ return RunInteractionRegistry
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="115">
+      <Item class="ModuleScript" referent="124">
         <Properties>
           <string name="Name">RunInventoryBridge</string>
           <string name="Source"><![CDATA[--!strict
@@ -13637,7 +14516,7 @@ return RunInventoryBridge
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="116">
+      <Item class="ModuleScript" referent="125">
         <Properties>
           <string name="Name">RunMonsterSpawnPolicy</string>
           <string name="Source"><![CDATA[-- RunMonsterSpawnPolicy.luau
@@ -13696,7 +14575,7 @@ return RunMonsterSpawnPolicy
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="117">
+      <Item class="ModuleScript" referent="126">
         <Properties>
           <string name="Name">RunOceanTrigger</string>
           <string name="Source"><![CDATA[local Players = game:GetService('Players')
@@ -13762,7 +14641,7 @@ return RunOceanTrigger
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="118">
+      <Item class="ModuleScript" referent="127">
         <Properties>
           <string name="Name">RunPortal</string>
           <string name="Source"><![CDATA[local RunPortal = {}
@@ -13804,7 +14683,7 @@ return RunPortal
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="119">
+      <Item class="ModuleScript" referent="128">
         <Properties>
           <string name="Name">RunScene</string>
           <string name="Source"><![CDATA[local RunAreaResolver = require(script.Parent.RunAreaResolver)
@@ -13878,7 +14757,13 @@ end
 local function buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot, terrainMesh)
     local raycastParams = RaycastParams.new()
     raycastParams.FilterType = Enum.RaycastFilterType.Include
-    local instances = { sceneCollisionRoot, shipCollisionRoot }
+    local instances = {}
+    if sceneCollisionRoot then
+        table.insert(instances, sceneCollisionRoot)
+    end
+    if shipCollisionRoot then
+        table.insert(instances, shipCollisionRoot)
+    end
     if terrainMesh and terrainMesh:IsA('BasePart') then
         table.insert(instances, terrainMesh)
     end
@@ -13921,18 +14806,48 @@ function RunScene.new(root)
         error('RunStaticWorld is missing required attribute "OutdoorThresholdZ".', 0)
     end
 
-    local collisionRoot =
-        requireContainer(root, RunStaticWorldContract.CollisionRootName, 'RunStaticWorld')
-    local sceneCollisionRoot = requireContainer(
-        collisionRoot,
-        RunStaticWorldContract.SceneCollisionName,
-        'RunStaticWorld Collision'
-    )
-    local shipCollisionRoot = requireContainer(
-        collisionRoot,
-        RunStaticWorldContract.ShipCollisionName,
-        'RunStaticWorld Collision'
-    )
+    local collisionRoot = root:FindFirstChild(RunStaticWorldContract.CollisionRootName)
+    if collisionRoot and not (collisionRoot:IsA('Folder') or collisionRoot:IsA('Model')) then
+        error(
+            string.format(
+                'RunStaticWorld container "%s" must be a Folder or Model.',
+                RunStaticWorldContract.CollisionRootName
+            ),
+            0
+        )
+    end
+
+    local sceneCollisionRoot = nil
+    local shipCollisionRoot = nil
+    if collisionRoot then
+        sceneCollisionRoot = collisionRoot:FindFirstChild(RunStaticWorldContract.SceneCollisionName)
+        if
+            sceneCollisionRoot
+            and not (sceneCollisionRoot:IsA('Folder') or sceneCollisionRoot:IsA('Model'))
+        then
+            error(
+                string.format(
+                    'RunStaticWorld Collision container "%s" must be a Folder or Model.',
+                    RunStaticWorldContract.SceneCollisionName
+                ),
+                0
+            )
+        end
+
+        shipCollisionRoot = collisionRoot:FindFirstChild(RunStaticWorldContract.ShipCollisionName)
+        if
+            shipCollisionRoot
+            and not (shipCollisionRoot:IsA('Folder') or shipCollisionRoot:IsA('Model'))
+        then
+            error(
+                string.format(
+                    'RunStaticWorld Collision container "%s" must be a Folder or Model.',
+                    RunStaticWorldContract.ShipCollisionName
+                ),
+                0
+            )
+        end
+    end
     local triggersRoot =
         requireContainer(root, RunStaticWorldContract.TriggersRootName, 'RunStaticWorld')
     local oceanTriggerRoot = requireContainer(
@@ -13953,10 +14868,9 @@ function RunScene.new(root)
         end
     end
     -- Initialize ship doors: find the Sci-Fi Space Ship model under terrainRoot
-    local allDoors = {}
     local shipModel = terrainRoot and terrainRoot:FindFirstChild('Sci-Fi Space Ship')
     if shipModel then
-        allDoors = ShipDoors.init(shipModel) or {}
+        ShipDoors.init(shipModel)
     end
     local spawnGroundParams =
         buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot, terrainMesh)
@@ -13971,12 +14885,6 @@ function RunScene.new(root)
     local terminals = {}
     for partName, kind in pairs(REQUIRED_PROMPT_PARTS) do
         terminals[kind] = RunTerminal.new(kind, requirePart(root, partName))
-    end
-
-    -- StartGamePrompt is optional; only create if the part exists in the static world
-    local startGamePart = root:FindFirstChild('StartGamePrompt')
-    if startGamePart and startGamePart:IsA('BasePart') then
-        terminals.StartGame = RunTerminal.new('StartGame', startGamePart)
     end
 
     local mazePortal = RunPortal.new(RunPortal.Kind.MazeGate, requirePart(root, 'MazeGateMarker'))
@@ -14000,11 +14908,11 @@ function RunScene.new(root)
             Scene = sceneCollisionRoot,
             Ship = shipCollisionRoot,
         },
+        ShipModel = shipModel,
         OceanTriggers = oceanTriggers,
         OutdoorThresholdZ = outdoorThresholdZ,
         AreaResolver = nil,
         SpawnCFramesByKind = spawnCFramesByKind,
-        ShipDoors = allDoors,
 
         SpawnCFrame = spawnCFramesByKind[RunSpawnPoint.Kind.Spawn],
         ReturnCFrame = spawnCFramesByKind[RunSpawnPoint.Kind.Return],
@@ -14012,6 +14920,7 @@ function RunScene.new(root)
         ShopPrompt = terminals.Shop.Prompt,
         SellPrompt = terminals.Sell.Prompt,
         ObjectivePrompt = terminals.Objective.Prompt,
+        BookPrompt = terminals.Objective.Prompt,
         LoadoutPrompt = terminals.Loadout.Prompt,
         UgcLabPrompt = terminals.UgcLab.Prompt,
         GatePrompt = terminals.Gate.Prompt,
@@ -14041,18 +14950,6 @@ function RunScene:openGate()
     self.Terminals.Gate.Prompt.ActionText = 'Gate Open'
 end
 
-function RunScene:lockAllShipDoors()
-    for _, door in ipairs(self.ShipDoors or {}) do
-        door:lock()
-    end
-end
-
-function RunScene:unlockAllShipDoors()
-    for _, door in ipairs(self.ShipDoors or {}) do
-        door:unlock()
-    end
-end
-
 function RunScene:bindInteractions(handlers)
     local registry = RunInteractionRegistry.new()
     registry:bindScene(self, handlers)
@@ -14065,7 +14962,7 @@ return RunScene
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="120">
+      <Item class="ModuleScript" referent="129">
         <Properties>
           <string name="Name">RunSessionService</string>
           <string name="Source"><![CDATA[local Players = game:GetService('Players')
@@ -14078,19 +14975,19 @@ local Shared = require(Packages:WaitForChild('Shared'))
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
 
 local SessionConfig = Shared.Config.SessionConfig
-local Remotes = Shared.Network.Remotes.ensureScope(Shared.Network.Remotes.Scope.Run)
+local Remotes = Shared.Network.Remotes.ensure()
 local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
 local MazeEntryAvailability = Shared.Session.MazeEntryAvailability
 local SessionSeedPolicy = Shared.Session.SessionSeedPolicy
-local HostPolicy = Shared.Util.HostPolicy
 local ControlStateService = Shared.Runtime.ControlStateService
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
 local InventoryService = Shared.Runtime.InventoryService
 local PlayerService = Shared.Runtime.PlayerService
 local PlayerStateService = Shared.Runtime.PlayerStateService
 local MonsterService = Shared.Runtime.MonsterService
-local TeleportInventoryHydrator = Shared.Runtime.TeleportInventoryHydrator
 local TODService = Shared.Runtime.TODService
+local TeleportInventoryHydrator = Shared.Runtime.TeleportInventoryHydrator
+local RoundSignalBus = Shared.Runtime.RoundSignalBus
 
 local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
 local RunWorldScanner = require(script.Parent.RunWorldScanner)
@@ -14125,6 +15022,16 @@ local OCEAN_SPLASH_MESSAGE = 'Sea spray crashes over you.'
 local OCEAN_SLOWDOWN_DELAY_SECONDS = 1
 local OCEAN_SLOWDOWN_WALK_SPEED = 12
 local OCEAN_DAMAGE_INTERVAL_SECONDS = 5
+local ROUND_RESET_DELAY_SECONDS = SessionConfig.SettlementDurationSeconds
+local ROUND_SETTLEMENT_REASON = table.freeze({
+    Book = 'book_settlement',
+    Timeout = 'timeout',
+    AllDead = 'all_dead',
+})
+local DAMAGE_KIND_BY_PIPS = table.freeze({
+    [1] = Gameplay.PlayerState.DamageKind.Light,
+    [2] = Gameplay.PlayerState.DamageKind.Heavy,
+})
 local SHOP_ITEMS = {
     {
         Id = 'temple_lantern',
@@ -14177,22 +15084,31 @@ end
 
 local function bindCharacterTeleport(self, player)
     player.CharacterAdded:Connect(function(character)
-        task.wait()
-        if not character.Parent then
-            return
-        end
+        task.defer(function()
+            local rootPart = character:FindFirstChild('HumanoidRootPart')
+                or character:WaitForChild('HumanoidRootPart', 5)
+            if rootPart == nil then
+                return
+            end
 
-        if not self.World then
-            return
-        end
+            if not character.Parent then
+                return
+            end
 
-        local pendingSpawnValue = self.PendingSpawnByUserId[player.UserId]
-        local targetCFrame = pendingSpawnValue
-                and resolvePendingSpawnCFrame(self, pendingSpawnValue)
-            or self.World.SpawnCFrame
-        self.PendingSpawnByUserId[player.UserId] = nil
-        character:PivotTo(targetCFrame)
-        self:_applyMovementMode(player)
+            if not self.World then
+                return
+            end
+
+            local pendingSpawnValue = self.PendingSpawnByUserId[player.UserId]
+            local targetCFrame = pendingSpawnValue
+                    and resolvePendingSpawnCFrame(self, pendingSpawnValue)
+                or self.World.SpawnCFrame
+            self.PendingSpawnByUserId[player.UserId] = nil
+            character:PivotTo(targetCFrame)
+            rootPart.AssemblyLinearVelocity = Vector3.zero
+            rootPart.AssemblyAngularVelocity = Vector3.zero
+            self:_applyMovementMode(player)
+        end)
     end)
 end
 
@@ -14304,13 +15220,18 @@ function RunSessionService.new(options)
         RunDurationSeconds = SessionConfig.DefaultRunDurationSeconds,
         InventoryCapacity = SessionConfig.InventoryCapacity,
     }
-    self.CampSession = CampMazeSessionContract.newCampSession({})
+    self.CampSession = CampMazeSessionContract.newCampSession({
+        SignalScope = string.format(
+            'run:%s',
+            if type(game.JobId) == 'string' and game.JobId ~= ''
+                then game.JobId
+                else tostring(os.time())
+        ),
+    })
     self.Status = INITIAL_TEMPLE_STATUS
     self.IsLaunched = false
     self.ShouldAutoLaunch = false
     self.GateOpen = false
-    self.GamePhase = 'Waiting'
-    self.HostUserId = nil
     self.World = nil
     self.WorldInteractions = nil
     self.SnapshotThread = nil
@@ -14333,13 +15254,269 @@ function RunSessionService.new(options)
     self.ControlStateService = ControlStateService.new()
     self.PlayerService = PlayerService.new()
     self.PlayerStateService = PlayerStateService.new()
-    self.TODService = TODService.new()
     self.RunToMazeTransition = runtimeOptions.RunToMazeTransition or RunToMazeTransition.new()
     self.WorldBuilder = runtimeOptions.RunWorldBuilder or RunWorldBuilder
+    self.TODService = runtimeOptions.TODService
+        or TODService.new({
+            Config = SessionConfig.TOD,
+            Remote = self.Remotes.TODState,
+        })
     self.RunTracker = Gameplay.Session.MazeRunTracker.new()
     self.MonsterService = nil -- deferred: initialized in _rebuildWorld after self.World is built
+    self.RoundSignalBus = runtimeOptions.RoundSignalBus or RoundSignalBus.new()
+    self.RoundSignalConnection = nil
+    self.RoundClosureInProgress = false
+    self.RoundResetToken = 0
+    self.MazePresence = {
+        AliveCount = 0,
+        ActiveCount = 0,
+    }
 
     return self
+end
+
+function RunSessionService:_getServerTimeNow()
+    local ok, result = pcall(function()
+        return Workspace:GetServerTimeNow()
+    end)
+    if ok and type(result) == 'number' then
+        return result
+    end
+
+    return os.time()
+end
+
+function RunSessionService:_ensureHost()
+    local players = Players:GetPlayers()
+    local currentHostUserId = self.CampSession.HostUserId
+
+    for _, player in ipairs(players) do
+        if player.UserId == currentHostUserId then
+            return
+        end
+    end
+
+    table.sort(players, function(left, right)
+        return left.UserId < right.UserId
+    end)
+
+    local nextHost = players[1]
+    self.CampSession =
+        CampMazeSessionContract.assignHost(self.CampSession, nextHost and nextHost.UserId or nil)
+end
+
+function RunSessionService:_isRoundStarted()
+    return self.CampSession.RoundStarted == true
+end
+
+function RunSessionService:_isRoundClosing()
+    return self.RoundClosureInProgress == true or self.CampSession.SettlementReason ~= nil
+end
+
+function RunSessionService:_isPlayerDead(player)
+    local summary = self.PlayerService:getSummary(player)
+    return summary ~= nil and summary.Health ~= nil and summary.Health.IsDead == true
+end
+
+function RunSessionService:_isPlayerInCamp(player)
+    return self:_getPlayerArea(player) ~= 'Wilderness'
+end
+
+function RunSessionService:_isPlayerTargetableInField(player)
+    return self:_isRoundStarted()
+        and self.CampSession.DangerActive == true
+        and not CampMazeSessionContract.isPlayerInMaze(self.CampSession, player.UserId)
+        and not self:_isPlayerDead(player)
+        and not self:_isPlayerInCamp(player)
+end
+
+function RunSessionService:_getRoundTimeRemainingSeconds()
+    local roundEndTime = self.CampSession.RoundEndTime
+    if type(roundEndTime) ~= 'number' then
+        return nil
+    end
+
+    return math.max(0, roundEndTime - self:_getServerTimeNow())
+end
+
+function RunSessionService:_evaluateMazeEntry(player)
+    local availability = MazeEntryAvailability.evaluate({
+        PlaceIds = SessionConfig.PlaceIds,
+        PlaceId = game.PlaceId,
+        GameId = game.GameId,
+        IsStudio = RunService:IsStudio(),
+    })
+
+    if not self:_isRoundStarted() then
+        availability.Mode = MazeEntryAvailability.Mode.Blocked
+        availability.ReasonCode = 'RoundNotStarted'
+        availability.Reason =
+            'The round has not started yet. Wait for the host to open the ship door.'
+    elseif self:_isRoundClosing() then
+        availability.Mode = MazeEntryAvailability.Mode.Blocked
+        availability.ReasonCode = 'RoundClosing'
+        availability.Reason = 'This round is already closing.'
+    elseif self:_isPlayerDead(player) then
+        availability.Mode = MazeEntryAvailability.Mode.Blocked
+        availability.ReasonCode = 'PlayerDead'
+        availability.Reason = 'Dead players return next round and cannot enter the maze.'
+    elseif CampMazeSessionContract.isPlayerInMaze(self.CampSession, player.UserId) then
+        availability.Mode = MazeEntryAvailability.Mode.Blocked
+        availability.ReasonCode = 'AlreadyInMaze'
+        availability.Reason = 'This player is already inside the maze.'
+    end
+
+    self.MazeEntryMode = availability.Mode
+    self.MazeEntryReason = availability.Reason
+    self.MazeEntryReasonCode = availability.ReasonCode
+
+    return availability
+end
+
+function RunSessionService:_getRunAliveCount()
+    local count = 0
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        if
+            not CampMazeSessionContract.isPlayerInMaze(self.CampSession, player.UserId)
+            and not self:_isPlayerDead(player)
+        then
+            count += 1
+        end
+    end
+
+    return count
+end
+
+function RunSessionService:_handleRoundSignal(payload)
+    if type(payload) ~= 'table' then
+        return
+    end
+
+    if payload.Kind == RoundSignalBus.MessageKind.MazePresence then
+        self.MazePresence = {
+            AliveCount = type(payload.AliveCount) == 'number' and payload.AliveCount or 0,
+            ActiveCount = type(payload.ActiveCount) == 'number' and payload.ActiveCount or 0,
+        }
+        self:_maybeEndRoundForAllDeaths()
+    end
+end
+
+function RunSessionService:_subscribeToRoundSignals()
+    if self.RoundSignalConnection and self.RoundSignalConnection.Disconnect then
+        self.RoundSignalConnection:Disconnect()
+        self.RoundSignalConnection = nil
+    end
+
+    local connection, ok = self.RoundSignalBus:subscribe(self.CampSession, function(payload)
+        self:_handleRoundSignal(payload)
+    end)
+    if ok then
+        self.RoundSignalConnection = connection
+    end
+end
+
+function RunSessionService:_publishRoundClosure(reason, player, countInventories)
+    self.RoundSignalBus:publish(self.CampSession, {
+        Kind = RoundSignalBus.MessageKind.RoundClosure,
+        Reason = reason,
+        TriggeredByUserId = player and player.UserId or nil,
+        TriggeredByName = player and player.DisplayName or nil,
+        CountInventories = countInventories ~= false,
+        IssuedAt = self:_getServerTimeNow(),
+    })
+end
+
+function RunSessionService:_resetRoundPlayerState(player)
+    self.ControlStateService:removePlayer(player)
+    self.ControlStateService:addPlayer(player)
+    self.PlayerStateService:removePlayer(player)
+    self.PlayerStateService:addPlayer(player)
+    self.PlayerService:removePlayer(player)
+    self.PlayerService:addPlayer(player)
+    self.LastOceanSplashAtByUserId[player.UserId] = nil
+    self.OceanStateByUserId[player.UserId] = nil
+    self.OceanTimersByUserId[player.UserId] = nil
+    self.OceanOriginalSpeedsByUserId[player.UserId] = nil
+    self.PendingSpawnByUserId[player.UserId] = RunSpawnPoint.Kind.Spawn
+end
+
+function RunSessionService:_resetForNextRound()
+    self.RoundClosureInProgress = false
+    self.GateOpen = false
+    self.MazePresence = {
+        AliveCount = 0,
+        ActiveCount = 0,
+    }
+    self.CampSession = CampMazeSessionContract.resetForNextRound(self.CampSession)
+    self:_ensureHost()
+
+    if self.MonsterService and self.MonsterService.destroy then
+        self.MonsterService:destroy()
+        self.MonsterService = nil
+    end
+
+    self:_rebuildWorld()
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        self:_resetRoundPlayerState(player)
+        if self.IsLaunched then
+            player:LoadCharacter()
+        end
+    end
+
+    self.Status = 'Camp is safe. The host can open the ship door when the crew is ready.'
+    self:_broadcastSnapshot()
+end
+
+function RunSessionService:_completeRound(reason, player, countInventories)
+    if not self:_isRoundStarted() or self.RoundClosureInProgress then
+        return
+    end
+
+    self.RoundClosureInProgress = true
+    self.GateOpen = false
+    self.CampSession = CampMazeSessionContract.markSettlementTriggered(self.CampSession, {
+        SettlementReason = reason,
+        TriggeredByUserId = player and player.UserId or nil,
+        TriggeredByName = player and player.DisplayName or nil,
+    })
+    self.CampSession.GateOpen = false
+    self.CampSession.RoundStarted = false
+    self.CampSession.RoundEndTime = self:_getServerTimeNow()
+    self.CampSession = CampMazeSessionContract.normalizeCampSession(self.CampSession)
+
+    if reason == ROUND_SETTLEMENT_REASON.Book then
+        self.Status =
+            string.format('%s invoked the Book of Sand. The round is ending.', player.DisplayName)
+    elseif reason == ROUND_SETTLEMENT_REASON.AllDead then
+        self.Status = 'All active players have fallen. The round is ending.'
+    else
+        self.Status = 'The round timer expired. The round is ending.'
+    end
+
+    self:_publishRoundClosure(reason, player, countInventories)
+    self:_broadcastSnapshot()
+
+    self.RoundResetToken += 1
+    local resetToken = self.RoundResetToken
+    task.delay(ROUND_RESET_DELAY_SECONDS, function()
+        if self.RoundResetToken ~= resetToken then
+            return
+        end
+
+        self:_resetForNextRound()
+    end)
+end
+
+function RunSessionService:_maybeEndRoundForAllDeaths()
+    if not self:_isRoundStarted() or self.RoundClosureInProgress then
+        return
+    end
+
+    if self:_getRunAliveCount() == 0 and (self.MazePresence.AliveCount or 0) == 0 then
+        self:_completeRound(ROUND_SETTLEMENT_REASON.AllDead, nil, false)
+    end
 end
 
 function RunSessionService:_addPlayerState(player)
@@ -14352,10 +15529,15 @@ end
 function RunSessionService:_removePlayerState(player)
     self.InventoryService:removePlayer(player)
     self.ControlStateService:removePlayer(player)
+    self.PlayerStateService:removePlayer(player)
     self.PlayerService:removePlayer(player)
 end
 
 function RunSessionService:_handleOceanEntered(player)
+    if self.CampSession.DangerActive ~= true then
+        return
+    end
+
     local now = os.clock()
     local lastSplashAt = self.LastOceanSplashAtByUserId[player.UserId]
     if
@@ -14476,6 +15658,13 @@ end
 
 function RunSessionService:_updateOceanPerPlayer(player, _dt)
     local state = self:_getOceanState(player)
+
+    if self.CampSession.DangerActive ~= true then
+        if state ~= 'None' then
+            self:_setOceanState(player, 'None')
+        end
+        return
+    end
 
     if state == 'None' then
         return
@@ -14661,6 +15850,8 @@ function RunSessionService:_applyIncomingCampSession(teleportData)
     self.CampSession = nextSession
     self.GateOpen = self.CampSession.GateOpen
     self.ShouldAutoLaunch = true
+    self:_ensureHost()
+    self:_subscribeToRoundSignals()
 
     return teleportData, true
 end
@@ -14798,31 +15989,8 @@ function RunSessionService:_rebuildWorld()
 
             self:_openShop(player)
         end,
-        OnSell = function(player)
-            if not self:_canManageInventory(player) then
-                return
-            end
-
-            self:_openSell(player)
-        end,
-        OnObjective = function(player)
+        OnBook = function(player)
             self:_openObjectiveBoard(player)
-        end,
-        OnLoadout = function(player)
-            self:_setStatus(
-                string.format(
-                    '%s checked the loadout bench. Equipment setup is coming soon.',
-                    player.DisplayName
-                )
-            )
-        end,
-        OnUgcLab = function(player)
-            self:_setStatus(
-                string.format(
-                    '%s checked the UGC lab console. Creature forging is coming soon.',
-                    player.DisplayName
-                )
-            )
         end,
         OnGate = function(player)
             self:_openGate(player)
@@ -14835,9 +16003,6 @@ function RunSessionService:_rebuildWorld()
         OnOceanEntered = function(player, state)
             self:_setOceanState(player, state or 'Touching')
             self:_handleOceanEntered(player)
-        end,
-        OnStartGame = function(player)
-            self:_onHostStartGame(player)
         end,
     })
 
@@ -14884,34 +16049,27 @@ function RunSessionService:_getReturnedSummaries()
 end
 
 function RunSessionService:_getObjectiveFor(player)
-    local area = self:_getPlayerArea(player)
-    local sessionPhase = self.CampSession.SessionPhase
-
-    if sessionPhase == CampMazeSessionContract.SessionPhase.RunPrep then
-        return 'Inspect the temple terminals and open the gate when the group is ready.'
+    if self:_isRoundClosing() then
+        return 'This round is closing. Survivors will regroup at camp for the next host start.'
     end
 
-    if sessionPhase == CampMazeSessionContract.SessionPhase.Debrief then
-        return 'The maze run is complete. Review the returned crew summaries in the temple.'
-    end
-
-    if sessionPhase == CampMazeSessionContract.SessionPhase.MazeActive then
-        if area == 'Wilderness' then
-            return 'A maze session is active. Use the gate outside to join the shared expedition.'
+    if not self:_isRoundStarted() then
+        if self.CampSession.HostUserId == player.UserId then
+            return 'Open the ship door when the crew is ready. That starts danger, monster spawns, the timer, and maze access.'
         end
 
-        return 'Head outside and use the maze gate to join the active shared expedition.'
+        return 'Camp is safe. Wait for the host to open the ship door before heading into danger or entering the maze.'
     end
 
-    if sessionPhase == CampMazeSessionContract.SessionPhase.SessionClosed then
-        return 'This temple session is closed. Return to the staging flow before launching another expedition.'
+    if self:_isPlayerDead(player) then
+        return 'You are dead for this round. Your next spawn will be back at camp when the next round starts.'
     end
 
-    if area == 'Wilderness' then
-        return 'Inspect the maze gate outside to open the first maze session.'
+    if self:_isPlayerInCamp(player) then
+        return 'Use the Shop or Book of Sand, then step outside to fight, explore, or enter the maze whenever you are ready.'
     end
 
-    return 'Step outside to the wilderness clearing and inspect the maze gate.'
+    return 'The field is dangerous now. Fight, explore briefly, or enter the maze whenever you decide to push deeper.'
 end
 
 function RunSessionService:_setStatus(status)
@@ -14930,6 +16088,9 @@ function RunSessionService:_getBookSnapshot()
         BookGoalAmount = self.BookGoalAmount,
         BookGoalProgress = progress,
         BookGoalReached = self.TeamPages >= self.BookGoalAmount,
+        RoundStarted = self:_isRoundStarted(),
+        RoundTimeRemainingSeconds = self:_getRoundTimeRemainingSeconds(),
+        SettlementReason = self.CampSession.SettlementReason,
     }
 end
 
@@ -14957,26 +16118,31 @@ function RunSessionService:_openShop(player)
         Items = buildShopPayload(),
         TeamPages = self.TeamPages,
         Inventory = self.InventoryService:getSummary(player),
+        RoundStarted = self:_isRoundStarted(),
     })
 end
 
 function RunSessionService:_openSell(player)
-    local inventorySummary = self.InventoryService:getSummary(player)
-    self:_sendPrivate(player, {
-        Type = 'OpenSell',
-        Items = buildSellPayload(inventorySummary),
-        TeamPages = self.TeamPages,
-    })
+    self:_openObjectiveBoard(player)
 end
 
 function RunSessionService:_openObjectiveBoard(player)
     local snapshot = self:_getBookSnapshot()
+    local canSettle = self:_isRoundStarted()
+        and not self:_isRoundClosing()
+        and not self:_isPlayerDead(player)
+        and self:_isPlayerInCamp(player)
     self:_sendPrivate(player, {
-        Type = 'OpenObjectiveBoard',
+        Type = 'OpenBook',
         BookGoalAmount = snapshot.BookGoalAmount,
         BookGoalProgress = snapshot.BookGoalProgress,
         BookGoalReached = snapshot.BookGoalReached,
         TeamPages = snapshot.TeamPages,
+        RoundStarted = snapshot.RoundStarted,
+        RoundTimeRemainingSeconds = snapshot.RoundTimeRemainingSeconds,
+        SettlementReason = snapshot.SettlementReason,
+        CanSettle = canSettle,
+        Items = buildSellPayload(self.InventoryService:getSummary(player)),
     })
 end
 
@@ -15040,8 +16206,8 @@ function RunSessionService:_handleSell(player, itemInstanceId)
     if not self:_canManageInventory(player) then
         return
     end
-    if not self:_isPlayerNearTerminalPrompt(player, self.World and self.World.SellPrompt) then
-        self:_toast(player, 'Move closer to the salvage terminal.', 'Error')
+    if not self:_isPlayerNearTerminalPrompt(player, self.World and self.World.BookPrompt) then
+        self:_toast(player, 'Move closer to the Book of Sand.', 'Error')
         return
     end
 
@@ -15072,7 +16238,7 @@ function RunSessionService:_handleSell(player, itemInstanceId)
     self.TeamPages += reward
 
     self:_sendPrivate(player, {
-        Type = 'SellResult',
+        Type = 'BookExchangeResult',
         Success = true,
         ItemInstanceId = itemInstanceId,
         Amount = reward,
@@ -15098,6 +16264,17 @@ function RunSessionService:_resolveMazeEntryAvailability()
         IsStudio = RunService:IsStudio(),
     })
 
+    if not self:_isRoundStarted() then
+        availability.Mode = MazeEntryAvailability.Mode.Blocked
+        availability.ReasonCode = 'RoundNotStarted'
+        availability.Reason =
+            'The round has not started yet. Wait for the host to open the ship door.'
+    elseif self:_isRoundClosing() then
+        availability.Mode = MazeEntryAvailability.Mode.Blocked
+        availability.ReasonCode = 'RoundClosing'
+        availability.Reason = 'This round is already closing.'
+    end
+
     self.MazeEntryMode = availability.Mode
     self.MazeEntryReason = availability.Reason
     self.MazeEntryReasonCode = availability.ReasonCode
@@ -15106,9 +16283,8 @@ function RunSessionService:_resolveMazeEntryAvailability()
 end
 
 function RunSessionService:_broadcastSnapshot()
-    local mazeEntryAvailability = self:_resolveMazeEntryAvailability()
-
     for _, player in ipairs(Players:GetPlayers()) do
+        local mazeEntryAvailability = self:_evaluateMazeEntry(player)
         self.Remotes.RunState:FireClient(
             player,
             RunSnapshotBuilder.buildForPlayer(self, player, mazeEntryAvailability)
@@ -15123,10 +16299,25 @@ function RunSessionService:_canManageInventory(player)
         return false
     end
 
+    if self:_isRoundClosing() then
+        self:_setStatus('This round is already closing, so camp inventory changes are locked.')
+        return false
+    end
+
     if CampMazeSessionContract.isPlayerInMaze(self.CampSession, player.UserId) then
         self:_setStatus(
             string.format(
-                '%s is already marked inside the maze and cannot change temple inventory.',
+                '%s is already marked inside the maze and cannot change camp inventory.',
+                player.DisplayName
+            )
+        )
+        return false
+    end
+
+    if self:_isPlayerDead(player) then
+        self:_setStatus(
+            string.format(
+                '%s is dead for this round and cannot use camp stations.',
                 player.DisplayName
             )
         )
@@ -15183,16 +16374,42 @@ function RunSessionService:_openGate(player)
         return
     end
 
-    if not self.GateOpen then
+    self:_ensureHost()
+
+    if self:_isRoundClosing() then
+        self:_setStatus(
+            'The current round is already closing. Wait for the camp reset before starting again.'
+        )
+        return
+    end
+
+    if not self:_isRoundStarted() then
+        if self.CampSession.HostUserId ~= player.UserId then
+            self:_setStatus(
+                string.format(
+                    '%s checked the ship door. Only the host can start the round.',
+                    player.DisplayName
+                )
+            )
+            return
+        end
+
+        local roundStartTime = self:_getServerTimeNow()
+        local roundEndTime = roundStartTime + self.SessionData.RunDurationSeconds
         self.GateOpen = true
-        self.RunTracker:beginExpedition()
+        self.CampSession = CampMazeSessionContract.markRoundStarted(self.CampSession, {
+            HostUserId = player.UserId,
+            RoundStartTime = roundStartTime,
+            RoundEndTime = roundEndTime,
+            DangerActive = true,
+        })
         self:_syncCampSession()
         self.World:openGate()
         self.TODService:start()
         self:_beginExpedition()
         self:_setStatus(
             string.format(
-                '%s opened the temple gate. The wilderness trail is now accessible.',
+                '%s opened the ship door. Danger, monsters, the global timer, and maze entry are now live.',
                 player.DisplayName
             )
         )
@@ -15200,10 +16417,7 @@ function RunSessionService:_openGate(player)
     end
 
     self:_setStatus(
-        string.format(
-            '%s checked the temple gate. The wilderness trail is already open.',
-            player.DisplayName
-        )
+        string.format('%s checked the ship door. This round is already live.', player.DisplayName)
     )
 end
 
@@ -15294,21 +16508,11 @@ function RunSessionService:_requestMazeEntry(player, requireDistanceCheck)
         return
     end
 
-    if not self.GateOpen then
-        self:_setStatus(
-            string.format(
-                '%s checked the maze gate, but the temple gate is still closed.',
-                player.DisplayName
-            )
-        )
-        return
-    end
-
     if requireDistanceCheck and not self:_isPlayerNearMazePrompt(player) then
         return
     end
 
-    local availability = self:_resolveMazeEntryAvailability()
+    local availability = self:_evaluateMazeEntry(player)
     if availability.Mode == MazeEntryAvailability.Mode.Teleport then
         self:_enterMaze(player)
         return
@@ -15386,20 +16590,61 @@ function RunSessionService:_createMonsterService()
     return MonsterService.new(
         monsterProfile,
         function()
-            return self.RunTracker:getState() == 'Expedition'
+            return self.CampSession.DangerActive == true
         end,
         function(player)
-            return self.RunTracker:isPlayerActive(player.UserId)
+            return self:_isPlayerTargetableInField(player)
         end,
         canTraverseFn,
         {
             RandomSeed = self.SessionData.Seed,
             RandomSource = randomSource,
-            OnAttackHit = function(player, damagePips, _hitContext)
+            OnAttackHit = function(player, damagePips, hitContext)
                 self:_applyPlayerDamage(player, damagePips)
+                if hitContext and hitContext.Effects then
+                    for _, effect in ipairs(hitContext.Effects) do
+                        self.PlayerStateService:applyEffect(
+                            player,
+                            effect.Id,
+                            effect.DurationSeconds
+                        )
+                    end
+                end
             end,
         }
     )
+end
+
+function RunSessionService:_applyPlayerDamage(player, damagePips)
+    if not self:_isPlayerTargetableInField(player) then
+        return
+    end
+    local damageKind = DAMAGE_KIND_BY_PIPS[damagePips]
+    if damageKind == nil then
+        return
+    end
+    local success, result = self.PlayerService:applyDamage(player, damageKind)
+    if not success then
+        warn(
+            ('[RunSessionService] applyDamage failed for %s: %s'):format(
+                player.DisplayName,
+                tostring(result)
+            )
+        )
+        return
+    end
+
+    local summary = self.PlayerService:getSummary(player)
+    if summary and summary.Health and summary.Health.IsDead then
+        self:_setStatus(
+            string.format(
+                '%s died in the run field and will respawn at camp next round.',
+                player.DisplayName
+            )
+        )
+        self:_toast(player, 'You are out for this round.', 'Error')
+        self:_maybeEndRoundForAllDeaths()
+    end
 end
 
 -- Called when ShipDoors first opened: spawn monsters at eligible patrol points
@@ -15419,17 +16664,22 @@ function RunSessionService:_beginExpedition()
     -- Get ship position for exclusion zone from world geometry
     local shipPosition = nil
     local shipCollision = self.World and self.World.Collision and self.World.Collision.Ship
-    if shipCollision then
-        if shipCollision:IsA('Model') and shipCollision.PrimaryPart then
-            shipPosition = shipCollision.PrimaryPart.Position
-        elseif shipCollision:IsA('BasePart') then
-            shipPosition = shipCollision.Position
-        end
+    if shipCollision and shipCollision:IsA('PVInstance') then
+        shipPosition = shipCollision:GetPivot().Position
     end
+
+    local shipModel = self.World and self.World.ShipModel
+    if not shipPosition and shipModel and shipModel:IsA('PVInstance') then
+        shipPosition = shipModel:GetPivot().Position
+    end
+
     if not shipPosition then
-        warn('[RunSessionService] Ship collision not found — skipping monster spawn')
+        warn(
+            '[RunSessionService] Ship position not found (no collision shell or model) - skipping monster spawn'
+        )
         return
     end
+
     local eligible = RunMonsterSpawnPolicy.collectEligiblePatrolPoints(allPositions, shipPosition)
     if #eligible == 0 then
         warn(
@@ -15462,14 +16712,10 @@ function RunSessionService:_launchRun(_player)
         return
     end
 
-    self.TODService:reset()
+    self:_ensureHost()
     self.GateOpen = self.CampSession.GateOpen == true
     self:_syncCampSession()
-
-    -- If gate is already open (session resume), start TOD immediately
-    if self.GateOpen then
-        self.TODService:start()
-    end
+    self:_subscribeToRoundSignals()
 
     self:_rebuildWorld()
 
@@ -15481,12 +16727,10 @@ function RunSessionService:_launchRun(_player)
     end
 
     self:_startSnapshotLoop()
-    if self.Status == INITIAL_TEMPLE_STATUS then
-        self:_setStatus(
-            'Temple is ready. Gather inside, then open the gate when you want to head out.'
-        )
+    if self.CampSession.RoundStarted == true then
+        self:_setStatus('The shared round is already live. Regroup or push deeper as needed.')
     else
-        self:_broadcastSnapshot()
+        self:_setStatus('Camp is safe. The host can open the ship door when the crew is ready.')
     end
 end
 
@@ -15525,6 +16769,15 @@ function RunSessionService:_startSnapshotLoop()
                     self:_updateOceanPerPlayer(player, dt)
                 end
 
+                if
+                    self:_isRoundStarted()
+                    and not self.RoundClosureInProgress
+                    and (self:_getRoundTimeRemainingSeconds() or 0) <= 0
+                then
+                    self:_completeRound(ROUND_SETTLEMENT_REASON.Timeout, nil, true)
+                end
+
+                self:_maybeEndRoundForAllDeaths()
                 self:_broadcastSnapshot()
             else
                 previousTick = os.clock()
@@ -15649,31 +16902,54 @@ function RunSessionService:_getLegacyHeldItemShim(player, legacyToolName)
 end
 
 function RunSessionService:_bindItemRemotes()
-    self.Remotes.GetInventory.OnServerInvoke = function(player: Player)
-        return self:_inventorySummaryFor(player)
+    local getInventoryRemote = self.Remotes.GetInventory
+    local getItemDataRemote = self.Remotes.GetItemData
+    local equipItemRemote = self.Remotes.EquipItem
+    local useItemRemote = self.Remotes.UseItem
+
+    -- Contract v2 keeps run startup on RunAction/RunState/RunPrivateState.
+    -- Older harnesses may still author the legacy item remotes, so only bind
+    -- them when they actually exist.
+    if
+        getInventoryRemote == nil
+        and getItemDataRemote == nil
+        and equipItemRemote == nil
+        and useItemRemote == nil
+    then
+        return
     end
 
-    self.Remotes.GetItemData.OnServerInvoke = function(player: Player, legacyToolName: string)
-        return self:_getLegacyHeldItemShim(player, legacyToolName)
-    end
-
-    self.Remotes.EquipItem.OnServerEvent:Connect(
-        function(player: Player, itemInstanceId: any, equip: any)
-            if type(itemInstanceId) ~= 'number' then
-                return
-            end
-
-            if equip == true then
-                self:_equipItem(player, itemInstanceId)
-            else
-                self:_unequipItem(player)
-            end
-
-            self:_broadcastSnapshot()
+    if getInventoryRemote ~= nil then
+        getInventoryRemote.OnServerInvoke = function(player: Player)
+            return self:_inventorySummaryFor(player)
         end
-    )
+    end
 
-    self.Remotes.UseItem.OnServerEvent:Connect(function(player: Player, legacyToolName: string)
+    if getItemDataRemote ~= nil then
+        getItemDataRemote.OnServerInvoke = function(player: Player, legacyToolName: string)
+            return self:_getLegacyHeldItemShim(player, legacyToolName)
+        end
+    end
+
+    if equipItemRemote == nil or useItemRemote == nil then
+        return
+    end
+
+    equipItemRemote.OnServerEvent:Connect(function(player: Player, itemInstanceId: any, equip: any)
+        if type(itemInstanceId) ~= 'number' then
+            return
+        end
+
+        if equip == true then
+            self:_equipItem(player, itemInstanceId)
+        else
+            self:_unequipItem(player)
+        end
+
+        self:_broadcastSnapshot()
+    end)
+
+    useItemRemote.OnServerEvent:Connect(function(player: Player, legacyToolName: string)
         if type(legacyToolName) ~= 'string' then
             return
         end
@@ -15700,10 +16976,12 @@ end
 function RunSessionService:start()
     warn(string.format('[run-session] build=%s', self.BuildFingerprint))
     self:_loadSessionDataFromJoin()
+    self:_ensureHost()
     self:_ensureAuthoritativeSessionSeed()
     RunInventoryBridge.bind(self)
     self:_bindItemRemotes()
     Players.CharacterAutoLoads = false
+    self:_subscribeToRoundSignals()
 
     for _, player in ipairs(Players:GetPlayers()) do
         bindCharacterTeleport(self, player)
@@ -15715,23 +16993,18 @@ function RunSessionService:start()
         end
     end
 
-    -- Lock ship doors and enter waiting phase
-    self.GamePhase = 'Waiting'
-    self:_lockAllShipDoors()
-
     Players.PlayerAdded:Connect(function(player)
         bindCharacterTeleport(self, player)
         self:_addPlayerState(player)
         self:_handlePlayerTeleportData(player)
+        self:_ensureHost()
 
-        if self.GamePhase == 'Waiting' then
-            self:_assignHost(player.UserId)
-            player:LoadCharacter()
-        elseif self.IsLaunched then
+        if self.IsLaunched then
             player:LoadCharacter()
         end
 
         self:_broadcastSnapshot()
+        self.TODService:sendToPlayer(player)
     end)
 
     Players.PlayerRemoving:Connect(function(player)
@@ -15749,11 +17022,7 @@ function RunSessionService:start()
         })
         self.GateOpen = self.CampSession.GateOpen
         self:_removePlayerState(player)
-
-        if self.GamePhase == 'Waiting' then
-            self:_assignHost(nil)
-        end
-
+        self:_ensureHost()
         self:_broadcastSnapshot()
     end)
 
@@ -15768,7 +17037,7 @@ function RunSessionService:start()
             end
         elseif payload.Type == 'RequestPurchaseItem' then
             self:_handlePurchase(player, payload.ItemId)
-        elseif payload.Type == 'RequestSellItem' then
+        elseif payload.Type == 'RequestSellItem' or payload.Type == 'RequestBookExchange' then
             self:_handleSell(player, payload.ItemInstanceId)
         elseif payload.Type == 'RequestEquipItem' then
             self:_equipItem(player, payload.ItemInstanceId)
@@ -15778,67 +17047,36 @@ function RunSessionService:start()
             self:_setPlayerSprinting(player, true)
         elseif payload.Type == 'RequestSprintStop' then
             self:_setPlayerSprinting(player, false)
-        elseif payload.Type == 'RequestStartExpedition' then
-            self:_setStatus(
-                string.format(
-                    '%s checked the old deploy action. Use the temple gate to head outside instead.',
-                    player.DisplayName
+        elseif payload.Type == 'RequestStartExpedition' or payload.Type == 'RequestStartRound' then
+            self:_openGate(player)
+        elseif payload.Type == 'RequestTriggerSettlement' then
+            if not self:_isRoundStarted() then
+                self:_toast(player, 'The round has not started yet.', 'Error')
+            elseif not self:_isPlayerInCamp(player) then
+                self:_toast(
+                    player,
+                    'Return to camp before using the Book of Sand to settle.',
+                    'Error'
                 )
-            )
+            elseif self:_isPlayerDead(player) then
+                self:_toast(player, 'Dead players cannot trigger settlement.', 'Error')
+            else
+                self:_completeRound(ROUND_SETTLEMENT_REASON.Book, player, false)
+            end
         end
     end)
 
+    self.TODService:prime()
     self:_broadcastSnapshot()
 
-    -- Enter waiting phase: build world, lock doors, assign host, load characters
-    self.IsLaunched = false
-    self:_rebuildWorld()
-    self.GamePhase = 'Waiting'
-    self:_lockAllShipDoors()
-    self:_assignHost(nil)
-    Players.CharacterAutoLoads = true
-
-    for _, player in ipairs(Players:GetPlayers()) do
-        player:LoadCharacter()
-    end
-
-    self:_broadcastSnapshot()
-end
-
-function RunSessionService:_lockAllShipDoors()
-    if self.World and self.World.lockAllShipDoors then
-        self.World:lockAllShipDoors()
-    end
-end
-
-function RunSessionService:_assignHost(newlyJoinedUserId)
-    self.HostUserId = HostPolicy.assignHost(Players:GetPlayers(), self.HostUserId)
-end
-
-function RunSessionService:_onHostStartGame(player)
-    if player.UserId ~= self.HostUserId then
-        return
-    end
-    if self.GamePhase ~= 'Waiting' then
-        return
-    end
-
-    self:_unlockAllShipDoors()
-    self.GamePhase = 'Playing'
-    self:_launchRun(player)
-end
-
-function RunSessionService:_unlockAllShipDoors()
-    if self.World and self.World.unlockAllShipDoors then
-        self.World:unlockAllShipDoors()
-    end
+    self:_launchRun(nil)
 end
 
 return RunSessionService
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="121">
+      <Item class="ModuleScript" referent="130">
         <Properties>
           <string name="Name">RunSnapshotBuilder</string>
           <string name="Source"><![CDATA[local RunSnapshotBuilder = {}
@@ -15849,24 +17087,31 @@ function RunSnapshotBuilder.buildForPlayer(service, player, mazeEntryAvailabilit
         then playerSummary.PlayerState
         else service.PlayerStateService:getSummary(player)
     local bookSnapshot = service:_getBookSnapshot()
+    local mazeEntry = mazeEntryAvailability or service:_evaluateMazeEntry(player)
 
     return {
         IsLaunched = service.IsLaunched,
         GamePhase = service.GamePhase,
-        HostUserId = service.HostUserId,
         Status = service.Status,
         BuildFingerprint = service.BuildFingerprint,
         Area = service:_getPlayerArea(player),
         GateOpen = service.GateOpen,
+        HostUserId = service.CampSession.HostUserId,
+        IsHost = service.CampSession.HostUserId == player.UserId,
+        RoundStarted = service.CampSession.RoundStarted == true,
+        DangerActive = service.CampSession.DangerActive == true,
+        RoundTimeRemainingSeconds = bookSnapshot.RoundTimeRemainingSeconds,
+        SettlementReason = service.CampSession.SettlementReason,
         Objective = service:_getObjectiveFor(player),
         SessionId = service.CampSession.SessionId,
         SessionPhase = service.CampSession.SessionPhase,
         MazeStatus = service.CampSession.MazeStatus,
         PlayersInMaze = service:_getActiveMazeRoster(),
         ReturnedPlayerSummaries = service:_getReturnedSummaries(),
-        MazeEntryMode = mazeEntryAvailability.Mode,
-        MazeEntryReason = mazeEntryAvailability.Reason,
-        MazeEntryReasonCode = mazeEntryAvailability.ReasonCode,
+        MazeEntryMode = mazeEntry.Mode,
+        MazeEntryReason = mazeEntry.Reason,
+        MazeEntryReasonCode = mazeEntry.ReasonCode,
+        CanEnterMaze = mazeEntry.Mode == 'Teleport',
         TeamPages = bookSnapshot.TeamPages,
         BookGoalAmount = bookSnapshot.BookGoalAmount,
         BookGoalProgress = bookSnapshot.BookGoalProgress,
@@ -15883,7 +17128,7 @@ return RunSnapshotBuilder
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="122">
+      <Item class="ModuleScript" referent="131">
         <Properties>
           <string name="Name">RunSpawnPoint</string>
           <string name="Source"><![CDATA[local RunSpawnPoint = {}
@@ -15912,17 +17157,18 @@ return RunSpawnPoint
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="123">
+      <Item class="ModuleScript" referent="132">
         <Properties>
           <string name="Name">RunStaticWorldContract</string>
           <string name="Source"><![CDATA[local RunStaticWorldContract = table.freeze({
     RootName = 'RunStaticWorld',
     CollisionRootName = 'Collision',
     SceneCollisionName = 'Scene',
+    -- Optional authored ship collision shell; absent in the current Studio-authored world.
     ShipCollisionName = 'Ship',
     TriggersRootName = 'Triggers',
     OceanTriggerName = 'Ocean',
-    BuildFingerprint = 'run-collision-contract-v2',
+    BuildFingerprint = 'run-collision-contract-v3',
     SpawnGroundCheckDepth = 32,
     SpawnLiftStuds = 4,
     OceanSplashCooldownSeconds = 1.5,
@@ -15954,7 +17200,7 @@ return RunStaticWorldContract
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="124">
+      <Item class="ModuleScript" referent="133">
         <Properties>
           <string name="Name">RunStaticWorldValidator</string>
           <string name="Source"><![CDATA[local Workspace = game:GetService('Workspace')
@@ -16186,7 +17432,13 @@ end
 local function buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot, terrainMesh)
     local raycastParams = RaycastParams.new()
     raycastParams.FilterType = Enum.RaycastFilterType.Include
-    local instances = { sceneCollisionRoot, shipCollisionRoot }
+    local instances = {}
+    if sceneCollisionRoot then
+        table.insert(instances, sceneCollisionRoot)
+    end
+    if shipCollisionRoot then
+        table.insert(instances, shipCollisionRoot)
+    end
     if terrainMesh and terrainMesh:IsA('BasePart') then
         table.insert(instances, terrainMesh)
     end
@@ -16207,14 +17459,20 @@ local function buildSpawnGroundSampleOffsets(spawnMarker)
     }
 end
 
-local function assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, terrainMesh, spawnMarker)
+local function assertMarkerHasGround(
+    sceneCollisionRoot,
+    shipCollisionRoot,
+    terrainMesh,
+    markerName,
+    markerPart
+)
     local raycastParams = buildSpawnGroundParams(sceneCollisionRoot, shipCollisionRoot, terrainMesh)
-    local sampleOffsets = buildSpawnGroundSampleOffsets(spawnMarker)
+    local sampleOffsets = buildSpawnGroundSampleOffsets(markerPart)
     local raycastDistance = Vector3.new(0, -RunStaticWorldContract.SpawnGroundCheckDepth, 0)
-    local raycastStartHeight = (spawnMarker.Size.Y * 0.5) + 2
+    local raycastStartHeight = (markerPart.Size.Y * 0.5) + 2
 
     for _, offset in ipairs(sampleOffsets) do
-        local origin = spawnMarker.Position + Vector3.new(offset.X, raycastStartHeight, offset.Z)
+        local origin = markerPart.Position + Vector3.new(offset.X, raycastStartHeight, offset.Z)
         local result = Workspace:Raycast(origin, raycastDistance, raycastParams)
         if result and result.Instance and result.Instance.CanCollide and result.Normal.Y > 0.5 then
             return
@@ -16223,11 +17481,25 @@ local function assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, terra
 
     error(
         string.format(
-            'RunStaticWorld SpawnMarker must raycast onto Collision/Scene, Collision/Ship, or terrain mesh within %d studs below it.',
+            'RunStaticWorld marker "%s" must raycast onto Collision/Scene, Collision/Ship, or terrain mesh within %d studs below it.',
+            markerName,
             RunStaticWorldContract.SpawnGroundCheckDepth
         ),
         0
     )
+end
+
+local function assertMarkerNotAtOrigin(markerName, markerPart)
+    local position = markerPart.Position
+    if position:FuzzyEq(Vector3.zero) then
+        error(
+            string.format(
+                'RunStaticWorld marker "%s" must not stay at the default origin (0, 0, 0). Author a real return point in Studio/source.',
+                markerName
+            ),
+            0
+        )
+    end
 end
 
 function RunStaticWorldValidator.validate(root)
@@ -16241,18 +17513,48 @@ function RunStaticWorldValidator.validate(root)
     -- Validate the visual terrain has collision disabled
     validateVisualTerrain(root)
 
-    local collisionRoot =
-        requireContainer(root, RunStaticWorldContract.CollisionRootName, 'RunStaticWorld')
-    local sceneCollisionRoot = requireContainer(
-        collisionRoot,
-        RunStaticWorldContract.SceneCollisionName,
-        'RunStaticWorld Collision'
-    )
-    local shipCollisionRoot = requireContainer(
-        collisionRoot,
-        RunStaticWorldContract.ShipCollisionName,
-        'RunStaticWorld Collision'
-    )
+    local collisionRoot = root:FindFirstChild(RunStaticWorldContract.CollisionRootName)
+    if collisionRoot and not (collisionRoot:IsA('Folder') or collisionRoot:IsA('Model')) then
+        error(
+            string.format(
+                'RunStaticWorld container "%s" must be a Folder or Model.',
+                RunStaticWorldContract.CollisionRootName
+            ),
+            0
+        )
+    end
+
+    local sceneCollisionRoot = nil
+    local shipCollisionRoot = nil
+    if collisionRoot then
+        sceneCollisionRoot = collisionRoot:FindFirstChild(RunStaticWorldContract.SceneCollisionName)
+        if
+            sceneCollisionRoot
+            and not (sceneCollisionRoot:IsA('Folder') or sceneCollisionRoot:IsA('Model'))
+        then
+            error(
+                string.format(
+                    'RunStaticWorld Collision container "%s" must be a Folder or Model.',
+                    RunStaticWorldContract.SceneCollisionName
+                ),
+                0
+            )
+        end
+
+        shipCollisionRoot = collisionRoot:FindFirstChild(RunStaticWorldContract.ShipCollisionName)
+        if
+            shipCollisionRoot
+            and not (shipCollisionRoot:IsA('Folder') or shipCollisionRoot:IsA('Model'))
+        then
+            error(
+                string.format(
+                    'RunStaticWorld Collision container "%s" must be a Folder or Model.',
+                    RunStaticWorldContract.ShipCollisionName
+                ),
+                0
+            )
+        end
+    end
     local triggersRoot =
         requireContainer(root, RunStaticWorldContract.TriggersRootName, 'RunStaticWorld')
     local oceanTriggerRoot = requireContainer(
@@ -16261,20 +17563,24 @@ function RunStaticWorldValidator.validate(root)
         'RunStaticWorld Triggers'
     )
 
-    validateCollisionParts(
-        requireBaseParts(sceneCollisionRoot, 'RunStaticWorld Collision/Scene'),
-        'RunStaticWorld Collision/Scene'
-    )
-    validateCollisionParts(
-        requireBaseParts(shipCollisionRoot, 'RunStaticWorld Collision/Ship'),
-        'RunStaticWorld Collision/Ship'
-    )
+    if sceneCollisionRoot then
+        validateCollisionParts(
+            requireBaseParts(sceneCollisionRoot, 'RunStaticWorld Collision/Scene'),
+            'RunStaticWorld Collision/Scene'
+        )
+    end
+    if shipCollisionRoot then
+        validateCollisionParts(
+            requireBaseParts(shipCollisionRoot, 'RunStaticWorld Collision/Ship'),
+            'RunStaticWorld Collision/Ship'
+        )
+    end
     validateOceanParts(
         requireBaseParts(oceanTriggerRoot, 'RunStaticWorld Triggers/Ocean'),
         'RunStaticWorld Triggers/Ocean'
     )
 
-    local spawnMarker = nil
+    local markersByName = {}
     for _, markerName in ipairs(REQUIRED_MARKER_NAMES) do
         local markerPart = root:FindFirstChild(markerName, true)
         if markerPart == nil or not markerPart:IsA('BasePart') then
@@ -16282,10 +17588,7 @@ function RunStaticWorldValidator.validate(root)
         end
 
         validateMarkerPart(markerPart, string.format('RunStaticWorld marker "%s"', markerName))
-
-        if markerName == 'SpawnMarker' then
-            spawnMarker = markerPart
-        end
+        markersByName[markerName] = markerPart
     end
 
     -- Find terrain mesh: RunTerrain_Main.Scene.RunTerrain_OriginalHigh.RunTerrain_OriginalHighMesh
@@ -16301,14 +17604,23 @@ function RunStaticWorldValidator.validate(root)
         end
     end
 
-    assertSpawnHasGround(sceneCollisionRoot, shipCollisionRoot, terrainMesh, spawnMarker)
+    for markerName, markerPart in pairs(markersByName) do
+        assertMarkerNotAtOrigin(markerName, markerPart)
+        assertMarkerHasGround(
+            sceneCollisionRoot,
+            shipCollisionRoot,
+            terrainMesh,
+            markerName,
+            markerPart
+        )
+    end
 end
 
 return RunStaticWorldValidator
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="125">
+      <Item class="ModuleScript" referent="134">
         <Properties>
           <string name="Name">RunTerminal</string>
           <string name="Source"><![CDATA[local RunTerminal = {}
@@ -16346,7 +17658,7 @@ return RunTerminal
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="126">
+      <Item class="ModuleScript" referent="135">
         <Properties>
           <string name="Name">RunToMazeTransition</string>
           <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -16465,7 +17777,7 @@ return RunToMazeTransition
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="127">
+      <Item class="ModuleScript" referent="136">
         <Properties>
           <string name="Name">RunWorldBuilder</string>
           <string name="Source"><![CDATA[local Workspace = game:GetService('Workspace')
@@ -16540,7 +17852,7 @@ return RunWorldBuilder
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="128">
+      <Item class="ModuleScript" referent="137">
         <Properties>
           <string name="Name">RunWorldScanner</string>
           <string name="Source"><![CDATA[-- RunWorldScanner.luau
@@ -16630,7 +17942,7 @@ return RunWorldScanner
 ]]></string>
         </Properties>
       </Item>
-      <Item class="ModuleScript" referent="129">
+      <Item class="ModuleScript" referent="138">
         <Properties>
           <string name="Name">ShipDoors</string>
           <string name="Source"><![CDATA[-- ShipDoors.luau
@@ -16648,6 +17960,7 @@ local TWEEN_INFO_OPEN = TweenInfo.new(1.2, Enum.EasingStyle.Quad, Enum.EasingDir
 local TWEEN_INFO_CLOSE = TweenInfo.new(0.8, Enum.EasingStyle.Quad, Enum.EasingDirection.In)
 local ROTATION_ANGLE = 80 -- degrees to swing from closed toward open
 local SLIDE_DISTANCE = 4 -- studs to slide for small doors
+local PROMPT_MAX_ACTIVATION_DISTANCE = 10
 
 -- Rotate a CFrame around a pivot point by angle on Y axis
 local function rotateAroundPivot(cframe, pivotPos, angleDeg)
@@ -16665,11 +17978,11 @@ function ShipDoors.new(config)
     self.SlideOffset = config.slideOffset or Vector3.new(0, 0, 0)
     self.IsLargeDoor = config.isLargeDoor or false
 
-    self._isOpen = false
+    self._isOpen = true
     self._isAnimating = false
     self._isLocked = false
     self._originalCFrames = {}
-    self._prompt = nil
+    self._prompts = {}
 
     -- Store original CFrames (OPEN position = ship's as-built state)
     for _, part in ipairs(self.Parts) do
@@ -16702,6 +18015,18 @@ function ShipDoors:_setCollision(enabled)
     end
 end
 
+function ShipDoors:_setPromptActionText(actionText)
+    for _, prompt in ipairs(self._prompts) do
+        prompt.ActionText = actionText
+    end
+end
+
+function ShipDoors:_setPromptEnabled(enabled)
+    for _, prompt in ipairs(self._prompts) do
+        prompt.Enabled = enabled
+    end
+end
+
 function ShipDoors:open()
     if self._isOpen or self._isAnimating then
         return
@@ -16719,9 +18044,7 @@ function ShipDoors:open()
     task.delay(TWEEN_INFO_OPEN.Time, function()
         self._isOpen = true
         self._isAnimating = false
-        if self._prompt then
-            self._prompt.ActionText = 'Close Door'
-        end
+        self:_setPromptActionText('Close Door')
     end)
 end
 
@@ -16742,9 +18065,7 @@ function ShipDoors:close()
         self._isOpen = false
         self._isAnimating = false
         self:_setCollision(true)
-        if self._prompt then
-            self._prompt.ActionText = 'Open Door'
-        end
+        self:_setPromptActionText('Open Door')
     end)
 end
 
@@ -16752,6 +18073,7 @@ function ShipDoors:toggle()
     if self._isLocked then
         return
     end
+
     if self._isOpen then
         self:close()
     else
@@ -16761,16 +18083,12 @@ end
 
 function ShipDoors:lock()
     self._isLocked = true
-    if self._prompt then
-        self._prompt.Enabled = false
-    end
+    self:_setPromptEnabled(false)
 end
 
 function ShipDoors:unlock()
     self._isLocked = false
-    if self._prompt then
-        self._prompt.Enabled = true
-    end
+    self:_setPromptEnabled(true)
 end
 
 function ShipDoors:isLocked()
@@ -16794,8 +18112,51 @@ local function findMeshPart(model)
     return nil
 end
 
+local function clearPromptArtifacts(part)
+    for _, child in ipairs(part:GetChildren()) do
+        if
+            child.Name == 'ShipDoorPrompt'
+            or child.Name == 'ShipDoorPromptInside'
+            or child.Name == 'ShipDoorPromptOutside'
+            or child.Name == 'ShipDoorPromptInsideAttachment'
+            or child.Name == 'ShipDoorPromptOutsideAttachment'
+        then
+            child:Destroy()
+        end
+    end
+end
+
+local function createPrompt(parent, name, objectText, actionText)
+    local prompt = Instance.new('ProximityPrompt')
+    prompt.Name = name
+    prompt.ActionText = actionText or 'Open Door'
+    prompt.ObjectText = objectText
+    prompt.KeyboardKeyCode = Enum.KeyCode.E
+    prompt.MaxActivationDistance = PROMPT_MAX_ACTIVATION_DISTANCE
+    prompt.HoldDuration = 0
+    prompt.RequiresLineOfSight = false
+    prompt.Parent = parent
+    return prompt
+end
+
+local function attachDoorPrompt(door, part, objectText)
+    clearPromptArtifacts(part)
+
+    local prompt = createPrompt(
+        part,
+        'ShipDoorPrompt',
+        objectText,
+        door._isOpen and 'Close Door' or 'Open Door'
+    )
+    prompt.Triggered:Connect(function()
+        door:toggle()
+    end)
+
+    table.insert(door._prompts, prompt)
+end
+
 -- ============================================================
--- INIT — set up all doors on the Sci-Fi Space Ship model
+-- INIT - set up all doors on the Sci-Fi Space Ship model
 -- Call this once after the ship model is available in the workspace
 -- ============================================================
 
@@ -16889,19 +18250,7 @@ function ShipDoors.init(shipModel)
                 isLargeDoor = true,
             })
 
-            local prompt = Instance.new('ProximityPrompt')
-            prompt.Name = 'ShipDoorPrompt'
-            prompt.ActionText = 'Open Door'
-            prompt.ObjectText = config.name
-            prompt.MaxActivationDistance = 10
-            prompt.HoldDuration = 0
-            prompt.Parent = panel
-
-            door._prompt = prompt
-
-            prompt.Triggered:Connect(function()
-                door:toggle()
-            end)
+            attachDoorPrompt(door, panel, config.name)
 
             table.insert(allDoors, door)
             print('[ShipDoors] Registered large hinged door: ' .. config.name)
@@ -16943,19 +18292,7 @@ function ShipDoors.init(shipModel)
                 isLargeDoor = false,
             })
 
-            local prompt = Instance.new('ProximityPrompt')
-            prompt.Name = 'ShipDoorPrompt'
-            prompt.ActionText = 'Open Door'
-            prompt.ObjectText = config.name
-            prompt.MaxActivationDistance = 10
-            prompt.HoldDuration = 0
-            prompt.Parent = part
-
-            door._prompt = prompt
-
-            prompt.Triggered:Connect(function()
-                door:toggle()
-            end)
+            attachDoorPrompt(door, part, config.name)
 
             table.insert(allDoors, door)
             print('[ShipDoors] Registered small sliding door: ' .. config.name)
@@ -16972,7 +18309,7 @@ return ShipDoors
       </Item>
     </Item>
   </Item>
-  <Item class="StarterPlayer" referent="130">
+  <Item class="StarterPlayer" referent="139">
     <Properties>
       <string name="Name">StarterPlayer</string>
       <float name="CameraMaxZoomDistance">12</float>
@@ -16980,11 +18317,11 @@ return ShipDoors
       <token name="CameraMode">0</token>
       <bool name="EnableMouseLockOption">false</bool>
     </Properties>
-    <Item class="StarterPlayerScripts" referent="131">
+    <Item class="StarterPlayerScripts" referent="140">
       <Properties>
         <string name="Name">StarterPlayerScripts</string>
       </Properties>
-      <Item class="LocalScript" referent="132">
+      <Item class="LocalScript" referent="141">
         <Properties>
           <string name="Name">RunClient</string>
           <string name="Source"><![CDATA[local Players = game:GetService('Players')
@@ -17001,6 +18338,8 @@ local Shared = require(Packages:WaitForChild('Shared'))
 local UI = require(Packages:WaitForChild('UI'))
 
 local Remotes = Shared.Network.Remotes.waitForScope(Shared.Network.Remotes.Scope.Run)
+local TODConfig = Shared.Config.SessionConfig.TOD
+local TODRemote = ReplicatedStorage:WaitForChild('Remotes'):WaitForChild('TODState')
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
 local heldItemController = Shared.Client.HeldItemController.new(localPlayer)
 local Theme = UI.Hud.Theme
@@ -17032,6 +18371,9 @@ local activeModal = nil
 local activeBuildFingerprint = 'unknown'
 local isInOcean = false
 local oceanSlowdownTween = nil
+local todClockTime = TODConfig.StartHour or 7
+local todRemainingSeconds = math.max(0, math.floor((TODConfig.RoundMinutes or 0) * 60 + 0.5))
+local todIsRunning = false
 ensureFirstPersonLock = function()
     disconnectFirstPersonLock = Shared.Client.FirstPersonController.start(localPlayer)
     ensureFirstPersonLock = function() end
@@ -17217,114 +18559,141 @@ local function buildSessionPhaseText(snapshot)
     return string.format('Phase: %s', snapshot.SessionPhase or 'RunPrep')
 end
 
-local menuBackdrop = Instance.new('Frame')
-menuBackdrop.Name = 'StartMenu'
-menuBackdrop.Size = UDim2.fromScale(1, 1)
-menuBackdrop.BackgroundColor3 = Theme.Background
-menuBackdrop.Parent = screenGui
+local function resolveHostDisplayName(snapshot)
+    local hostUserId = snapshot.HostUserId
+    if type(hostUserId) ~= 'number' then
+        return nil
+    end
 
-local menuBackdropGradient = Instance.new('UIGradient')
-menuBackdropGradient.Rotation = 120
-menuBackdropGradient.Color = ColorSequence.new({
-    ColorSequenceKeypoint.new(0, Theme.Background:Lerp(Color3.new(1, 1, 1), 0.02)),
-    ColorSequenceKeypoint.new(1, Theme.Background:Lerp(Color3.new(0, 0, 0), 0.12)),
-})
-menuBackdropGradient.Parent = menuBackdrop
+    for _, rosterEntry in ipairs(snapshot.Roster or {}) do
+        if rosterEntry.UserId == hostUserId then
+            if hostUserId == localPlayer.UserId then
+                return 'You'
+            end
 
-local menuPanel = Instance.new('Frame')
-menuPanel.Name = 'Panel'
-menuPanel.AnchorPoint = Vector2.new(0.5, 0.5)
-menuPanel.Position = UDim2.fromScale(0.5, 0.5)
-menuPanel.Size = UDim2.fromOffset(520, 360)
-menuPanel.BackgroundColor3 = Theme.Surface
-menuPanel.BorderSizePixel = 0
-menuPanel.Parent = menuBackdrop
+            return rosterEntry.Name
+        end
+    end
 
-applyPanelStyle(menuPanel, 18, 0.8)
+    if hostUserId == localPlayer.UserId then
+        return 'You'
+    end
 
-local menuPadding = Instance.new('UIPadding')
-menuPadding.PaddingTop = UDim.new(0, 28)
-menuPadding.PaddingLeft = UDim.new(0, 28)
-menuPadding.PaddingRight = UDim.new(0, 28)
-menuPadding.PaddingBottom = UDim.new(0, 28)
-menuPadding.Parent = menuPanel
-
-local menuList = Instance.new('UIListLayout')
-menuList.Padding = UDim.new(0, 14)
-menuList.Parent = menuPanel
-
-local eyebrow = makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 20), Theme.Accent, 16, true)
-eyebrow.Text = 'TEMPLE DIRECT ENTRY'
-
-local menuTitle = makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 72), Theme.Text, 34, true)
-menuTitle.Text = string.format('Enter the %s', TEMPLE_LABEL)
-
-local menuBody = makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 78), Theme.SubtleText, 18, false)
-menuBody.Text =
-    'Run now boots directly into the temple flow. Hold while the camp session syncs, then regroup inside before opening the gate to the wilderness and the shared maze.'
-
-local singlePlayerButton = Instance.new('TextButton')
-singlePlayerButton.Size = UDim2.new(1, 0, 0, 52)
-singlePlayerButton.BackgroundColor3 = Theme.Accent
-singlePlayerButton.TextColor3 = Theme.Background
-singlePlayerButton.Font = Enum.Font.GothamBold
-singlePlayerButton.TextSize = 20
-singlePlayerButton.Text = string.format('Syncing %s...', TEMPLE_LABEL)
-singlePlayerButton.Parent = menuPanel
-singlePlayerButton.Active = false
-singlePlayerButton.AutoButtonColor = false
-
-local singlePlayerCorner = Instance.new('UICorner')
-singlePlayerCorner.CornerRadius = UDim.new(0, 12)
-singlePlayerCorner.Parent = singlePlayerButton
-
-local singlePlayerStroke = Instance.new('UIStroke')
-singlePlayerStroke.Color = Theme.Background
-singlePlayerStroke.Transparency = 0.55
-singlePlayerStroke.Thickness = 1
-singlePlayerStroke.Parent = singlePlayerButton
-
-local singlePlayerGradient = Instance.new('UIGradient')
-singlePlayerGradient.Rotation = 90
-singlePlayerGradient.Color = ColorSequence.new({
-    ColorSequenceKeypoint.new(0, Theme.Accent:Lerp(Color3.new(1, 1, 1), 0.1)),
-    ColorSequenceKeypoint.new(1, Theme.Accent:Lerp(Color3.new(0, 0, 0), 0.12)),
-})
-singlePlayerGradient.Parent = singlePlayerButton
-
-local menuStatusLabel =
-    makeTextLabel(menuPanel, UDim2.new(1, 0, 0, 52), Theme.SubtleText, 16, false)
-menuStatusLabel.Text = string.format('Preparing %s access...', TEMPLE_LABEL)
-
-local placeholders = Instance.new('Frame')
-placeholders.Size = UDim2.new(1, 0, 0, 78)
-placeholders.BackgroundTransparency = 1
-placeholders.Parent = menuPanel
-
-local placeholderList = Instance.new('UIListLayout')
-placeholderList.Padding = UDim.new(0, 10)
-placeholderList.FillDirection = Enum.FillDirection.Horizontal
-placeholderList.Parent = placeholders
-
-local function makePlaceholder(text)
-    local button = Instance.new('TextButton')
-    button.Size = UDim2.new(0.5, -5, 1, 0)
-    button.BackgroundColor3 = Theme.Background
-    button.TextColor3 = Theme.SubtleText
-    button.Font = Theme.Font
-    button.TextSize = 16
-    button.Text = text
-    button.AutoButtonColor = false
-    button.Active = false
-    button.Parent = placeholders
-
-    local corner = Instance.new('UICorner')
-    corner.CornerRadius = UDim.new(0, 12)
-    corner.Parent = button
+    return string.format('User %d', hostUserId)
 end
 
-makePlaceholder('Temple Shop (Soon)')
-makePlaceholder('Shared Maze Gate')
+local function buildWaitingHostText(snapshot)
+    if snapshot.GamePhase ~= 'Waiting' then
+        return 'Run state: Playing'
+    end
+
+    local hostDisplayName = resolveHostDisplayName(snapshot)
+    if hostDisplayName == nil then
+        return 'Run state: Waiting for host assignment'
+    end
+
+    if snapshot.HostUserId == localPlayer.UserId then
+        return 'Run state: Waiting | Host: You can start from the ship console'
+    end
+
+    return string.format('Run state: Waiting | Host: %s', hostDisplayName)
+end
+
+local function formatClockTime(clockTime)
+    local normalizedClockTime = (clockTime or 0) % 24
+    local hours = math.floor(normalizedClockTime)
+    local minutes = math.floor(((normalizedClockTime - hours) * 60) + 0.5)
+
+    if minutes >= 60 then
+        minutes = 0
+        hours = (hours + 1) % 24
+    end
+
+    return string.format('%02d:%02d', hours, minutes)
+end
+
+local function formatCountdown(remainingSeconds)
+    local totalSeconds = math.max(0, math.floor((remainingSeconds or 0) + 0.5))
+    local minutes = math.floor(totalSeconds / 60)
+    local seconds = totalSeconds % 60
+    return string.format('%02d:%02d', minutes, seconds)
+end
+
+local watchPanel = Instance.new('Frame')
+watchPanel.Name = 'WatchPanel'
+watchPanel.AnchorPoint = Vector2.new(1, 0)
+watchPanel.Position = UDim2.new(1, -24, 0, 24)
+watchPanel.Size = UDim2.fromOffset(130, 58)
+watchPanel.BackgroundColor3 = Theme.Surface
+watchPanel.BorderSizePixel = 0
+watchPanel.Parent = screenGui
+
+applyPanelStyle(watchPanel, 14, 0.8)
+
+local watchPadding = Instance.new('UIPadding')
+watchPadding.PaddingTop = UDim.new(0, 8)
+watchPadding.PaddingLeft = UDim.new(0, 10)
+watchPadding.PaddingRight = UDim.new(0, 10)
+watchPadding.PaddingBottom = UDim.new(0, 8)
+watchPadding.Parent = watchPanel
+
+local watchList = Instance.new('UIListLayout')
+watchList.Padding = UDim.new(0, 2)
+watchList.Parent = watchPanel
+
+local watchTimeLabel = makeTextLabel(watchPanel, UDim2.new(1, 0, 0, 20), Theme.Text, 18, true)
+local watchCountdownLabel =
+    makeTextLabel(watchPanel, UDim2.new(1, 0, 0, 16), Theme.SubtleText, 14, false)
+
+local function updateWatchHud()
+    local accentColor = if todIsRunning then Theme.Text else Theme.SubtleText
+    local countdownColor = if todIsRunning then Theme.Accent else Theme.SubtleText
+
+    watchPanel.BackgroundTransparency = if todIsRunning then 0.12 else 0.24
+    watchTimeLabel.TextColor3 = accentColor
+    watchCountdownLabel.TextColor3 = countdownColor
+    watchTimeLabel.Text = formatClockTime(todClockTime)
+    watchCountdownLabel.Text = formatCountdown(todRemainingSeconds)
+end
+
+updateWatchHud()
+
+local menuBackdrop = Instance.new('Frame')
+menuBackdrop.Name = 'StartupBanner'
+menuBackdrop.AnchorPoint = Vector2.new(0.5, 0)
+menuBackdrop.Position = UDim2.fromScale(0.5, 0.03)
+menuBackdrop.Size = UDim2.new(0.92, 0, 0, 180)
+menuBackdrop.BackgroundColor3 = Theme.Surface
+menuBackdrop.BorderSizePixel = 0
+menuBackdrop.Visible = false
+menuBackdrop.Parent = screenGui
+
+applyPanelStyle(menuBackdrop, 16, 0.82)
+
+local menuPadding = Instance.new('UIPadding')
+menuPadding.PaddingTop = UDim.new(0, 18)
+menuPadding.PaddingLeft = UDim.new(0, 20)
+menuPadding.PaddingRight = UDim.new(0, 20)
+menuPadding.PaddingBottom = UDim.new(0, 18)
+menuPadding.Parent = menuBackdrop
+
+local menuList = Instance.new('UIListLayout')
+menuList.Padding = UDim.new(0, 8)
+menuList.Parent = menuBackdrop
+
+local eyebrow = makeTextLabel(menuBackdrop, UDim2.new(1, 0, 0, 18), Theme.Accent, 15, true)
+eyebrow.Text = 'RUN SYNC'
+
+local menuTitle = makeTextLabel(menuBackdrop, UDim2.new(1, 0, 0, 28), Theme.Text, 24, true)
+menuTitle.Text = 'Camp session syncing'
+
+local menuBody = makeTextLabel(menuBackdrop, UDim2.new(1, 0, 0, 30), Theme.SubtleText, 15, false)
+menuBody.Text =
+    'Startup is now informational only. You will spawn directly onto the ship deck once the run session is ready.'
+
+local menuStatusLabel =
+    makeTextLabel(menuBackdrop, UDim2.new(1, 0, 0, 80), Theme.SubtleText, 15, false)
+menuStatusLabel.Text = string.format('Preparing %s session...', TEMPLE_LABEL)
 
 local panel = Instance.new('Frame')
 panel.Name = 'CampPanel'
@@ -17519,18 +18888,18 @@ watchClockIcon.TextSize = 14
 watchClockIcon.Text = '\u{1F551}'
 watchClockIcon.Parent = watchFrame
 
-local watchTimeLabel = Instance.new('TextLabel')
-watchTimeLabel.Name = 'GameTime'
-watchTimeLabel.Size = UDim2.new(1, -36, 0, 22)
-watchTimeLabel.Position = UDim2.fromOffset(30, 6)
-watchTimeLabel.BackgroundTransparency = 1
-watchTimeLabel.Font = Enum.Font.GothamBold
-watchTimeLabel.TextColor3 = Theme.Text
-watchTimeLabel.TextSize = 18
-watchTimeLabel.TextXAlignment = Enum.TextXAlignment.Left
-watchTimeLabel.TextYAlignment = Enum.TextYAlignment.Center
-watchTimeLabel.Text = '07:00'
-watchTimeLabel.Parent = watchFrame
+local watchGameTimeLabel = Instance.new('TextLabel')
+watchGameTimeLabel.Name = 'GameTime'
+watchGameTimeLabel.Size = UDim2.new(1, -36, 0, 22)
+watchGameTimeLabel.Position = UDim2.fromOffset(30, 6)
+watchGameTimeLabel.BackgroundTransparency = 1
+watchGameTimeLabel.Font = Enum.Font.GothamBold
+watchGameTimeLabel.TextColor3 = Theme.Text
+watchGameTimeLabel.TextSize = 18
+watchGameTimeLabel.TextXAlignment = Enum.TextXAlignment.Left
+watchGameTimeLabel.TextYAlignment = Enum.TextYAlignment.Center
+watchGameTimeLabel.Text = '07:00'
+watchGameTimeLabel.Parent = watchFrame
 
 local watchRemainLabel = Instance.new('TextLabel')
 watchRemainLabel.Name = 'Remaining'
@@ -17665,7 +19034,7 @@ progressBarBack.BorderSizePixel = 0
 progressBarBack.Parent = objectivePanel
 
 local progressBarFill = Instance.new('Frame')
-progressBarFill.Size = UDim2.new(0, 0, 1, 0)
+progressBarFill.Size = UDim2.fromScale(0, 1)
 progressBarFill.BackgroundColor3 = Theme.Accent
 progressBarFill.BorderSizePixel = 0
 progressBarFill.Parent = progressBarBack
@@ -17701,7 +19070,7 @@ local function updateObjectiveUi()
     objectiveGoalLabel.Text = string.format('Goal: %d %s', goalAmount, PAGE_LABEL)
     objectiveProgressLabel.Text =
         string.format('%s: %d%%', SAND_BOOK_PROGRESS_LABEL, math.floor(clampedProgress * 100 + 0.5))
-    progressBarFill.Size = UDim2.new(clampedProgress, 0, 1, 0)
+    progressBarFill.Size = UDim2.fromScale(clampedProgress, 1)
 end
 
 local function updatePageLabels()
@@ -17948,6 +19317,23 @@ sprintInputEndedConnection = UserInputService.InputEnded:Connect(function(input,
     })
 end)
 
+TODRemote.OnClientEvent:Connect(function(payload)
+    if type(payload) ~= 'table' then
+        return
+    end
+
+    if type(payload.ClockTime) == 'number' then
+        todClockTime = payload.ClockTime
+    end
+
+    if type(payload.RoundTimeRemainingSeconds) == 'number' then
+        todRemainingSeconds = payload.RoundTimeRemainingSeconds
+    end
+
+    todIsRunning = payload.IsRunning == true
+    updateWatchHud()
+end)
+
 Remotes.RunPrivateState.OnClientEvent:Connect(function(payload)
     if type(payload) ~= 'table' then
         return
@@ -18097,15 +19483,13 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
         visibleBackpackItems = {}
         heldItemController:applyInventory(nil)
         menuStatusLabel.Text = string.format(
-            '%s\n%s\n%s\nMaze Entry: %s',
+            '%s\n%s\n%s\n%s\nMaze Entry: %s',
             snapshot.Status,
             buildFingerprintText(snapshot),
             buildSessionPhaseText(snapshot),
+            buildWaitingHostText(snapshot),
             buildMazeEntryText(snapshot)
         )
-        singlePlayerButton.Active = false
-        singlePlayerButton.AutoButtonColor = false
-        singlePlayerButton.Text = string.format('Syncing %s...', TEMPLE_LABEL)
         inventoryLabel.Text = 'Inventory: --'
         inventoryDetailLabel.Text = ''
         playerStateLabel.Text = 'Health: --\nStamina: --\nState: --\nMovement: --'
@@ -18116,10 +19500,11 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
     canRequestMazeEntry = snapshot.GateOpen == true
 
     statusLabel.Text = string.format(
-        '%s\n%s\n%s\nArea: %s | Gate: %s | Maze: %s\nEntry: %s',
+        '%s\n%s\n%s\n%s\nArea: %s | Gate: %s | Maze: %s\nEntry: %s',
         snapshot.Status,
         buildFingerprintText(snapshot),
         buildSessionPhaseText(snapshot),
+        buildWaitingHostText(snapshot),
         snapshot.Area,
         snapshot.GateOpen and 'Open' or 'Closed',
         snapshot.MazeStatus or 'idle',
@@ -18190,7 +19575,18 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
 
     local rosterLines = {}
     for _, rosterEntry in ipairs(snapshot.Roster) do
-        local marker = rosterEntry.UserId == localPlayer.UserId and ' (You)' or ''
+        local markers = {}
+        if rosterEntry.UserId == localPlayer.UserId then
+            table.insert(markers, 'You')
+        end
+        if rosterEntry.UserId == snapshot.HostUserId then
+            table.insert(markers, 'Host')
+        end
+
+        local marker = ''
+        if #markers > 0 then
+            marker = string.format(' (%s)', table.concat(markers, ', '))
+        end
         table.insert(rosterLines, string.format('%s%s', rosterEntry.Name, marker))
     end
 
@@ -18233,177 +19629,42 @@ end)
       </Item>
     </Item>
   </Item>
-  <Item class="Workspace" referent="133">
+  <Item class="Workspace" referent="142">
     <Properties>
       <string name="Name">Workspace</string>
       <bool name="NeedsPivotMigration">false</bool>
     </Properties>
-    <Item class="Folder" referent="134">
+    <Item class="Folder" referent="143">
       <Properties>
         <string name="Name">RunStaticWorld</string>
         <BinaryString name="AttributesSerialize">AQAAABEAAABPdXRkb29yVGhyZXNob2xkWgYAAAAAAABJQA==</BinaryString>
       </Properties>
-      <Item class="Folder" referent="135">
-        <Properties>
-          <string name="Name">Collision</string>
-        </Properties>
-        <Item class="Folder" referent="136">
-          <Properties>
-            <string name="Name">Scene</string>
-          </Properties>
-          <Item class="Part" referent="137">
-            <Properties>
-              <string name="Name">CampGround</string>
-              <bool name="Anchored">true</bool>
-              <bool name="CanCollide">true</bool>
-              <bool name="CanQuery">true</bool>
-              <bool name="CanTouch">false</bool>
-              <Vector3 name="Position">
-                <X>50.842907</X>
-                <Y>6.449505</Y>
-                <Z>324.17737</Z>
-              </Vector3>
-              <Vector3 name="size">
-                <X>220</X>
-                <Y>4</Y>
-                <Z>220</Z>
-              </Vector3>
-              <float name="Transparency">1</float>
-            </Properties>
-          </Item>
-        </Item>
-        <Item class="Folder" referent="138">
-          <Properties>
-            <string name="Name">Ship</string>
-          </Properties>
-          <Item class="Part" referent="139">
-            <Properties>
-              <string name="Name">HullDeckMain</string>
-              <bool name="Anchored">true</bool>
-              <bool name="CanCollide">true</bool>
-              <bool name="CanQuery">true</bool>
-              <bool name="CanTouch">false</bool>
-              <Vector3 name="Position">
-                <X>49.761387</X>
-                <Y>14.449505</Y>
-                <Z>299.2431</Z>
-              </Vector3>
-              <Vector3 name="size">
-                <X>72</X>
-                <Y>2</Y>
-                <Z>72</Z>
-              </Vector3>
-              <float name="Transparency">1</float>
-            </Properties>
-          </Item>
-          <Item class="Part" referent="140">
-            <Properties>
-              <string name="Name">HullRailEast</string>
-              <bool name="Anchored">true</bool>
-              <bool name="CanCollide">true</bool>
-              <bool name="CanQuery">true</bool>
-              <bool name="CanTouch">false</bool>
-              <Vector3 name="Position">
-                <X>84.76139</X>
-                <Y>17.449505</Y>
-                <Z>299.2431</Z>
-              </Vector3>
-              <Vector3 name="size">
-                <X>2</X>
-                <Y>6</Y>
-                <Z>72</Z>
-              </Vector3>
-              <float name="Transparency">1</float>
-            </Properties>
-          </Item>
-          <Item class="Part" referent="141">
-            <Properties>
-              <string name="Name">HullRailNorth</string>
-              <bool name="Anchored">true</bool>
-              <bool name="CanCollide">true</bool>
-              <bool name="CanQuery">true</bool>
-              <bool name="CanTouch">false</bool>
-              <Vector3 name="Position">
-                <X>49.761387</X>
-                <Y>17.449505</Y>
-                <Z>334.2431</Z>
-              </Vector3>
-              <Vector3 name="size">
-                <X>68</X>
-                <Y>6</Y>
-                <Z>2</Z>
-              </Vector3>
-              <float name="Transparency">1</float>
-            </Properties>
-          </Item>
-          <Item class="Part" referent="142">
-            <Properties>
-              <string name="Name">HullRailSouth</string>
-              <bool name="Anchored">true</bool>
-              <bool name="CanCollide">true</bool>
-              <bool name="CanQuery">true</bool>
-              <bool name="CanTouch">false</bool>
-              <Vector3 name="Position">
-                <X>49.761387</X>
-                <Y>17.449505</Y>
-                <Z>264.2431</Z>
-              </Vector3>
-              <Vector3 name="size">
-                <X>68</X>
-                <Y>6</Y>
-                <Z>2</Z>
-              </Vector3>
-              <float name="Transparency">1</float>
-            </Properties>
-          </Item>
-          <Item class="Part" referent="143">
-            <Properties>
-              <string name="Name">HullRailWest</string>
-              <bool name="Anchored">true</bool>
-              <bool name="CanCollide">true</bool>
-              <bool name="CanQuery">true</bool>
-              <bool name="CanTouch">false</bool>
-              <Vector3 name="Position">
-                <X>14.761387</X>
-                <Y>17.449505</Y>
-                <Z>299.2431</Z>
-              </Vector3>
-              <Vector3 name="size">
-                <X>2</X>
-                <Y>6</Y>
-                <Z>72</Z>
-              </Vector3>
-              <float name="Transparency">1</float>
-            </Properties>
-          </Item>
-        </Item>
-      </Item>
       <Item class="Part" referent="144">
         <Properties>
-          <string name="Name">DoorLeft</string>
+          <string name="Name">BookOfSand</string>
           <bool name="Anchored">true</bool>
         </Properties>
-      </Item>
-      <Item class="Part" referent="145">
-        <Properties>
-          <string name="Name">DoorRight</string>
-          <bool name="Anchored">true</bool>
-        </Properties>
-      </Item>
-      <Item class="Part" referent="146">
-        <Properties>
-          <string name="Name">GateSwitch</string>
-          <bool name="Anchored">true</bool>
-        </Properties>
-        <Item class="ProximityPrompt" referent="147">
+        <Item class="ProximityPrompt" referent="145">
           <Properties>
             <string name="Name">Prompt</string>
           </Properties>
         </Item>
       </Item>
+      <Item class="Part" referent="146">
+        <Properties>
+          <string name="Name">DoorLeft</string>
+          <bool name="Anchored">true</bool>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="147">
+        <Properties>
+          <string name="Name">DoorRight</string>
+          <bool name="Anchored">true</bool>
+        </Properties>
+      </Item>
       <Item class="Part" referent="148">
         <Properties>
-          <string name="Name">LoadoutBench</string>
+          <string name="Name">GateSwitch</string>
           <bool name="Anchored">true</bool>
         </Properties>
         <Item class="ProximityPrompt" referent="149">
@@ -18430,68 +19691,61 @@ end)
           <bool name="CanCollide">false</bool>
           <bool name="CanQuery">true</bool>
           <bool name="CanTouch">false</bool>
+          <Vector3 name="Position">
+            <X>56.842907</X>
+            <Y>18.449505</Y>
+            <Z>300.17737</Z>
+          </Vector3>
         </Properties>
       </Item>
       <Item class="Part" referent="153">
-        <Properties>
-          <string name="Name">ObjectiveBoard</string>
-          <bool name="Anchored">true</bool>
-        </Properties>
-        <Item class="ProximityPrompt" referent="154">
-          <Properties>
-            <string name="Name">Prompt</string>
-          </Properties>
-        </Item>
-      </Item>
-      <Item class="Part" referent="155">
         <Properties>
           <string name="Name">ReturnMarker</string>
           <bool name="Anchored">true</bool>
           <bool name="CanCollide">false</bool>
           <bool name="CanQuery">true</bool>
           <bool name="CanTouch">false</bool>
+          <Vector3 name="Position">
+            <X>44.842907</X>
+            <Y>18.449505</Y>
+            <Z>300.17737</Z>
+          </Vector3>
         </Properties>
       </Item>
-      <Item class="Part" referent="156">
-        <Properties>
-          <string name="Name">SalvageTerminal</string>
-          <bool name="Anchored">true</bool>
-        </Properties>
-        <Item class="ProximityPrompt" referent="157">
-          <Properties>
-            <string name="Name">Prompt</string>
-          </Properties>
-        </Item>
-      </Item>
-      <Item class="Part" referent="158">
+      <Item class="Part" referent="154">
         <Properties>
           <string name="Name">ShopTerminal</string>
           <bool name="Anchored">true</bool>
         </Properties>
-        <Item class="ProximityPrompt" referent="159">
+        <Item class="ProximityPrompt" referent="155">
           <Properties>
             <string name="Name">Prompt</string>
           </Properties>
         </Item>
       </Item>
-      <Item class="Part" referent="160">
+      <Item class="Part" referent="156">
         <Properties>
           <string name="Name">SpawnMarker</string>
           <bool name="Anchored">true</bool>
           <bool name="CanCollide">false</bool>
           <bool name="CanQuery">true</bool>
           <bool name="CanTouch">false</bool>
+          <Vector3 name="Position">
+            <X>50.842907</X>
+            <Y>18.449505</Y>
+            <Z>300.17737</Z>
+          </Vector3>
         </Properties>
       </Item>
-      <Item class="Folder" referent="161">
+      <Item class="Folder" referent="157">
         <Properties>
           <string name="Name">Triggers</string>
         </Properties>
-        <Item class="Folder" referent="162">
+        <Item class="Folder" referent="158">
           <Properties>
             <string name="Name">Ocean</string>
           </Properties>
-          <Item class="Part" referent="163">
+          <Item class="Part" referent="159">
             <Properties>
               <string name="Name">OceanTrigger</string>
               <bool name="Anchored">true</bool>
@@ -18511,17 +19765,6 @@ end)
               <float name="Transparency">1</float>
             </Properties>
           </Item>
-        </Item>
-      </Item>
-      <Item class="Part" referent="164">
-        <Properties>
-          <string name="Name">UgcLabConsole</string>
-          <bool name="Anchored">true</bool>
-        </Properties>
-        <Item class="ProximityPrompt" referent="165">
-          <Properties>
-            <string name="Name">Prompt</string>
-          </Properties>
         </Item>
       </Item>
     </Item>

--- a/tests/default.project.json
+++ b/tests/default.project.json
@@ -21,37 +21,13 @@
         "ToolTemplates": {
           "$className": "Folder",
           "ToolFlashlight": {
-            "$className": "Model",
-            "Handle": {
-              "$className": "Part",
-              "$properties": {
-                "Anchored": true,
-                "CanCollide": false,
-                "Size": [0.2, 0.35, 0.2]
-              }
-            }
+            "$path": "../assets/ToolTemplates/ToolFlashlight.rbxmx"
           },
           "ToolCrowbar": {
-            "$className": "Model",
-            "Handle": {
-              "$className": "Part",
-              "$properties": {
-                "Anchored": true,
-                "CanCollide": false,
-                "Size": [0.15, 0.55, 0.12]
-              }
-            }
+            "$path": "../assets/ToolTemplates/ToolCrowbar.rbxmx"
           },
           "ToolPotion": {
-            "$className": "Model",
-            "Handle": {
-              "$className": "Part",
-              "$properties": {
-                "Anchored": true,
-                "CanCollide": false,
-                "Size": [0.25, 0.45, 0.25]
-              }
-            }
+            "$path": "../assets/ToolTemplates/ToolPotion.rbxmx"
           }
         }
       },

--- a/tests/default.project.json
+++ b/tests/default.project.json
@@ -21,13 +21,37 @@
         "ToolTemplates": {
           "$className": "Folder",
           "ToolFlashlight": {
-            "$path": "../assets/ToolTemplates/ToolFlashlight.rbxmx"
+            "$className": "Model",
+            "Handle": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": false,
+                "Size": [0.2, 0.35, 0.2]
+              }
+            }
           },
           "ToolCrowbar": {
-            "$path": "../assets/ToolTemplates/ToolCrowbar.rbxmx"
+            "$className": "Model",
+            "Handle": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": false,
+                "Size": [0.15, 0.55, 0.12]
+              }
+            }
           },
           "ToolPotion": {
-            "$path": "../assets/ToolTemplates/ToolPotion.rbxmx"
+            "$className": "Model",
+            "Handle": {
+              "$className": "Part",
+              "$properties": {
+                "Anchored": true,
+                "CanCollide": false,
+                "Size": [0.25, 0.45, 0.25]
+              }
+            }
           }
         }
       },

--- a/tests/default.project.json
+++ b/tests/default.project.json
@@ -19,7 +19,16 @@
       "Assets": {
         "$className": "Folder",
         "ToolTemplates": {
-          "$className": "Folder"
+          "$className": "Folder",
+          "ToolFlashlight": {
+            "$path": "../assets/ToolTemplates/ToolFlashlight.rbxmx"
+          },
+          "ToolCrowbar": {
+            "$path": "../assets/ToolTemplates/ToolCrowbar.rbxmx"
+          },
+          "ToolPotion": {
+            "$path": "../assets/ToolTemplates/ToolPotion.rbxmx"
+          }
         }
       },
       "PlaceModules": {

--- a/tests/src/Shared/HeldToolVisual.spec.luau
+++ b/tests/src/Shared/HeldToolVisual.spec.luau
@@ -1,0 +1,44 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
+    local shared = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared'))
+    local ToolItems = gameplay.Config.ToolItems
+    local HeldToolVisual = shared.Client.HeldToolVisual
+
+    local function makeMinimalCharacter()
+        local char = Instance.new('Model')
+        char.Name = 'SpecCharacter'
+        local hand = Instance.new('Part')
+        hand.Name = 'RightHand'
+        hand.Size = Vector3.new(1, 1, 1)
+        hand.Anchored = true
+        hand.Parent = char
+        return char
+    end
+
+    for _, itemId in ipairs({ 'tool-potion', 'tool-flashlight', 'tool-crowbar' }) do
+        local entry = ToolItems[itemId]
+        assert(entry ~= nil, string.format('ToolItems should define %q', itemId))
+        assert(
+            type(entry.ToolTemplateName) == 'string' and entry.ToolTemplateName ~= '',
+            string.format('%q should have ToolTemplateName for visual spec', itemId)
+        )
+
+        local char = makeMinimalCharacter()
+        char.Parent = workspace
+
+        HeldToolVisual.sync(char, entry)
+        local hand = char:FindFirstChild('RightHand')
+        assert(hand ~= nil, 'Spec character should have RightHand')
+        local clone = hand:FindFirstChild('HeldToolVisualClone')
+        assert(clone ~= nil, string.format('sync should parent clone for %q', itemId))
+
+        HeldToolVisual.clear(char)
+        assert(
+            hand:FindFirstChild('HeldToolVisualClone') == nil,
+            string.format('clear should remove clone for %q', itemId)
+        )
+
+        char:Destroy()
+    end
+end

--- a/tests/src/Shared/HeldToolVisual.spec.luau
+++ b/tests/src/Shared/HeldToolVisual.spec.luau
@@ -16,6 +16,13 @@ return function()
         return char
     end
 
+    local function withMinimalCharacter(callback)
+        local char = makeMinimalCharacter()
+        local ok, err = pcall(callback, char)
+        char:Destroy()
+        assert(ok, err)
+    end
+
     for _, itemId in ipairs({ 'tool-potion', 'tool-flashlight', 'tool-crowbar' }) do
         local entry = ToolItems[itemId]
         assert(entry ~= nil, string.format('ToolItems should define %q', itemId))
@@ -24,21 +31,18 @@ return function()
             string.format('%q should have ToolTemplateName for visual spec', itemId)
         )
 
-        local char = makeMinimalCharacter()
-        char.Parent = workspace
+        withMinimalCharacter(function(char)
+            HeldToolVisual.sync(char, entry)
+            local hand = char:FindFirstChild('RightHand')
+            assert(hand ~= nil, 'Spec character should have RightHand')
+            local clone = hand:FindFirstChild(HeldToolVisual.CLONE_NAME)
+            assert(clone ~= nil, string.format('sync should parent clone for %q', itemId))
 
-        HeldToolVisual.sync(char, entry)
-        local hand = char:FindFirstChild('RightHand')
-        assert(hand ~= nil, 'Spec character should have RightHand')
-        local clone = hand:FindFirstChild('HeldToolVisualClone')
-        assert(clone ~= nil, string.format('sync should parent clone for %q', itemId))
-
-        HeldToolVisual.clear(char)
-        assert(
-            hand:FindFirstChild('HeldToolVisualClone') == nil,
-            string.format('clear should remove clone for %q', itemId)
-        )
-
-        char:Destroy()
+            HeldToolVisual.clear(char)
+            assert(
+                hand:FindFirstChild(HeldToolVisual.CLONE_NAME) == nil,
+                string.format('clear should remove clone for %q', itemId)
+            )
+        end)
     end
 end

--- a/tests/src/Shared/Remotes.spec.luau
+++ b/tests/src/Shared/Remotes.spec.luau
@@ -74,7 +74,7 @@ return function()
         'waitForScope should reuse an existing MazeState remote without creating a new one'
     )
 
-    existingContainer:Destroy()
+    container:Destroy()
     local missingWaitOk, missingWaitError = pcall(function()
         shared.Network.Remotes.waitForScope(shared.Network.Remotes.Scope.Maze, 0)
     end)

--- a/tests/src/Shared/ToolTemplatesContract.spec.luau
+++ b/tests/src/Shared/ToolTemplatesContract.spec.luau
@@ -4,7 +4,8 @@ return function()
     local ItemPresentation = gameplay.Config.ItemPresentation
     local ToolItems = gameplay.Config.ToolItems
 
-    local assetsFolder = ReplicatedStorage:WaitForChild(ItemPresentation.REPLICATED_STORAGE_ASSETS_FOLDER, 10)
+    local assetsFolder =
+        ReplicatedStorage:WaitForChild(ItemPresentation.REPLICATED_STORAGE_ASSETS_FOLDER, 10)
     assert(
         assetsFolder ~= nil,
         'ReplicatedStorage should contain Assets folder (check tests/default.project.json)'

--- a/tests/src/Shared/ToolTemplatesContract.spec.luau
+++ b/tests/src/Shared/ToolTemplatesContract.spec.luau
@@ -1,0 +1,45 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
+    local ItemPresentation = gameplay.Config.ItemPresentation
+    local ToolItems = gameplay.Config.ToolItems
+
+    local assetsFolder = ReplicatedStorage:FindFirstChild(ItemPresentation.REPLICATED_STORAGE_ASSETS_FOLDER)
+    assert(assetsFolder ~= nil, 'ReplicatedStorage should contain Assets folder')
+
+    local templatesFolder = assetsFolder:FindFirstChild(ItemPresentation.TOOL_TEMPLATES_FOLDER)
+    assert(templatesFolder ~= nil, 'Assets should contain ToolTemplates folder')
+
+    for itemId, entry in pairs(ToolItems) do
+        local templateName = entry.ToolTemplateName
+        if type(templateName) == 'string' and templateName ~= '' then
+            local inst = templatesFolder:FindFirstChild(templateName)
+            assert(
+                inst ~= nil,
+                string.format(
+                    'ToolTemplates must contain model for ToolTemplateName=%q (item %q)',
+                    templateName,
+                    itemId
+                )
+            )
+            assert(
+                inst:IsA('Model') or inst:IsA('Tool'),
+                string.format(
+                    'Template %q for item %q must be a Model or Tool, got %s',
+                    templateName,
+                    itemId,
+                    inst.ClassName
+                )
+            )
+            local handle = inst:FindFirstChild('Handle', true)
+            assert(
+                handle ~= nil and handle:IsA('BasePart'),
+                string.format(
+                    'Template %q for item %q must have a BasePart named Handle (descendant)',
+                    templateName,
+                    itemId
+                )
+            )
+        end
+    end
+end

--- a/tests/src/Shared/ToolTemplatesContract.spec.luau
+++ b/tests/src/Shared/ToolTemplatesContract.spec.luau
@@ -4,11 +4,17 @@ return function()
     local ItemPresentation = gameplay.Config.ItemPresentation
     local ToolItems = gameplay.Config.ToolItems
 
-    local assetsFolder = ReplicatedStorage:FindFirstChild(ItemPresentation.REPLICATED_STORAGE_ASSETS_FOLDER)
-    assert(assetsFolder ~= nil, 'ReplicatedStorage should contain Assets folder')
+    local assetsFolder = ReplicatedStorage:WaitForChild(ItemPresentation.REPLICATED_STORAGE_ASSETS_FOLDER, 10)
+    assert(
+        assetsFolder ~= nil,
+        'ReplicatedStorage should contain Assets folder (check tests/default.project.json)'
+    )
 
-    local templatesFolder = assetsFolder:FindFirstChild(ItemPresentation.TOOL_TEMPLATES_FOLDER)
-    assert(templatesFolder ~= nil, 'Assets should contain ToolTemplates folder')
+    local templatesFolder = assetsFolder:WaitForChild(ItemPresentation.TOOL_TEMPLATES_FOLDER, 10)
+    assert(
+        templatesFolder ~= nil,
+        'Assets should contain ToolTemplates folder (check tests/default.project.json)'
+    )
 
     for itemId, entry in pairs(ToolItems) do
         local templateName = entry.ToolTemplateName

--- a/tests/src/TestSuite.module.luau
+++ b/tests/src/TestSuite.module.luau
@@ -1,7 +1,12 @@
 local TestSuite = {}
 
 local function getTestModules()
-    return script.Parent:WaitForChild('Shared'):GetChildren()
+    local sharedFolder = script.Parent:WaitForChild('Shared')
+    local modules = sharedFolder:GetChildren()
+    table.sort(modules, function(a, b)
+        return a.Name < b.Name
+    end)
+    return modules
 end
 
 function TestSuite.run()


### PR DESCRIPTION
Add minimal Model templates (ToolFlashlight, ToolCrowbar, ToolPotion) under assets/ToolTemplates and mount them from maze/run/tests Rojo projects so HeldToolVisual.sync can resolve templates.

- Contract spec: ToolItems.ToolTemplateName must exist with Handle
- Behavior spec: sync/clear HeldToolVisualClone on RightHand
- Export HeldToolVisual from Shared.Client; sync run harness ToolTemplates

Closes https://github.com/Gazerrr03/roblox_experience/issues/234

## Summary

- What changed?
- Why is this change needed?
- Any prototype-only exceptions or follow-up work?

## Roblox Integration Checklist

- [ ] The change updates the active runtime source under `packages/**`, or I explained why another source path had to change.
- [ ] If Studio tree structure changed, I updated the relevant `default.project.json` in the same PR.
- [ ] If I changed Remote names, replicated schema, or visibility behavior, I updated all linked producers/consumers/tests in the same PR.
- [ ] If I changed non-trivial shared/gameplay behavior, I added or updated deterministic coverage under `tests/src/Shared`, or I explained why no test change was needed.
- [ ] If I touched `SessionConfig.PlaceIds` or any other real-environment configuration, I documented the required rollout or environment follow-up.
- [ ] If this PR includes `.rbxl`, generated output, or other non-source artifacts, I explained why they are required.

## Validation

- [ ] `stylua --check .`
- [ ] `selene .`
- [ ] Additional verification steps are listed below if this PR needs more than static checks.

## Notes

- Manual test notes:
- Risks / follow-ups:
