### PR TITLE
feat(gameplay): share tool use effects between Run and Maze

### DIFF
--- a/packages/gameplay/src/ToolUseEffects.luau
+++ b/packages/gameplay/src/ToolUseEffects.luau
@@ -4,6 +4,8 @@
 
 local ToolUseEffects = {}
 
+local FLASHLIGHT_COLOR = Color3.fromRGB(255, 255, 240)
+
 export type ToolUseDeps = {
     MonsterService: any?,
     PlayerService: any?,
@@ -31,7 +33,7 @@ local function toggleHeadFlashlight(player: Player): (boolean, string)
 
     local spot = Instance.new('SpotLight')
     spot.Name = 'FlashlightLight'
-    spot.Color = Color3.fromRGB(255, 255, 240)
+    spot.Color = FLASHLIGHT_COLOR
     spot.Brightness = 2
     spot.Range = 50
     spot.Angle = 45

--- a/packages/gameplay/src/ToolUseEffects.luau
+++ b/packages/gameplay/src/ToolUseEffects.luau
@@ -20,10 +20,13 @@ local function toggleHeadFlashlight(player: Player): (boolean, string)
         return false, 'No head.'
     end
 
-    local flashlightLight = head:FindFirstChild('FlashlightLight')
-    if flashlightLight and flashlightLight:IsA('Light') then
-        flashlightLight.Enabled = not flashlightLight.Enabled
-        return flashlightLight.Enabled, ''
+    local existing = head:FindFirstChild('FlashlightLight')
+    if existing then
+        if existing:IsA('Light') then
+            existing.Enabled = not existing.Enabled
+            return existing.Enabled, ''
+        end
+        existing:Destroy()
     end
 
     local spot = Instance.new('SpotLight')

--- a/packages/gameplay/src/ToolUseEffects.luau
+++ b/packages/gameplay/src/ToolUseEffects.luau
@@ -1,0 +1,117 @@
+--!strict
+-- Shared server-side effects after a held tool successfully consumes use (cooldown / charges).
+-- Used by Maze and Run so flashlight / crowbar / potion behave the same.
+
+local ToolUseEffects = {}
+
+export type ToolUseDeps = {
+    MonsterService: any?,
+    PlayerService: any?,
+}
+
+local function toggleHeadFlashlight(player: Player): (boolean, string)
+    local character = player.Character
+    if not character then
+        return false, 'No character.'
+    end
+
+    local head = character:FindFirstChild('Head')
+    if not head or not head:IsA('BasePart') then
+        return false, 'No head.'
+    end
+
+    local flashlightLight = head:FindFirstChild('FlashlightLight')
+    if flashlightLight and flashlightLight:IsA('Light') then
+        flashlightLight.Enabled = not flashlightLight.Enabled
+        return flashlightLight.Enabled, ''
+    end
+
+    local spot = Instance.new('SpotLight')
+    spot.Name = 'FlashlightLight'
+    spot.Color = Color3.fromRGB(255, 255, 240)
+    spot.Brightness = 2
+    spot.Range = 50
+    spot.Angle = 45
+    spot.Face = Enum.NormalId.Front
+    spot.Enabled = true
+    spot.Parent = head
+
+    return true, ''
+end
+
+function ToolUseEffects.applyHeldToolUse(
+    player: Player,
+    updatedHeldItem: { [string]: any },
+    deps: ToolUseDeps
+): (string, string)
+    local category = updatedHeldItem.ToolCategory
+
+    if category == 'Flashlight' then
+        local enabled, err = toggleHeadFlashlight(player)
+        if not enabled and err ~= '' then
+            return 'flashed', err
+        end
+        if enabled then
+            return 'flashed', 'The area is illuminated.'
+        end
+        return 'flashed', 'You switch the beam off.'
+    end
+
+    if category == 'Crowbar' then
+        local actionWord = 'swung'
+        local effectText = 'A satisfying swoosh cuts the air!'
+
+        local damagePips = 1
+        if type(updatedHeldItem.MeleeDamage) == 'number' and updatedHeldItem.MeleeDamage >= 1 then
+            damagePips = math.floor(updatedHeldItem.MeleeDamage)
+        end
+
+        local monsterService = deps.MonsterService
+        if monsterService and type(monsterService.tryApplyPlayerMeleeHit) == 'function' then
+            local meleeOk, meleeResult = monsterService:tryApplyPlayerMeleeHit(player, {
+                DamagePips = damagePips,
+                SwingArcDegrees = updatedHeldItem.SwingArcDegrees,
+                SwingRange = updatedHeldItem.SwingRange,
+            })
+            if meleeOk then
+                if meleeResult and meleeResult.Killed then
+                    effectText = 'The crowbar connects — the threat goes down!'
+                elseif meleeResult and type(meleeResult.RemainingHitPoints) == 'number' then
+                    effectText = string.format(
+                        'The crowbar connects! Foe stamina: ~%d.',
+                        meleeResult.RemainingHitPoints
+                    )
+                end
+            end
+        end
+
+        return actionWord, effectText
+    end
+
+    if category == 'Potion' then
+        local actionWord = 'drank'
+        local healPips = 1
+        if
+            type(updatedHeldItem.HealHealthPips) == 'number'
+            and updatedHeldItem.HealHealthPips >= 1
+        then
+            healPips = math.floor(updatedHeldItem.HealHealthPips)
+        end
+
+        local playerService = deps.PlayerService
+        if not playerService or type(playerService.healHealthPips) ~= 'function' then
+            return actionWord, 'The brew has no effect (no player service).'
+        end
+
+        local healOk, healResult = playerService:healHealthPips(player, healPips)
+        if healOk then
+            return actionWord,
+                string.format('The brew steadies you — health pips: %d.', healResult)
+        end
+        return actionWord, string.format('The brew has no effect (%s).', tostring(healResult))
+    end
+
+    return 'used', 'It worked!'
+end
+
+return ToolUseEffects

--- a/packages/gameplay/src/init.luau
+++ b/packages/gameplay/src/init.luau
@@ -9,4 +9,5 @@ return {
     ProcGen = require(script.ProcGen),
     Roles = require(script.Roles),
     Session = require(script.Session),
+    ToolUseEffects = require(script.ToolUseEffects),
 }

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -1332,52 +1332,10 @@ function MazeSessionService:_handleUseTool(player)
 
     local updatedHeldItem = consumeResult
 
-    local actionWord = 'used'
-    local effectText = 'It worked!'
-
-    if updatedHeldItem.ToolCategory == 'Flashlight' then
-        actionWord = 'flashed'
-        effectText = 'The area is illuminated.'
-    elseif updatedHeldItem.ToolCategory == 'Crowbar' then
-        actionWord = 'swung'
-        effectText = 'A satisfying swoosh cuts the air!'
-
-        local damagePips = 1
-        if type(updatedHeldItem.MeleeDamage) == 'number' and updatedHeldItem.MeleeDamage >= 1 then
-            damagePips = math.floor(updatedHeldItem.MeleeDamage)
-        end
-
-        local meleeOk, meleeResult = self.MonsterService:tryApplyPlayerMeleeHit(player, {
-            DamagePips = damagePips,
-            SwingArcDegrees = updatedHeldItem.SwingArcDegrees,
-            SwingRange = updatedHeldItem.SwingRange,
-        })
-        if meleeOk then
-            if meleeResult and meleeResult.Killed then
-                effectText = 'The crowbar connects — the threat goes down!'
-            elseif meleeResult and type(meleeResult.RemainingHitPoints) == 'number' then
-                effectText = string.format(
-                    'The crowbar connects! Foe stamina: ~%d.',
-                    meleeResult.RemainingHitPoints
-                )
-            end
-        end
-    elseif updatedHeldItem.ToolCategory == 'Potion' then
-        actionWord = 'drank'
-        local healPips = 1
-        if
-            type(updatedHeldItem.HealHealthPips) == 'number'
-            and updatedHeldItem.HealHealthPips >= 1
-        then
-            healPips = math.floor(updatedHeldItem.HealHealthPips)
-        end
-        local healOk, healResult = self.PlayerService:healHealthPips(player, healPips)
-        if healOk then
-            effectText = string.format('The brew steadies you — health pips: %d.', healResult)
-        else
-            effectText = string.format('The brew has no effect (%s).', tostring(healResult))
-        end
-    end
+    local actionWord, effectText = Gameplay.ToolUseEffects.applyHeldToolUse(player, updatedHeldItem, {
+        MonsterService = self.MonsterService,
+        PlayerService = self.PlayerService,
+    })
 
     self:_setStatus(
         string.format(

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -1332,10 +1332,11 @@ function MazeSessionService:_handleUseTool(player)
 
     local updatedHeldItem = consumeResult
 
-    local actionWord, effectText = Gameplay.ToolUseEffects.applyHeldToolUse(player, updatedHeldItem, {
-        MonsterService = self.MonsterService,
-        PlayerService = self.PlayerService,
-    })
+    local actionWord, effectText =
+        Gameplay.ToolUseEffects.applyHeldToolUse(player, updatedHeldItem, {
+            MonsterService = self.MonsterService,
+            PlayerService = self.PlayerService,
+        })
 
     self:_setStatus(
         string.format(

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -2020,10 +2020,11 @@ function RunSessionService:_bindItemRemotes()
         end
 
         local updatedHeldItem = consumeResult
-        local actionWord, effectText = Gameplay.ToolUseEffects.applyHeldToolUse(player, updatedHeldItem, {
-            MonsterService = self.MonsterService,
-            PlayerService = self.PlayerService,
-        })
+        local actionWord, effectText =
+            Gameplay.ToolUseEffects.applyHeldToolUse(player, updatedHeldItem, {
+                MonsterService = self.MonsterService,
+                PlayerService = self.PlayerService,
+            })
 
         self:_setStatus(
             string.format(
@@ -2036,8 +2037,6 @@ function RunSessionService:_bindItemRemotes()
                 updatedHeldItem.CurrentState
             )
         )
-
-        self:_broadcastSnapshot()
     end)
 end
 

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -2001,7 +2001,42 @@ function RunSessionService:_bindItemRemotes()
             return
         end
 
-        self.InventoryService:consumeHeldItemState(player, os.clock())
+        local consumeOk, consumeResult, cooldownRemaining =
+            self.InventoryService:consumeHeldItemState(player, os.clock())
+        if not consumeOk then
+            if consumeResult == 'Cooldown' then
+                self:_toast(
+                    player,
+                    string.format(
+                        'Tool on cooldown (%.1fs left).',
+                        math.max(cooldownRemaining or 0, 0)
+                    ),
+                    'Error'
+                )
+            elseif consumeResult == 'Depleted' then
+                self:_toast(player, 'That tool is depleted.', 'Error')
+            end
+            return
+        end
+
+        local updatedHeldItem = consumeResult
+        local actionWord, effectText = Gameplay.ToolUseEffects.applyHeldToolUse(player, updatedHeldItem, {
+            MonsterService = self.MonsterService,
+            PlayerService = self.PlayerService,
+        })
+
+        self:_setStatus(
+            string.format(
+                '%s %s the %s. %s (%s remaining: %d)',
+                player.DisplayName,
+                actionWord,
+                updatedHeldItem.Name,
+                effectText,
+                updatedHeldItem.StateModel or 'state',
+                updatedHeldItem.CurrentState
+            )
+        )
+
         self:_broadcastSnapshot()
     end)
 end

--- a/tests/src/Shared/ToolUseEffects.spec.luau
+++ b/tests/src/Shared/ToolUseEffects.spec.luau
@@ -1,0 +1,74 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local Gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
+    local ToolUseEffects = Gameplay.ToolUseEffects
+
+    local fakePlayerCrowbar = {} :: any
+
+    local meleeCalled = false
+    local mockMonster = {
+        tryApplyPlayerMeleeHit = function(_self, pl, opts)
+            meleeCalled = true
+            assert(pl == fakePlayerCrowbar, 'player passed to melee')
+            assert(opts.DamagePips == 2, 'damage from MeleeDamage')
+            return false, 'OutOfRange'
+        end,
+    }
+
+    local action, effect = ToolUseEffects.applyHeldToolUse(fakePlayerCrowbar, {
+        ToolCategory = 'Crowbar',
+        MeleeDamage = 2,
+        SwingRange = 6,
+        SwingArcDegrees = 70,
+    }, { MonsterService = mockMonster })
+
+    assert(meleeCalled, 'MonsterService.tryApplyPlayerMeleeHit should be called')
+    assert(action == 'swung', action)
+    assert(string.find(effect, 'swoosh') ~= nil, effect)
+
+    local mockPlayerService = {
+        healHealthPips = function(_self, _player, amount)
+            assert(amount == 3, 'heal pips')
+            return true, 8
+        end,
+    }
+
+    action, effect = ToolUseEffects.applyHeldToolUse(fakePlayerCrowbar, {
+        ToolCategory = 'Potion',
+        HealHealthPips = 3,
+    }, { PlayerService = mockPlayerService })
+
+    assert(action == 'drank', action)
+    assert(string.find(effect, '8') ~= nil, effect)
+
+    action, effect = ToolUseEffects.applyHeldToolUse(fakePlayerCrowbar, {
+        ToolCategory = 'UnknownGadget',
+    }, {})
+
+    assert(action == 'used' and effect == 'It worked!', string.format('%s | %s', action, effect))
+
+    local charModel = Instance.new('Model')
+    local head = Instance.new('Part')
+    head.Name = 'Head'
+    head.Anchored = true
+    head.Parent = charModel
+    local fakePlayerLight = { Character = charModel } :: any
+
+    action, effect = ToolUseEffects.applyHeldToolUse(fakePlayerLight, {
+        ToolCategory = 'Flashlight',
+    }, {})
+
+    assert(action == 'flashed', action)
+    assert(string.find(effect, 'illuminated') ~= nil, effect)
+    local light = head:FindFirstChild('FlashlightLight')
+    assert(light and light:IsA('SpotLight'), 'SpotLight should be parented to Head')
+    assert(light.Enabled == true, 'first use should enable light')
+
+    action, effect = ToolUseEffects.applyHeldToolUse(fakePlayerLight, {
+        ToolCategory = 'Flashlight',
+    }, {})
+    assert(light.Enabled == false, 'second use toggles off')
+    assert(string.find(effect, 'beam off') ~= nil, effect)
+
+    charModel:Destroy()
+end


### PR DESCRIPTION
## Summary
- Add `Gameplay.ToolUseEffects` so flashlight / crowbar / potion **server-side effects** after a successful `consumeHeldItemState` live in one place.
- **Maze**: `_handleUseTool` calls the shared module (behavior unchanged, code deduped).
- **Run**: legacy `UseItem` path now runs the same effects, checks consume success before broadcast, and surfaces cooldown/depleted via toast + `_setStatus` on success.
- **Tests**: `ToolUseEffects.spec.luau` for crowbar/potion/unknown + flashlight toggle on a fake character with `Head`.

## Motivation
Run previously only consumed tool state on `UseItem` without melee/heal/flashlight parity with Maze.

## Test plan
- [x] `stylua` / `selene` on touched files
- [x] `rojo build tests/default.project.json` + `run-in-roblox` (ToolUseEffects spec)
- [ ] Studio: Run — equip tool, fire `UseItem` (or client path you use), verify status + gameplay matches expectations when expedition/monsters active

## Notes / follow-ups
- `ItemFunctionality` + `UseItemFunction` remote is **unchanged**; optional later PR to route or deprecate.

## Summary

- What changed?
- Why is this change needed?
- Any prototype-only exceptions or follow-up work?

## Roblox Integration Checklist

- [ ] The change updates the active runtime source under `packages/**`, or I explained why another source path had to change.
- [ ] If Studio tree structure changed, I updated the relevant `default.project.json` in the same PR.
- [ ] If I changed Remote names, replicated schema, or visibility behavior, I updated all linked producers/consumers/tests in the same PR.
- [ ] If I changed non-trivial shared/gameplay behavior, I added or updated deterministic coverage under `tests/src/Shared`, or I explained why no test change was needed.
- [ ] If I touched `SessionConfig.PlaceIds` or any other real-environment configuration, I documented the required rollout or environment follow-up.
- [ ] If this PR includes `.rbxl`, generated output, or other non-source artifacts, I explained why they are required.

## Validation

- [ ] `stylua --check .`
- [ ] `selene .`
- [ ] Additional verification steps are listed below if this PR needs more than static checks.

## Notes

- Manual test notes:
- Risks / follow-ups:
