### PR TITLE
更新迷宫工具模板：撬棍与药水 rbxmx

### DIFF
--- a/assets/ToolTemplates/ToolCrowbar.rbxmx
+++ b/assets/ToolTemplates/ToolCrowbar.rbxmx
@@ -181,9 +181,9 @@
 				<token name="RightSurfaceInput">0</token>
 				<int name="RootPriority">0</int>
 				<Vector3 name="RotVelocity">
-					<X>1</X>
-					<Y>1</Y>
-					<Z>1</Z>
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
 				</Vector3>
 				<float name="TopParamA">-0.5</float>
 				<float name="TopParamB">0.5</float>
@@ -257,75 +257,6 @@
 					<BinaryString name="Tags"></BinaryString>
 				</Properties>
 			</Item>
-		</Item>
-		<Item class="Script" referent="RBX1787527955E94A928791287F523D1A80">
-			<Properties>
-				<ProtectedString name="Source"><![CDATA[local tool = script.Parent
-local canDamage = false
-local cooldown = script.cooldown.Value
-local sound2 = script.Parent.Handle.Sound2
-local function onTouch(otherPart)
-
-			local humanoid = otherPart.Parent:FindFirstChild("Zombie")
-	if not humanoid then 
-		return 
-	end
-	if humanoid.Parent ~= tool.Parent and canDamage and cooldown == false then 
-		cooldown = true
-		sound2:Play()
-		humanoid:TakeDamage(19)
-		wait(1)
-		cooldown = false
-	else
-		return
-	end
-	canDamage = false
-end
-local function slash()
-	local str = Instance.new("StringValue")
-	str.Name = "toolanim"
-	str.Parent = tool
-		canDamage = true
-
-end
-	tool.Activated:Connect(slash)
-	tool.Handle.Touched:Connect(onTouch)
-
-
-]]></ProtectedString>
-				<bool name="Disabled">false</bool>
-				<Content name="LinkedSource"><null></null></Content>
-				<token name="RunContext">0</token>
-				<string name="ScriptGuid">{510F704C-E20B-4CB9-BB72-1AE0EDDFACBF}</string>
-				<BinaryString name="AttributesSerialize"></BinaryString>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-				<bool name="DefinesCapabilities">false</bool>
-				<string name="Name">hit</string>
-				<int64 name="SourceAssetId">-1</int64>
-				<BinaryString name="Tags"></BinaryString>
-			</Properties>
-			<Item class="BoolValue" referent="RBX3820891C35434A80A59F31803D4CFA73">
-				<Properties>
-					<bool name="Value">false</bool>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-					<bool name="DefinesCapabilities">false</bool>
-					<string name="Name">cooldown</string>
-					<int64 name="SourceAssetId">-1</int64>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
-		</Item>
-		<Item class="Animation" referent="RBXBDA340F8DE8A49F88FD6F8CE65CDE49A">
-			<Properties>
-				<Content name="AnimationId"><url>rbxassetid://12799561514</url></Content>
-				<BinaryString name="AttributesSerialize"></BinaryString>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-				<bool name="DefinesCapabilities">false</bool>
-				<string name="Name">Slash</string>
-				<int64 name="SourceAssetId">-1</int64>
-				<BinaryString name="Tags"></BinaryString>
-			</Properties>
 		</Item>
 	</Item>
 	<SharedStrings>

--- a/assets/ToolTemplates/ToolCrowbar.rbxmx
+++ b/assets/ToolTemplates/ToolCrowbar.rbxmx
@@ -1,42 +1,408 @@
-<?xml version="1.0" encoding="utf-8"?>
 <roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
-  <Meta name="ExplicitAutoJoints">true</Meta>
-  <External>null</External>
-  <External>nil</External>
-  <Item class="Model" referent="RBXToolCrowbarRoot">
-    <Properties>
-      <string name="Name">ToolCrowbar</string>
-    </Properties>
-    <Item class="Part" referent="RBXToolCrowbarHandle">
-      <Properties>
-        <string name="Name">Handle</string>
-        <bool name="Anchored">true</bool>
-        <bool name="CanCollide">false</bool>
-        <Vector3 name="Size">
-          <X>0.15</X>
-          <Y>0.55</Y>
-          <Z>0.12</Z>
-        </Vector3>
-        <CoordinateFrame name="CFrame">
-          <X>0</X>
-          <Y>0</Y>
-          <Z>0</Z>
-          <R00>1</R00>
-          <R01>0</R01>
-          <R02>0</R02>
-          <R10>0</R10>
-          <R11>1</R11>
-          <R12>0</R12>
-          <R20>0</R20>
-          <R21>0</R21>
-          <R22>1</R22>
-        </CoordinateFrame>
-        <Color3 name="Color">
-          <R>0.7843137383460999</R>
-          <G>0.7843137383460999</G>
-          <B>0.7843137383460999</B>
-        </Color3>
-      </Properties>
-    </Item>
-  </Item>
+	<Meta name="ExplicitAutoJoints">true</Meta>
+	<External>null</External>
+	<External>nil</External>
+	<Item class="Tool" referent="RBXC94037B37E98488C8C501F1C3E2FD8D8">
+		<Properties>
+			<bool name="CanBeDropped">true</bool>
+			<bool name="Enabled">true</bool>
+			<CoordinateFrame name="Grip">
+				<X>-0.0857925415</X>
+				<Y>-0.79999733</Y>
+				<Z>-0.206478119</Z>
+				<R00>-0.997564137</R00>
+				<R01>5.68969689e-08</R01>
+				<R02>0.0697562769</R02>
+				<R10>5.71861847e-08</R10>
+				<R11>1</R11>
+				<R12>2.14917906e-09</R12>
+				<R20>-0.0697562769</R20>
+				<R21>6.13303897e-09</R21>
+				<R22>-0.997564137</R22>
+			</CoordinateFrame>
+			<bool name="ManualActivationOnly">false</bool>
+			<bool name="RequiresHandle">true</bool>
+			<string name="ToolTip"></string>
+			<Content name="TextureId"><null></null></Content>
+			<token name="LevelOfDetail">0</token>
+			<CoordinateFrame name="ModelMeshCFrame">
+				<X>0</X>
+				<Y>0</Y>
+				<Z>0</Z>
+				<R00>1</R00>
+				<R01>0</R01>
+				<R02>0</R02>
+				<R10>0</R10>
+				<R11>1</R11>
+				<R12>0</R12>
+				<R20>0</R20>
+				<R21>0</R21>
+				<R22>1</R22>
+			</CoordinateFrame>
+			<SharedString name="ModelMeshData">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
+			<Vector3 name="ModelMeshSize">
+				<X>0</X>
+				<Y>0</Y>
+				<Z>0</Z>
+			</Vector3>
+			<token name="ModelStreamingMode">0</token>
+			<bool name="NeedsPivotMigration">false</bool>
+			<Ref name="PrimaryPart">null</Ref>
+			<float name="ScaleFactor">1</float>
+			<SharedString name="SlimHash">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
+			<OptionalCoordinateFrame name="WorldPivotData">
+				<CFrame>
+					<X>47.4401093</X>
+					<Y>-6.11881924</Y>
+					<Z>12.1000061</Z>
+					<R00>-0.997564077</R00>
+					<R01>5.71861811e-08</R01>
+					<R02>-0.0697562695</R02>
+					<R10>0.0697562695</R10>
+					<R11>2.14917883e-09</R11>
+					<R12>-0.997564018</R12>
+					<R20>-5.68969689e-08</R20>
+					<R21>-1</R21>
+					<R22>-6.13303897e-09</R22>
+				</CFrame>
+			</OptionalCoordinateFrame>
+			<BinaryString name="AttributesSerialize"></BinaryString>
+			<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+			<bool name="DefinesCapabilities">false</bool>
+			<string name="Name">ToolCrowbar</string>
+			<int64 name="SourceAssetId">11981459837</int64>
+			<BinaryString name="Tags"></BinaryString>
+		</Properties>
+		<Item class="MeshPart" referent="RBXC6B8788FC4FC4675B78A916BF496C7CD">
+			<Properties>
+				<bool name="DoubleSided">false</bool>
+				<bool name="HasJointOffset">false</bool>
+				<bool name="HasSkinnedMesh">false</bool>
+				<Vector3 name="InitialSize">
+					<X>9.83852577</X>
+					<Y>212.872955</Y>
+					<Z>47.2966652</Z>
+				</Vector3>
+				<Vector3 name="JointOffset">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<Content name="MeshId"><url>rbxassetid://441564090</url></Content>
+				<BinaryString name="PhysicsData"></BinaryString>
+				<token name="RenderFidelity">1</token>
+				<Content name="TextureID"><url>rbxassetid://441564112</url></Content>
+				<int name="VertexCount">0</int>
+				<SharedString name="AeroMeshData">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
+				<token name="FluidFidelityInternal">0</token>
+				<bool name="InertiaMigrated">true</bool>
+				<SharedString name="PhysicalConfigData">d9uxvF2B2ZEwqqb1h+2fiQ==</SharedString>
+				<Vector3 name="UnscaledCofm">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<Vector3 name="UnscaledVolInertiaDiags">
+					<X>426217888</X>
+					<Y>26663710</Y>
+					<Z>403700416</Z>
+				</Vector3>
+				<Vector3 name="UnscaledVolInertiaOffDiags">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<float name="UnscaledVolume">99056.0547</float>
+				<bool name="Anchored">false</bool>
+				<bool name="AudioCanCollide">true</bool>
+				<float name="BackParamA">-0.5</float>
+				<float name="BackParamB">0.5</float>
+				<token name="BackSurface">0</token>
+				<token name="BackSurfaceInput">0</token>
+				<float name="BottomParamA">-0.5</float>
+				<float name="BottomParamB">0.5</float>
+				<token name="BottomSurface">0</token>
+				<token name="BottomSurfaceInput">0</token>
+				<CoordinateFrame name="CFrame">
+					<X>-1.92995453</X>
+					<Y>0.440590382</Y>
+					<Z>-1</Z>
+					<R00>-0.997564077</R00>
+					<R01>5.71861811e-08</R01>
+					<R02>-0.0697562695</R02>
+					<R10>0.0697562695</R10>
+					<R11>2.14917883e-09</R11>
+					<R12>-0.997564018</R12>
+					<R20>-5.68969689e-08</R20>
+					<R21>-1</R21>
+					<R22>-6.13303897e-09</R22>
+				</CoordinateFrame>
+				<bool name="CanCollide">true</bool>
+				<bool name="CanQuery">true</bool>
+				<bool name="CanTouch">true</bool>
+				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
+				<int name="CollisionGroupId">0</int>
+				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
+				<PhysicalProperties name="CustomPhysicalProperties">
+					<CustomPhysics>false</CustomPhysics>
+				</PhysicalProperties>
+				<bool name="EnableFluidForces">true</bool>
+				<float name="FrontParamA">-0.5</float>
+				<float name="FrontParamB">0.5</float>
+				<token name="FrontSurface">0</token>
+				<token name="FrontSurfaceInput">0</token>
+				<float name="LeftParamA">-0.5</float>
+				<float name="LeftParamB">0.5</float>
+				<token name="LeftSurface">0</token>
+				<token name="LeftSurfaceInput">0</token>
+				<bool name="Locked">false</bool>
+				<bool name="Massless">false</bool>
+				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
+				<CoordinateFrame name="PivotOffset">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+					<R00>1</R00>
+					<R01>0</R01>
+					<R02>0</R02>
+					<R10>0</R10>
+					<R11>1</R11>
+					<R12>0</R12>
+					<R20>0</R20>
+					<R21>0</R21>
+					<R22>1</R22>
+				</CoordinateFrame>
+				<float name="Reflectance">0</float>
+				<float name="RightParamA">-0.5</float>
+				<float name="RightParamB">0.5</float>
+				<token name="RightSurface">0</token>
+				<token name="RightSurfaceInput">0</token>
+				<int name="RootPriority">0</int>
+				<Vector3 name="RotVelocity">
+					<X>1</X>
+					<Y>1</Y>
+					<Z>1</Z>
+				</Vector3>
+				<float name="TopParamA">-0.5</float>
+				<float name="TopParamB">0.5</float>
+				<token name="TopSurface">0</token>
+				<token name="TopSurfaceInput">0</token>
+				<float name="Transparency">0</float>
+				<Vector3 name="Velocity">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<Vector3 name="size">
+					<X>0.225215808</X>
+					<Y>4.87296438</Y>
+					<Z>1.08268309</Z>
+				</Vector3>
+				<BinaryString name="AttributesSerialize"></BinaryString>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+				<bool name="DefinesCapabilities">false</bool>
+				<string name="Name">Handle</string>
+				<int64 name="SourceAssetId">441564128</int64>
+				<BinaryString name="Tags"></BinaryString>
+			</Properties>
+			<Item class="Sound" referent="RBX9AAB50D7F938486C80BCB38B624FEF79">
+				<Properties>
+					<bool name="AcousticSimulationEnabled">true</bool>
+					<NumberRange name="LoopRegion">0 60000 </NumberRange>
+					<bool name="Looped">false</bool>
+					<bool name="PlayOnRemove">false</bool>
+					<NumberRange name="PlaybackRegion">0 60000 </NumberRange>
+					<bool name="PlaybackRegionsEnabled">false</bool>
+					<float name="PlaybackSpeed">1</float>
+					<bool name="Playing">false</bool>
+					<float name="RollOffMaxDistance">10000</float>
+					<float name="RollOffMinDistance">10</float>
+					<token name="RollOffMode">0</token>
+					<Ref name="SoundGroup">null</Ref>
+					<Content name="SoundId"><url>rbxassetid://6319141700</url></Content>
+					<double name="TimePosition">0</double>
+					<float name="Volume">0.5</float>
+					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+					<bool name="DefinesCapabilities">false</bool>
+					<string name="Name">Sound2</string>
+					<int64 name="SourceAssetId">-1</int64>
+					<BinaryString name="Tags"></BinaryString>
+				</Properties>
+			</Item>
+			<Item class="Sound" referent="RBXBE03C4D8D45D44509CC0080154620B52">
+				<Properties>
+					<bool name="AcousticSimulationEnabled">true</bool>
+					<NumberRange name="LoopRegion">0 60000 </NumberRange>
+					<bool name="Looped">false</bool>
+					<bool name="PlayOnRemove">false</bool>
+					<NumberRange name="PlaybackRegion">0 60000 </NumberRange>
+					<bool name="PlaybackRegionsEnabled">false</bool>
+					<float name="PlaybackSpeed">1</float>
+					<bool name="Playing">false</bool>
+					<float name="RollOffMaxDistance">10000</float>
+					<float name="RollOffMinDistance">10</float>
+					<token name="RollOffMode">0</token>
+					<Ref name="SoundGroup">null</Ref>
+					<Content name="SoundId"><url>rbxassetid://2156366946</url></Content>
+					<double name="TimePosition">0</double>
+					<float name="Volume">0.5</float>
+					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+					<bool name="DefinesCapabilities">false</bool>
+					<string name="Name">Sound</string>
+					<int64 name="SourceAssetId">-1</int64>
+					<BinaryString name="Tags"></BinaryString>
+				</Properties>
+			</Item>
+		</Item>
+		<Item class="Script" referent="RBX1787527955E94A928791287F523D1A80">
+			<Properties>
+				<ProtectedString name="Source"><![CDATA[local tool = script.Parent
+local canDamage = false
+local cooldown = script.cooldown.Value
+local sound2 = script.Parent.Handle.Sound2
+local function onTouch(otherPart)
+
+			local humanoid = otherPart.Parent:FindFirstChild("Zombie")
+	if not humanoid then 
+		return 
+	end
+	if humanoid.Parent ~= tool.Parent and canDamage and cooldown == false then 
+		cooldown = true
+		sound2:Play()
+		humanoid:TakeDamage(19)
+		wait(1)
+		cooldown = false
+	else
+		return
+	end
+	canDamage = false
+end
+local function slash()
+	local str = Instance.new("StringValue")
+	str.Name = "toolanim"
+	str.Parent = tool
+		canDamage = true
+
+end
+	tool.Activated:Connect(slash)
+	tool.Handle.Touched:Connect(onTouch)
+
+
+]]></ProtectedString>
+				<bool name="Disabled">false</bool>
+				<Content name="LinkedSource"><null></null></Content>
+				<token name="RunContext">0</token>
+				<string name="ScriptGuid">{510F704C-E20B-4CB9-BB72-1AE0EDDFACBF}</string>
+				<BinaryString name="AttributesSerialize"></BinaryString>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+				<bool name="DefinesCapabilities">false</bool>
+				<string name="Name">hit</string>
+				<int64 name="SourceAssetId">-1</int64>
+				<BinaryString name="Tags"></BinaryString>
+			</Properties>
+			<Item class="BoolValue" referent="RBX3820891C35434A80A59F31803D4CFA73">
+				<Properties>
+					<bool name="Value">false</bool>
+					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+					<bool name="DefinesCapabilities">false</bool>
+					<string name="Name">cooldown</string>
+					<int64 name="SourceAssetId">-1</int64>
+					<BinaryString name="Tags"></BinaryString>
+				</Properties>
+			</Item>
+		</Item>
+		<Item class="Animation" referent="RBXBDA340F8DE8A49F88FD6F8CE65CDE49A">
+			<Properties>
+				<Content name="AnimationId"><url>rbxassetid://12799561514</url></Content>
+				<BinaryString name="AttributesSerialize"></BinaryString>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+				<bool name="DefinesCapabilities">false</bool>
+				<string name="Name">Slash</string>
+				<int64 name="SourceAssetId">-1</int64>
+				<BinaryString name="Tags"></BinaryString>
+			</Properties>
+		</Item>
+	</Item>
+	<SharedStrings>
+		<SharedString md5="d9uxvF2B2ZEwqqb1h+2fiQ==">Q1NHUEhTCAAAAAIAKLUv/WAwG7V7ACqv+ClEEDDqzQGirmTnATx9Ns/iRFxx2yLTlBfQqHQz
+OnoBlDKZvamUw+er9Ga/wiWToAqb+ExKwwUc3zEi/w8QbutoUfXU2AGZApACgQKGXBqZG21S
+zW8367ZWK4PvjXoV2NodNb7n5MbDKcJ0vdS6emRjCNvL8Y3zfQBFV+Bbk+zumGWodn303nvv
+vXfvvffe+w7Ve+/9rXfvve/+0GmGcxm4kJ0Y0GV7e0BxbgWU+fEwagf6gMK5V7SyI4fFXaSB
+ovyBnYsdeMSTc8FEObYjYQtKd3iXhi8bglVtL1aMc8P48uKO1D48YcW5LMbyYgkicJFG85MO
+Wnbh5A/e1dCmtzl9OzCLFN6l+tNv/nIDco7gXR4K6DW/ss1nldcspXuPcQqIt7Ed+DXHuY+Q
+WgCuEfaeCEEeeWR2kUu3w63E3Xd9obdJYwtSabszgrgNTRDBudYn2Yst7sMzLpyLRpYXN2zu
+QSwxAglI24MgSCG7tFtwgKdI7PYKkvHu0JreniDcgzVb3k1S0nNYNGwjiNk5SpvNl4S/ZYK3
+YMxVb72fe/AuSN6zedl7dh/4BnlcLdPWRMpAUgfylGaV+oGtlIHR6oyGWUDFlW2SYsnp6avv
+ZetAL1cKQ3Z5RwLDpIwJifOSYSg01KKJUpBe5lQipr9somIIhQ1yPlaCcqhatqR4enWGokJ4
+UFalcwblbNgCdLrawCcUNCSVForZlVM5eN2y08vaIJOT46QpdVXlzzNHTwsLjsdNmRwQeiMM
+GcQuRkXytyhLemCZH8RuB9jJKYSRwqAiRlJYy7EnIl4bRoZEFvmbandVJaSUIHBPykloCqGn
+lSAlL/aLY0fP1uGFHCfJMCmcF55YAJcmZSTkFLRkVJi45VvoFRpFIAQko1D4AowWG0RT68KQ
+wCJKhVNcSZ5WhEDqYQ0XpaxxMGQtNGxEEUu4/ogfsuJISy/ftdJJpR1IkEpfaKTSCk8peKTS
+GCKpFKZIKpXiBJ9akxlSccEqB71lMYF2W8LD/UTHNJBL7N466fG+rpJ343rhfpUudpeWNh4o
+wp+Xw0Brd/nYwo/8IfFxdqAWvFarRNM+0qxywCmq1l4McpPM0Fyjjnph0lfNLDqozkrcp7Xz
+Z5XO/9lwA5NLxIueCQKvb/u05L0qAHQYjauWsPBjEJ7LNrn4MT73NAcref+ADcBxX5sHedIC
+qV/tnILBUcZHwMQ37tMOdswfXD/KyBv74cQ+S2onBM5bM5D4Pqw/VTLSvlyZFANukr6XDH+m
+QoNfndLSMXRfny6vLUayIs1Pv3LERBBg7Jh+j/0nfCQm0iE0fzIJ/U8lcJDVBYJcxMMPmzNB
+EPk1LoCJ4qL9qAuqV8KuB5Lj8omz/dOxCqZBXGI+Q94nrXr+9AaMPFnjw59+sJjvyIeMmQPp
+A70ofnrxNBUPKtb7gERbYXB9KQW+rBkY0Fnbc+L3IPSJIHDtj+YBkvIsxj8rwbGDbqo/tgCK
+mM8zzvMclXnqE5zP6ih+tvGmYyrp8quAHuisxqrvI4kTb5AXJE9ekIDeEQWLH8Y1fE1n1/tw
+cfEzOHVWkrttZGFA+/PknTSru8zH1qOAmvYlaQ2umFmUQeWom8QOlzOhgdEBSAk3mHfSjNpm
+SD2EQujtIh46NpXnDpqyIVVDsoE6c75SY0WC6LUPgHKlb7EhwXu/gOQoXwI28hi8UNgkCKuc
+CQGJPfxpkxlVUNEubiTYVm0iuNdKBX02RISIOKmJdnRkxbMMdI4vjcYsUReFkbcHTTpueH3r
+mzP0tPa+hyZ4ZxdnjDybo98GMwvneKDLLpOZklOsYGfAdeuhubnBUmS1SjBprblsOs4wx+5S
+QcpSnPTtICaoMkNyatUKuD8BiV2fPq5DmNVn5RZjxMslD2Rpy1Oh8l/g0Pj3mNDWHDg+Dwo6
+Y8WZLzM3zPhHYuq5pSTfC0XNWYknH4jniLjvSem4KSw9d3ZWU6j98fE+t2LFqUXvtoPzhygZ
+jBVngPB005gfBAtZ/FOw8nMBUKrJzQFp8Dovlp8NxVMMCz2ZR9yxZqyDYXD5PtQs3HFnRv6m
+wJY/AHWeOyki6t/Oq+79PtrCGaNkeiWNz9dOQjnjkYwMvrrweUCjeOMIUzmst3+MGSRnXIKh
+ry9OfJisK3cCY5bDQmC0+U+k6XinEuitX5l/dHRZLYLCv06Aww8r1HTRBK49xvSJx3liudJD
+Cv9GBFTAXWm/isTlcVYwi75Q/Ds4DOCKaRz0FWdNR/rFUaDF7tMkjtDBJyx/9qmG8GlukvJX
+S5W/ggmjtoKb/BudYLzSw0zOOTwQ8de/4AxZm+gBgz+SbepriwJy7oZfDjwyCgm53r1YLzyS
+Da+HH8H8jVFODkXzgR4GrODd8kpwRwpG/bW6BXIKWwdnTq11vrrxPHKLl8NGqDlfFR7p3y00
+PUN5LfljCF5/dZHYz/Cq/PGECv46IqvJmaTHXgWC6B4RMAZXNJOSwRDQXZNyeCyJVsKjmb/g
+rmOTocdiq3oI/vC5e++7ABrc8Mc8z/4lwTHnyhMi4ExwxPR1CoF9AYiGP974zOG2s0mkDebm
+vdc/Z44/OWPq4bWqjr9d/IliZf9qgshLTUocSlgyg4te6DoXVd4IxamvMrgbgxgVT6JpqS/I
+3M6gzI5NiBqLpYqEGezgIjaNJEXjShxY6uAHDtBaa21Ws9eAEY6tNsWLCyap+S+77VYje+GA
+iR18XSQGRFx8uAJfayFGzllrI6uKCN+7ERpHq8LroY9iRaATmHWttZkVES4nZSGPEmX+bNjn
+clNk2XKIjRIYOtbl1grKPzQdry2/SSfL5XqQvFaTCZ+uKS3wn1G/W6N6zYSrjGoeuHCutFLx
+ncRK8FjFFkx1XD2Hfu7o1CcDeK2FKM2oGp2qLK/QPyoFD23l4fmhZiK1FhuRwQ901rQjh3Jg
+4U+VOuDUKjBt/WbOy0jqr6x7AkBW2S7ds0934ihpZMlaO2AjVAkySmCXLqNIvpZpR/3M7KdN
+Jq0rMQ+ELKg+ELYxVAnwT7F0dWrh1lurIn9WlIOmhZo/NVHA/tPVTgAOdfSetU7ggFBpDbet
+r20xGiWAVvApSqNWZtquffCBnFqESqv+dAkKnSqkg9RbHRj8WU7JzELvn+7ACUql0kxJ41J3
+rI6VtTbgMl/RnkCsdsb8J8QjLZ2gKx8ohSLokQ9/6rfVqTzovNWG7WezwGVief1pADmfMsOd
+1o0zeu+9+0hqAHr54NM7JGuN00HOztAAtRlSJ/RVnRx7ulNy3RR9qwP6WQFaZeVP50zoVAs2
++KwRbPzsFKZMDii+z+ZbTJ38V7p3ry4huCAOjlxZQAc5a11D1RHWUvD3DhuNPTJCqcESK9jx
+d3Xq8cBRoy6KwfFDOc7wu+sIFr8sjQPRGV6/LCYEv6Ok7GHK3XWY8LsrablSusA3k6AJ/LlD
+k8AaoX26qr7Po4rw96Xy9+gr+A9JhCtQWX6SEyEcEOvQX2MAP9Rf97r9+ViXOlZQBv4mCNT8
+VZLF54ETzZVW+5vZNVDZgY32LShG9HIN5AfoH9ZojCNfxrTWGvKwxwthef5hEghiKIR5Pq4u
+yTecQtXZNbH1hMUBgz6ogloNRoQ4JTIiMpIkSWMSawKOIYGeo25iwjJBcoU6YIwBv7V+CE5Q
+HtDNvbJHyxbzAr3GYsTf3BjyyOHx+j2dLtMlfnSn723qw1XDMy77wDBM4A2n6zg8PhvIiUry
+7xOt6xfSy+ZfYrWLoNXjKl+ub4HnDOsf8U60FIvwPmH+5pxhc/1z/r5YB0Otw/gnvHnO9vKp
+r89f2In3/q+pb9lvbdt/LMXFUMCh+RnvNJb3SDfoyMs8v/d8PEi5RzH+EX8JQdb2GYAd+c4n
+XjW5o483psnmX06OmMNkobG32D3CAn/N1fXyJjZ/LMru7+FfhvWj1bvDaZ3SGzKfMjxxv3mz
+9fJr+gfmMMNr6pjvp/fNmMbpQvZvB5xd/9jR1Ztmk945mHXFQjp/wHzZtrgj+G2ywPdluzyv
+/Xa5zI/1T8szerfyNG/58ijhkA442xBn5MmxaWQkL/udlH1ewx2ZTuzb98B4TNHF8V+9/a65
+5K97qZ2kcQNwyxUrzIH8hdjmR+k31q5lZRm8yhtz3UlDHtn3T91zRc+dSGMIyjYFQU9ogy8Z
+naXgExh/sTaoA+w/u2YkrXRx+6/Q7GnBRz5J0l49+/Uzz12tWLvY1PJkhhE486WFta+f3Qh3
+EyylCTSn5JyqvzXOw0+T7Jii6X+AtgG2FN9tScf4cSQDGvrlegfhdBT6dZ/aOkDhTV3/ZcZf
+ef6+pQ1+m5Cd1bMufrizPmVHC6+OvV9m44a78141ZsEg5qyKj71Czre9qwNygmWvceLX5wET
+57N8HVa7imc8//XdnSdNoOArrWtxubfxOcUmywSfaTLPCgfKvBOtdiT6sZiGFenVrgex79N0
+fJaMv664uADElDORjOPThsGZD3Yu1ogLErzAu3UY8vnbvqeWa4K/6wR747VasO20k8IEDuw/
+zq+y+ZnXgtc88vBusP+AxlqR4U7Ru3YrZc7Bl5hPy3W13QbEqDomINx4KJSAo0Eflu9kL9ea
+/M746YPJigTkcA5xnnPtxmbyCDLpmv/kVC7EaXLcpYkOtrhQ1X87yih/XXxG4x9ED33qgg91
+sjmr0tmQ/Ev4xq0+3xX7obgqv2ruRos4USjMgD9/FOQzn6uJQVbihZIzCo4l+SSVh4i/PA6j
+vwgIccM1OwReelHlnlxgdD3xxF6V65csm0m9zs0I9IbigLHl29kH0Y+JdH6k45x/HIc3ubOS
+WEG/m93tGY77B5h4eV5ko78YqRTd2+vniFXkrzi8fK01Ib+B9yhsMo7/a95z8nsheBxwYHiR
+YTP6yoL0ZYby8vckZCaxw2d1qcx1JSbpb09cXh4kav6yKpKjLT5nZM9y/HAa/zD783cZqYxN
+fAVyTxyw+HF0kWzh8l3jweQQwa6C9J4n1ej8dc109AglD6xm13nA8zepbXdk6UYeD+J74vGE
+OeTSstuncpx5XpzX3zTtMp4/4WNXJr9/x+cfJxFu3ky56o7N8Xo70K2fMhTxoLgL7XCsd+x/
+/T2R1Rxz1Jx6HmTl2uDe1op7XQ5GDSwxc+KGyvA/BrxOOb8+OTXOx/O/q8rX/B4l+0tlXOAM
++kdQueOHX+k9gTj2Y+/4pJdhM+vfYrOJDp547XymenVn5NGIHxbEZ55Bt4XF8Vg77yI//oui
+UZT2I9AH4u5T/j3zMufCPC8j/TwInP+TBWG06sdYgTbzgezdoz0=</SharedString>
+		<SharedString md5="yuZpQdnvvUBOTYh1jqZ2cA=="></SharedString>
+	</SharedStrings>
 </roblox>

--- a/assets/ToolTemplates/ToolPotion.rbxmx
+++ b/assets/ToolTemplates/ToolPotion.rbxmx
@@ -1,42 +1,496 @@
-<?xml version="1.0" encoding="utf-8"?>
 <roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
-  <Meta name="ExplicitAutoJoints">true</Meta>
-  <External>null</External>
-  <External>nil</External>
-  <Item class="Model" referent="RBXToolPotionRoot">
-    <Properties>
-      <string name="Name">ToolPotion</string>
-    </Properties>
-    <Item class="Part" referent="RBXToolPotionHandle">
-      <Properties>
-        <string name="Name">Handle</string>
-        <bool name="Anchored">true</bool>
-        <bool name="CanCollide">false</bool>
-        <Vector3 name="Size">
-          <X>0.25</X>
-          <Y>0.45</Y>
-          <Z>0.25</Z>
-        </Vector3>
-        <CoordinateFrame name="CFrame">
-          <X>0</X>
-          <Y>0</Y>
-          <Z>0</Z>
-          <R00>1</R00>
-          <R01>0</R01>
-          <R02>0</R02>
-          <R10>0</R10>
-          <R11>1</R11>
-          <R12>0</R12>
-          <R20>0</R20>
-          <R21>0</R21>
-          <R22>1</R22>
-        </CoordinateFrame>
-        <Color3 name="Color">
-          <R>0.9254902005195618</R>
-          <G>0.2823529541492462</G>
-          <B>0.6000000238418579</B>
-        </Color3>
-      </Properties>
-    </Item>
-  </Item>
+	<Meta name="ExplicitAutoJoints">true</Meta>
+	<External>null</External>
+	<External>nil</External>
+	<Item class="Model" referent="RBX080AB10590E744CFAB5863C57981C6B9">
+		<Properties>
+			<token name="LevelOfDetail">0</token>
+			<CoordinateFrame name="ModelMeshCFrame">
+				<X>0</X>
+				<Y>0</Y>
+				<Z>0</Z>
+				<R00>1</R00>
+				<R01>0</R01>
+				<R02>0</R02>
+				<R10>0</R10>
+				<R11>1</R11>
+				<R12>0</R12>
+				<R20>0</R20>
+				<R21>0</R21>
+				<R22>1</R22>
+			</CoordinateFrame>
+			<SharedString name="ModelMeshData">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
+			<Vector3 name="ModelMeshSize">
+				<X>0</X>
+				<Y>0</Y>
+				<Z>0</Z>
+			</Vector3>
+			<token name="ModelStreamingMode">0</token>
+			<bool name="NeedsPivotMigration">false</bool>
+			<Ref name="PrimaryPart">null</Ref>
+			<float name="ScaleFactor">1</float>
+			<SharedString name="SlimHash">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
+			<OptionalCoordinateFrame name="WorldPivotData">
+				<CFrame>
+					<X>50.5317383</X>
+					<Y>60.1407471</Y>
+					<Z>26.5506592</Z>
+					<R00>1</R00>
+					<R01>0</R01>
+					<R02>0</R02>
+					<R10>0</R10>
+					<R11>1</R11>
+					<R12>0</R12>
+					<R20>0</R20>
+					<R21>0</R21>
+					<R22>1</R22>
+				</CFrame>
+			</OptionalCoordinateFrame>
+			<BinaryString name="AttributesSerialize"></BinaryString>
+			<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+			<bool name="DefinesCapabilities">false</bool>
+			<string name="Name">ToolPotion</string>
+			<int64 name="SourceAssetId">11273536123</int64>
+			<BinaryString name="Tags"></BinaryString>
+		</Properties>
+		<Item class="MeshPart" referent="RBX4FBED7EA93294805A3DC7D5216FCDD42">
+			<Properties>
+				<bool name="DoubleSided">false</bool>
+				<bool name="HasJointOffset">false</bool>
+				<bool name="HasSkinnedMesh">false</bool>
+				<Vector3 name="InitialSize">
+					<X>2</X>
+					<Y>2.00000024</Y>
+					<Z>2.00000024</Z>
+				</Vector3>
+				<Vector3 name="JointOffset">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<Content name="MeshId"><url>rbxassetid://442130733</url></Content>
+				<BinaryString name="PhysicsData"></BinaryString>
+				<token name="RenderFidelity">1</token>
+				<Content name="TextureID"><null></null></Content>
+				<int name="VertexCount">0</int>
+				<SharedString name="AeroMeshData">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
+				<token name="FluidFidelityInternal">0</token>
+				<bool name="InertiaMigrated">true</bool>
+				<SharedString name="PhysicalConfigData">O4Ogzvwv4FzvUP9Pl1kkQg==</SharedString>
+				<Vector3 name="UnscaledCofm">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<Vector3 name="UnscaledVolInertiaDiags">
+					<X>8.88889313</X>
+					<Y>8.88889313</Y>
+					<Z>8.88889217</Z>
+				</Vector3>
+				<Vector3 name="UnscaledVolInertiaOffDiags">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<float name="UnscaledVolume">8.00000191</float>
+				<bool name="Anchored">true</bool>
+				<bool name="AudioCanCollide">true</bool>
+				<float name="BackParamA">-0.5</float>
+				<float name="BackParamB">0.5</float>
+				<token name="BackSurface">0</token>
+				<token name="BackSurfaceInput">0</token>
+				<float name="BottomParamA">-0.5</float>
+				<float name="BottomParamB">0.5</float>
+				<token name="BottomSurface">0</token>
+				<token name="BottomSurfaceInput">0</token>
+				<CoordinateFrame name="CFrame">
+					<X>50.5506592</X>
+					<Y>59.8978882</Y>
+					<Z>26.5380859</Z>
+					<R00>1</R00>
+					<R01>0</R01>
+					<R02>0</R02>
+					<R10>0</R10>
+					<R11>1</R11>
+					<R12>0</R12>
+					<R20>0</R20>
+					<R21>0</R21>
+					<R22>1</R22>
+				</CoordinateFrame>
+				<bool name="CanCollide">true</bool>
+				<bool name="CanQuery">true</bool>
+				<bool name="CanTouch">true</bool>
+				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
+				<int name="CollisionGroupId">0</int>
+				<Color3uint8 name="Color3uint8">4278255360</Color3uint8>
+				<PhysicalProperties name="CustomPhysicalProperties">
+					<CustomPhysics>false</CustomPhysics>
+				</PhysicalProperties>
+				<bool name="EnableFluidForces">true</bool>
+				<float name="FrontParamA">-0.5</float>
+				<float name="FrontParamB">0.5</float>
+				<token name="FrontSurface">0</token>
+				<token name="FrontSurfaceInput">0</token>
+				<float name="LeftParamA">-0.5</float>
+				<float name="LeftParamB">0.5</float>
+				<token name="LeftSurface">0</token>
+				<token name="LeftSurfaceInput">0</token>
+				<bool name="Locked">false</bool>
+				<bool name="Massless">false</bool>
+				<token name="Material">288</token>
+				<string name="MaterialVariantSerialized"></string>
+				<CoordinateFrame name="PivotOffset">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+					<R00>1</R00>
+					<R01>0</R01>
+					<R02>0</R02>
+					<R10>0</R10>
+					<R11>1</R11>
+					<R12>0</R12>
+					<R20>0</R20>
+					<R21>0</R21>
+					<R22>1</R22>
+				</CoordinateFrame>
+				<float name="Reflectance">0</float>
+				<float name="RightParamA">-0.5</float>
+				<float name="RightParamB">0.5</float>
+				<token name="RightSurface">0</token>
+				<token name="RightSurfaceInput">0</token>
+				<int name="RootPriority">0</int>
+				<Vector3 name="RotVelocity">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<float name="TopParamA">-0.5</float>
+				<float name="TopParamB">0.5</float>
+				<token name="TopSurface">0</token>
+				<token name="TopSurfaceInput">0</token>
+				<float name="Transparency">0</float>
+				<Vector3 name="Velocity">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<Vector3 name="size">
+					<X>0.863073409</X>
+					<Y>0.755189359</Y>
+					<Z>0.917015553</Z>
+				</Vector3>
+				<BinaryString name="AttributesSerialize"></BinaryString>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+				<bool name="DefinesCapabilities">false</bool>
+				<string name="Name">Liquid</string>
+				<int64 name="SourceAssetId">-1</int64>
+				<BinaryString name="Tags"></BinaryString>
+			</Properties>
+			<Item class="WeldConstraint" referent="RBX6F32D51543374DB6A6171EFEE084BD2C">
+				<Properties>
+					<CoordinateFrame name="CFrame0">
+						<X>-0.0189208984</X>
+						<Y>0.242858887</Y>
+						<Z>0.0125732422</Z>
+						<R00>1</R00>
+						<R01>0</R01>
+						<R02>0</R02>
+						<R10>0</R10>
+						<R11>1</R11>
+						<R12>0</R12>
+						<R20>0</R20>
+						<R21>0</R21>
+						<R22>1</R22>
+					</CoordinateFrame>
+					<Ref name="Part0Internal">RBX4FBED7EA93294805A3DC7D5216FCDD42</Ref>
+					<Ref name="Part1Internal">RBX4F6B91C8320B44BCAC076D35B99A3143</Ref>
+					<int name="State">3</int>
+					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+					<bool name="DefinesCapabilities">false</bool>
+					<string name="Name">WeldConstraint</string>
+					<int64 name="SourceAssetId">-1</int64>
+					<BinaryString name="Tags"></BinaryString>
+				</Properties>
+			</Item>
+		</Item>
+		<Item class="MeshPart" referent="RBX4F6B91C8320B44BCAC076D35B99A3143">
+			<Properties>
+				<bool name="DoubleSided">false</bool>
+				<bool name="HasJointOffset">false</bool>
+				<bool name="HasSkinnedMesh">false</bool>
+				<Vector3 name="InitialSize">
+					<X>0.474099994</X>
+					<Y>0.663599968</Y>
+					<Z>0.498400003</Z>
+				</Vector3>
+				<Vector3 name="JointOffset">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<Content name="MeshId"><url>rbxassetid://921382236</url></Content>
+				<BinaryString name="PhysicsData"></BinaryString>
+				<token name="RenderFidelity">1</token>
+				<Content name="TextureID"><null></null></Content>
+				<int name="VertexCount">0</int>
+				<SharedString name="AeroMeshData">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
+				<token name="FluidFidelityInternal">0</token>
+				<bool name="InertiaMigrated">true</bool>
+				<SharedString name="PhysicalConfigData">YFH1lZDcd+52TG9J7PMAHw==</SharedString>
+				<Vector3 name="UnscaledCofm">
+					<X>0.00408957992</X>
+					<Y>-0.0528763719</Y>
+					<Z>0.00891572982</Z>
+				</Vector3>
+				<Vector3 name="UnscaledVolInertiaDiags">
+					<X>0.00315474137</X>
+					<Y>0.00154500722</Y>
+					<Z>0.00300869509</Z>
+				</Vector3>
+				<Vector3 name="UnscaledVolInertiaOffDiags">
+					<X>-1.77097791e-05</X>
+					<Y>2.91025572e-07</Y>
+					<Z>-2.58622131e-05</Z>
+				</Vector3>
+				<float name="UnscaledVolume">0.0638271794</float>
+				<bool name="Anchored">true</bool>
+				<bool name="AudioCanCollide">true</bool>
+				<float name="BackParamA">-0.5</float>
+				<float name="BackParamB">0.5</float>
+				<token name="BackSurface">0</token>
+				<token name="BackSurfaceInput">0</token>
+				<float name="BottomParamA">-0.5</float>
+				<float name="BottomParamB">0.5</float>
+				<token name="BottomSurface">0</token>
+				<token name="BottomSurfaceInput">0</token>
+				<CoordinateFrame name="CFrame">
+					<X>50.5317383</X>
+					<Y>60.1407471</Y>
+					<Z>26.5506592</Z>
+					<R00>1</R00>
+					<R01>0</R01>
+					<R02>0</R02>
+					<R10>0</R10>
+					<R11>1</R11>
+					<R12>0</R12>
+					<R20>0</R20>
+					<R21>0</R21>
+					<R22>1</R22>
+				</CoordinateFrame>
+				<bool name="CanCollide">true</bool>
+				<bool name="CanQuery">true</bool>
+				<bool name="CanTouch">true</bool>
+				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
+				<int name="CollisionGroupId">0</int>
+				<Color3uint8 name="Color3uint8">4289715711</Color3uint8>
+				<PhysicalProperties name="CustomPhysicalProperties">
+					<CustomPhysics>false</CustomPhysics>
+				</PhysicalProperties>
+				<bool name="EnableFluidForces">true</bool>
+				<float name="FrontParamA">-0.5</float>
+				<float name="FrontParamB">0.5</float>
+				<token name="FrontSurface">0</token>
+				<token name="FrontSurfaceInput">0</token>
+				<float name="LeftParamA">-0.5</float>
+				<float name="LeftParamB">0.5</float>
+				<token name="LeftSurface">0</token>
+				<token name="LeftSurfaceInput">0</token>
+				<bool name="Locked">false</bool>
+				<bool name="Massless">false</bool>
+				<token name="Material">1568</token>
+				<string name="MaterialVariantSerialized"></string>
+				<CoordinateFrame name="PivotOffset">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+					<R00>1</R00>
+					<R01>0</R01>
+					<R02>0</R02>
+					<R10>0</R10>
+					<R11>1</R11>
+					<R12>0</R12>
+					<R20>0</R20>
+					<R21>0</R21>
+					<R22>1</R22>
+				</CoordinateFrame>
+				<float name="Reflectance">0</float>
+				<float name="RightParamA">-0.5</float>
+				<float name="RightParamB">0.5</float>
+				<token name="RightSurface">0</token>
+				<token name="RightSurfaceInput">0</token>
+				<int name="RootPriority">0</int>
+				<Vector3 name="RotVelocity">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<float name="TopParamA">-0.5</float>
+				<float name="TopParamB">0.5</float>
+				<token name="TopSurface">0</token>
+				<token name="TopSurfaceInput">0</token>
+				<float name="Transparency">0.150000006</float>
+				<Vector3 name="Velocity">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<Vector3 name="size">
+					<X>1.05278635</X>
+					<Y>1.47359014</Y>
+					<Z>1.10674703</Z>
+				</Vector3>
+				<BinaryString name="AttributesSerialize"></BinaryString>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+				<bool name="DefinesCapabilities">false</bool>
+				<string name="Name">Handle</string>
+				<int64 name="SourceAssetId">-1</int64>
+				<BinaryString name="Tags"></BinaryString>
+			</Properties>
+		</Item>
+	</Item>
+	<SharedStrings>
+		<SharedString md5="O4Ogzvwv4FzvUP9Pl1kkQg==">Q1NHUEhTCAAAAAEAKLUv/WDMAO0JAFJPOTRgT3NRI7swRjHy3lLoWjVqdH8cL4MqIgjIh+bQ
+FNlvGp7V0h2kOua7kl7ZpIIc2qobukFSHSHIpaoE6y4D9k6ewXQ+EljSimovxjOP8B2F+f71
++aEHSTPVXoMJSSN6aqxTkCoTy96AllSiXp6Rnv+9UdWl6gTrLh7hSkf4cUkhnOPIspfANwrE
+ujwhLqlFz/+q9VJcqryeH3KsO6iXiEDPf9+oDifTNG5Zj0VSio5QxSNs4WxomghBPT/UEX56
+/tfBcR04Y/sLBJJN1oCxAdBg8IiaY/b5n3McOUfcpC0wcwEzRwEtKHCUzNA8UORx1mtpcOPu
+guEGyeorOluRfthK/+vf7f4ECZu0YN3qsO/KwIDpHQrbAfjmMTCQhWsyPDvQOCu7kOWfOZy3
+Du6stvZ9VoHHD3DTTuEI</SharedString>
+		<SharedString md5="YFH1lZDcd+52TG9J7PMAHw==">Q1NHUEhTCAAAAAIAKLUv/WBkMW3cAPo3bUs5EBDtTQdWJDBbvI1XPXp1pTKWJxHCCrPy3Npa
+pl93t1iwO/abu3DYIBYxaW1FGiAlVRPvdBCqStaTsQSjBKAEmxbGU1SVFqdJOOE4pnQcvEZn
+zTkJ5OEzGMIvfvqDut5GsOK4U9ja1zJKwk11cVI1uxfp2OqoKtzDp8biQtYNpiG4vyYaUaw5
+FyE0mOk4Sx722Wmr11VQeylOyHSz3EjRwriTJYuv/WmLfEC1YJ+hzl8bXPAM4nL/Q6LZhYAG
+4BjcDHzpICinR6TacLCZ5ZhTCp6luOTAAjCHwKGriSuByfvWabMrraRv8Sf2KWGCX53Nb6QF
+ogLKyi+Ahxsid+Ii02sV60/Ex8s321jrRmS4GY0OHvRFK28a0L8MkRB96EE/BPBHtBworetU
+4x4/5oLbeLvJ4FlJdSNhntFqGJRjQ+l0ezXIxV2GCBBOtXdksO+cV3b7277iUQ0fqht8lRBM
++8gVGagM8rZionT06ERxSTYonwCSRhdE9cyMOD8joPQj67VzQ0+AzzppcSbHQe1SyH2ouOhh
+M1HbyFZcRwJBoYntaBMQXLERx1y4zyNwiyadCe4nP/S2TR7CMY9Ue0gEna1LM10xNm0n8Xsj
+jHQO1+NpXXiC+1Thgj+bqexXghsKhEl0LCZTRpc/PQu1fj1FufAeFjAYi0fsIKLDwVB6wjIe
+utqOot5GrvBVPTXAW6dRWK7P6QELb+MRO2ADuSu9oXE4P59HLLsBg8P1KXnav8fvLFKCV0nI
+8oTnHzVCrR9SQZNv1UjtWpRydR6VA6PLAz3ryZmnHWx9G1ay+hThaNSGHJ0WO+g4s5cd3Naz
+SmD61EY+7Qy6Ds5goo9xg7oSicE3ksEE52IJ5DbOV0dYLZjDGwpPKBoq52Zh41xXu9XGPYYP
+NZGTcy4x9PyPXVA4Fnp/sABVZNjOs20ymVJatUFb6FxmOc4Q+kGeryST3jgs/SOsRE9j1PxQ
+dhZfcQzMf8HED9qi9cfwTq7X5K9zNb9wRBq3RcukJdufkqOvTAJnSxMnRY5mjsvuS4SYNfwq
+KP4im8bNQFaxdVggIaa8ZCMEW04sw8r9/KKqeSLU6oTCGZsgcOZTvcYEYNpeN2vyGvf0FNDO
+tMoT7laHZlNAmwIztKHkyuxxp8pqRgeYhid+5h9lpoBBTmrWALKk4yeucaRuKbs9OpeyTZJ5
+xWMQqvAEHE8wVT8nk0xtEXBwA9o6KdG6kmuvqNwlAaHz2zmj1GJVxdPRdHIyFepw11FTqZxq
+9DDPkIGA0oy+Np3o6SA4fKMCJ44FI0syTnmaxTTaJKG5ZerVNjWoZApmYFhFiC2ORZK7VPmd
+NaVyKeO3Qx7l/AqjeXhyiuZnEzputFHTOxUnfVyHCxPTcLGI4wSrYVLlJOYzrqlJoQq3MLKN
+auQoBMRB4RtXiVGG+Ughz9ytJhCfZSr5igWzCU9qKM3yaTiBSIKdOTHaV0WpXuOZUphwpg05
+MJsWkzYizadloDAQZRgushOEmcaw7yQYmlOPbhxOIp30wcnnN7pjclOcYzI1NDCMFqO2hVK8
++pqgi9WXmDD6y+q0MMRXEDHWmhSblFhm8iQnXSBWWMcdltBppw4RFB6OVUjvyRdnkJO5vGMT
+BAciazWAzzRmyMn3Ighx3vciJOg9qFx2uqfZtlsaI9ttz3eb9rTdEojabrk42+22GxZOUOi+
+jz4dj5oH5C0HYYGCav+t1o8IUMF3o5AcLcHWZFYHQDjSWHuuitV4tJF+NCeHtjj7mSJq+/lk
+csvJuGTLiXW5rTNHSNYsTmnrNzu8j5AAp1ODgW1dVnb5STCytmyg4pccCJswzKvaIJlWgqOZ
+xIr7bFW9sg7860fiBAOyhzD8QQGVe9BErQKrLUdLYvLHHnqEEbuBkkfr7ppM4dO51mzCZ6yu
+NTmuWUuH1JsR9Nqsts9VO1Q54/UV83REQ6Pe0sOQT8Jd/cwHQlD09p03qrznE96T2Yp7H0FP
+tCSoJyBv0K1PeC9Urf1usLW/cSmX2HKDqo5Shqt1zJro4A9BN9Zo+ZoKzUUfVzaihzJ6R12S
+ElwLRUyvZJ/fWIQXWU2EAPiXlhnrAYl9Ptqxz00EeqSsvF3jrZen+13n4oDjv4LGoGTElgCh
+0CtEy+KWdrbaTz0PwPNObFutuaGxMeu+HUKYpR3kkUznggoQJhOqpdhY44VFdXDZlrinx6a/
+ZbEirO0K/6CKtLIBvr5EzTlKtPGHII3AfEjK6mU9QfwX7xcktNGUBlr1Sl7/4ngww68b+PGb
+YUS9YYIO79qFboKCp6Ry9ZQUpH4IU3frUOcJz4RGKMvALRDN7qciHSVteYMpnpQJydadH0pm
+5VYbgM+Hj5dzGDlacdSj911lCxUb/NDll9PTyDaWjOfNg3ZUjFDp29+2FnvGGQIUppTy9FD1
+sPkVRxk2WzDL2/4KJXEisRo4vswymtk7QrWCQ68yAfXVvrJfpl7wrVG2GQaNQtPXTUlFx2Rs
+2u6yMeZLJQfVds3wF76qQWMpPXmZjEmZDTXinekiSI/0eMoffTOiLCctkT6BhNdCwgE6SRYl
+SThqqp+B7Zc4g36suduorebvGIrtlnBpQopFAUu+Cz6MuxfJiW4jI9wNfJL2ruHutBis48TC
+AbBA86+IEH9sjhuHMco1lu4bT1BVWpMRhfqdCF/vGgbcN3hLf4N98WGAFjiKYtBdbrvVpuza
+8XTvqCC3QXHY6TgROE5qdxSDd5WlsVmz+O0sGQy5ARyjHYAE3X2lAmO34lf26QEvH7x0e5BM
+pb/JFp4bCcuIAtGtnibelfZtkzkBtXWKWIn1A/3SIBReJBM4vHdmS9wehWo8sUKF56wgA/OH
+IotezKWpe42YPvYFDjAtTARKQPt+OtEIMm/W4IwzALzPccRQmgDBxrEVZOjSQGwGG4djalGQ
+r2IwtVeH75zKLidTyF4GYNvAKih8h9TdNita25xcEFA8b4ACThS2ujF7JGzyeQnWEVlngAGv
+wjty+fAHSmP/tDjLtXHXl96oxKIEXoHQM8T5jMnQp9z1MA4+nQaVoWTvVqmZdq4vLjYITvSd
+N9d1FIkyYxKjt42N6WKpQlZUKLAiGPWsOSUyB9y+4RLuoRTJ62B9rKj3pFUFdqEfIn9mcP8a
+a/BnqNqeGHSiDzBWyJ0ugZwxNeMPkpR4kZML3Uv3LL0BurSkWh6KTaqh8wwjyEFk5P6QFOBf
+XpKYPqxIXMyUdZN6De5z001XKtE5FgBVfhYOczthcrZVzT94kSDj30BaFsXuwJILR3RRlnSI
+1Mff4Wba1TWLKD9vgQ4+go+ZHQUG85lUy24Je4o3SoUq9FjtilX5yBiihK+fXThF4Hyqupah
+HFvXFN9SUaGGGJNbHTlynCkn9lnKh3PMm9notIisi96ekpXO2XLS1ZaLcCR8kOGPhw2YcSHt
+bqHbJx1zwNXGRmUUbVve7ZJ9UjDYR1xbEQZzlofVNNgBKZWNBX8mrDo9DXQFXCABi5d+dE+/
+H5/jgwt/f3YC9x6zyj8rWXnOLjYvOxJ9LTAL1Lh7hVThRBcqiwh2XtSlzEU3LGbuDdJArIFh
+QYNpcMrBaYG8KAZfmRdiH2YUDL32wzNlK5UO4Uj0mIA933LcmPbaeqoj+9U6LvxsSqAmQoJV
+u7cJaS4442WYLTj5DHm4jKGZ2fB14IQ3I5sS/pZF8eaxyudo3PYPm0huMQWW/GYWMBpHop+N
+OuMi0IDf+RHy4KKT23oDhvyPWiheeqfWDsS9jWN7R1BRuvTK6BmTBJESwkHyO+yoaw69PESP
+N6lEOp9/QkJ2aYLXRjTKtBRaBpaAeTxntkSNQK3sHbm8tpYrLpvPAb3DjsGuogIIuoXcXD7x
+Anq4UdlQE1S+BWizKR2CMd6xN24MQ6M2p4u66/IJSHA8O+yiuP55slIZcxrHzp+d+hFz4+A3
+X4n8IQGU/MYxx6cRxSpxY71dgNZTxKhPYVv3hz3++JYKLWxc/A1Ln9bihvqEGElwGXmMqQS/
+Kzu4OnOhD4KWTBY5holDDPxjliGbCuzCytunPDWlPBLEwYVUfsWiGF+J6fmDOqbfstfXFAC2
+LwLkmzE9pxMVTqgDQj1K0JtSlXVSlmqLqZAkn5tszJwzn8pJA0tMbBxboVVcbHIZunLvQxS8
+rRklu/lmY72JXgZUhPurhRdAZ7dbyLfDznyLHucSzLnxoYFzIU3pOMly4+yuMGZngnG4K3xG
+7S5v+RKLP3rFkSXQMyNqNDAfmlem1akcDOYx9VIRoF4Udl/GBQKRlX+f5EqGaLjCf7GU3KF/
+HYIYJTuII0+vyZGwMe9GeRBa7kQQKD4W6vAZRZf2jSDVOKQqW80T8IFgiZ9pAAz7zIprDUVb
+12UxGHwOJNZlshbIy9h6SI3ve46wrM0peoAWDRT5kKLTafSyKjcU0GtekEIiWuhcr6p/zNvp
+3BiMR3VpNCCCVghunY7s4Em0Jcb+CTWDwIXczmKwmtOzuO+e1siiSLucE/6bL5D9pMujzuHR
+Vb89eduWFGg/B2HHnzTohJ1PFHFb2LxNsltPzlGqzzFLVDSijYd6jogPfQanCdoOCQSEyb1m
+LMtzto+KgV2H7yQFdwQOsr6zUDNJztFnPpgoES+VObyvmGf4bTvtucpQsbJGqTe7Od7zBeO7
+7Sn+4hCqPyVnvmlm98usSS/aoPWFhIB9yxqoXyMLS2egoH4gM5bUqB8uLUx5fR2SQ8Wt3Rva
+EFuyTX1lg2535HvPCYr1B57VQJqlWgXb4GAe5D/qWelcGliVabW9xgWjD9SdToP3+UXg7nsQ
+uHl6gFGb7xQf8spGrchX/szU+auj/PjWOwrUfUYVPtVQTyR/o2BkC5J9yLy/BbUwwTJE5LX1
+fQTA+7v1eawRnKYPnmwmqmdV2RiytMskhFnCsL2qk2EtT3HSZlC6oWi+mg8QSGD0PVW6u/re
+EiI/odRGSm48yc2HmkOPOCN6fqkdc4Y2bgm35EmRBeo3aok22Ktkb0wb5DPvLKqi/cRS4xIc
+QBrVnpYEZsy0jwm3D9sjWwe1+lKGgFVHiEG0wq3LW7Idkhewj4Q6DohYV06ikQoUZP1cMTWg
+XaGt0RjBYwUsYS+z4ttBeJ5KCsGUdM9MfCShHSRR7ecgEETuSpB/dbL0TKbwAOMp8QU845hm
+LXTIKymdlzW+MqlL14HkDXOEWbL5+LrRDzjONNWoIhw8SeHsatx2DWUfXpCRKcwF47uYukNj
++/nFHivluq4NXCP1h8DtHxWJWoUHsHoQhRFnl4wAbrRsLOQonWjiL98wwWcOUqdC+YB/jL7U
+d8GLxAkv4+oq0ofqJ7HaIXpm+V8qe+gLta/NTGs0t0seubqr1BtorjoTpYY9AEuZzqOiatdY
+TCGl85XxmyPodv314MlCUOwyV0JOz9u++3oR9CnYWQjCRK8Y9o+RHgdT2GgtVhJAeOOjI72q
+KOjZiV+8GUMFdhdCQA0zOwdT8sk6q7sKBSQFEAGd4WXsb566+0mFek4IDn3mgB4dAvXvd3QM
+UHl2SSl4sP0Maa2PlkhqR0UHILjtW5QCphZ9KWzfwyaRmDPmvp1FVD9lC5UOISQK1wuxZoKp
+2bqg7cTc1anFSyvmnt2gqzQG+gSRa4ulGPQN4WCOhlK6yBEIelxr2RL2gFCxjMe0V9gSVdE6
+AhrmIDiFlwaEEIMOQE5BX+QUmQWxlvdvL5lE3Hylu1/1ze3MLrHdgUxK4lhgxWwnVrXuGUFP
+UkNX24uQsA9Lyj8gawzpxJ/x2dK/kKP7/6zEmgS0AXGwelqT3muOtg5IesCPDxLt0EfXQRPd
+K2Bl9DIrBhtRDw/u86wucC9evuBEV41F/nw4kw3VUQI2/Ctj8omOs5GVpVqMjrlSjCCjf1fI
+FNBtrjZm7Q0oWtKke6O8jCXe9N3Aa99x6DrMcFwND8SFKy5mWoLf+VVyECTiXDdqXTkQOBkq
+l70mArxb5cNGpwiJq49uIEOCITYcuhuGQbHuaNdaMtVzqEDdN664vQs+oIbn1v+KCJF59XQs
+RUCxUh2ujZu+1AbUaZiAuwTY7hPj067FYvz5CW4nwhSrGp65MFxpd36Ue0035yYbsi2unazL
+uPNc5XSrRjFksF5ImP2vY6qNjxp0sdPTJ+Xy1CFX5DU3uzMBS7/QAQxPCAG6lRqUzk+dbeep
+e2HulhjqOaoc9L0H4/7nOe53LpSUUaRtO9eaE2fS0/bPAvzo/BHXRTh4CEyX+ydyszMldXgl
+GtRoFyriXgqGpxcN5dlBJry8EhqutdFaFITRu9qzyZgjJ6KaTOoQkSDhd7m4AwH9v9HqoY55
+3vLQTciH2bdMFD0xhOF9uHi2BDIeMsUV7TOG9COMLHynnBl6i41R/UjA+En8AG4DShjUYVsQ
+X+pJ0oakQvc2MtTeD25OvMUJVvL9FjT9Edjv45ckUuwqGM/6pZB594pMJboPqgeFaqhDpoCc
+LOIQn8iMaJKkMKwBEzUTQJKIYhaEYB+DsAVdCPAZoZJUMm0HA2Xf0vyH7viWNPca8mvLoz33
+iCf7ahS7z8vGdOwiDfyXb5e5rcfV847f9FgXyeu7ZXkbQ6Zb/TDtM4Gfqw5s0r+c9+qvbx2t
+/Aw6PAzqm5+rdMzp+GffanU1EVsO/79iZcwfH+JK6y2Nphs4ZzGlT1to8OuY4+0XETvjFeP7
+ueSxDTwTzs/q6QuzKtPZi4/60n1uiyP24MlrweEW8U5kUlNNkZdTWVywRR/U+XVkWfNlw1yt
+jWkYubY1QMVjehaOe865P1PEW8Lvoicl5ox5lQVe5cXg5UKfIXhjqcY6fy3v72lnQ13KE9Jt
+7UlfdjVy5eiorQsB4bGI+sKRNQZwnTf/sG1ph57rvROIwfSnQ8Q/ze9C1M6LK1GEMp9jje8I
+7tiC0IGerrZz1o8zaXbijM3+/Uw6ou1vNUCrIi7aHxj0FVOwOb1jOm7i31v0oD4332nF8Jmf
+9wXEBPG3azY+G1h2muUrEwsTIxOIJuDoSic3rubPlsX3H3o+XNuZ13TkMaZospeuOITjOrCF
+6n+pEg6ejICua4XxvQpf7lXC47LbunxVjY8uZ6c3T7cnHpVVf6nuJ2O53+sDVQjfxEUNAyFq
+CcSFw6/nXv8S7k2lum3vGZ27Lb95TOWnXdE1a0evuf+L7gnovqzvKyGpdbNoG9FxsU54PawV
+W6MfBk/s0/QHuzKf/GK73qAO4LpmzZ/l3xATzHfyz0Vbjbsy9KazH5hv70p+fHB8oRi/7lDF
+CzM+jyxPH2N9JFM6SXm2t/ntz24Pl0F557ivGO/aYCa369J/wo/84VSkwOSsru6CLcArpgOS
+8c2Npbd/tSCzzIXg7vgjyLUhl3HMT8as3GHN7nSYkyt8DLJe2hkh2PyJpj5veMP5Wi/HsZKA
+leclIJWMl1ulpn1mXF2YehJbacwsA6RccCi74Ut8fmVfUm1Xsc1RPbLYi2tgoPnQNne0X3ff
+MJ5h8QY+2uLBP3/Xf4leh3R591XDQLhWsYVO/eR2PuTlcffoxWmpH8z8VqktVt1pv9J8RXSa
+atU9dsZnVyLvm0fBpa6LhHOFCDfsc5xh3AcM+P6J3BPWZhB+RxCrIvJRB+Frkj0E+Xr/M30P
+b9JhPMIRl/IhgLY4gwp3Yc7gncvwgniFObkWb7dp+Xw5S+5ShFzGTrlZVNvIWcBfkfAUNpV9
+6MtFsMU7w2fq9slf4j6i+f3FOFTvI7C2hyT9LIhMD3+CT3LMzxWegcSLA/HJDFovfiw+iJnq
+965TKq560Jpk2eGjVfkWRS/sMtOeBSs2oUWD4HYDx5QtnEHmuIXBM9xBn9Usdg+rBTZ2Njw/
+yp9Wf+j2g56vyuZ6hDy/T/7kudxkiS1lOJKCIw5sR85L2++nHuK/ekX+549xHY/yMapbw9vp
+P3fnO6wRfSn4+UtED0JNn57K/juKvUxj+8eSTW1WxHWwXgd2zDuQTdHPyiyOL/dHmvA2acEA
+Xmn7IiN4v4bRRDAuuo/W52WJpftGkMsfXE5UOyFN65Pj8aB/dF/6tLNnPobEtTtcnDKmtwH6
+iI1fk8/eVnAIn19j8eUIQOz+WInvsnX9dgM+OYztiZB6FkNnw2BMCLoAzoFu+fMIxgg29zfu
+sPT6ts7HqJvL11AwImCLAtsaPwUtS+v7bMf3RGPhSvRJun0gJNN8Boop794SjqWzOV5dZk6R
+UB4Fc1hDU6pD5TbSLNqwPNUOP1fNX33+wfmcZeICGu7fbglY+//tNd97pPxiFGx2RzhZFwMf
+es4Fh+Hh77LjXex4dgSfCv0aO6FLcnfOrw+C+uKccbvUDyrHCKGSe/jUnY66aCTJ9xDYOR/v
+QeJx9yr9xvCwcy5GtNvgL/z7Q8yquS+ZUDC47zNbb3fNMSPs7/UJ61lIw6aPN4p4X0J7K3Wm
+uD9PCE5bNDCft+v6XGM/ty0Z0nM43X7iG2ejg/qW3pen5cPTOXyIxb17PXnnaAVi83NceHq6
+L9+W+QXjZwKosYn+4ZCD2w/8vDoL274SM7q315rbgv6W5U7ivNfbT8bB28GcaO0Anvrq1esC
+rLzyF3z6YVBsR5x9Y9rHSmzc5cJfOzKi5AfxDudwZ7U+g4KW835U5SnnVa++l1iN5wCwr2io
+/4B4kmbsQlrbgpr4ObGdGOslpUMmdY8KIn20O0cdc5k7SWTBlPzYJE1OtFxVjtusajHwumgo
+2zgMDaqqwE298QXg9CyDC9RphZBwh99I+Pa+zjjJXDaKXr1zbCKfuqVvS3mFwqtgWYW/wpet
+t/q/FNZNBCdhmtUyTYDDzDAI5CZqV73gqCd3AbgWZ7lwOisvYomhlcC3HD7z9+wYcv5FTKj/
+c0prYr0Y+0wdGaN2O7jgTr/jls1pehHbQHwU8/73C6ZyWfxmoUXbgG4H6BaPnxrOXcCeGtu8
+50vQu7owpa/4X1E3CNpJrxwhv1gufN+36pzwNsz2MBthIoXOrsB+4ANvwH+JvxyZyZm03NZo
+zdzBHonTBNOW8KHLHtGb+/fe1nMqQcQvuv1aOZBXwe3Cf7zjUh32/6J9YHF+xXkrbuA++jLF
+s+j35qGcQU6J/4b7ucPhK1CxHNglqZm+pM7yUFiNDx8wAfbYboaw28Tw3/k/xa6LJtZH2CrR
+lE2UlwPE0KleJ2UfW/1hZmH6AuR9r+oJSMwCvJ0UP/rQtGufHj/7Fdqs/6pZY3YApglrbg46
+Lfklp1g78U/1n0NOsPf5kRG/0PMx6xbvN2sW3ukA+XwzthOA+oQjDkhjm4sXYd2Zne6ouxyG
+E9VP87RwW+JyDP7dpppFqMnvLRoQv7J3ZNEDMBaGLvLdHxqX/2ysMYPFOi6LmU/ONu/pZ0bM
+TWl896SpvkTudOZYS8Jj+XUYLXvZ798HT08+TT0Frg/uoU4cf5hW9PWi+0KpsUAzlb/1RlJc
+AQ==</SharedString>
+		<SharedString md5="yuZpQdnvvUBOTYh1jqZ2cA=="></SharedString>
+	</SharedStrings>
 </roblox>


### PR DESCRIPTION
本更新 ReplicatedStorage.Assets.ToolTemplates 对应的磁盘资源（Rojo $path），不涉及玩法逻辑。

Updates on-disk tool templates for Rojo-mapped ToolTemplates; no gameplay logic changes.

## Summary

- What changed?
- Why is this change needed?
- Any prototype-only exceptions or follow-up work?

## Roblox Integration Checklist

- [ ] The change updates the active runtime source under `packages/**`, or I explained why another source path had to change.
- [ ] If Studio tree structure changed, I updated the relevant `default.project.json` in the same PR.
- [ ] If I changed Remote names, replicated schema, or visibility behavior, I updated all linked producers/consumers/tests in the same PR.
- [ ] If I changed non-trivial shared/gameplay behavior, I added or updated deterministic coverage under `tests/src/Shared`, or I explained why no test change was needed.
- [ ] If I touched `SessionConfig.PlaceIds` or any other real-environment configuration, I documented the required rollout or environment follow-up.
- [ ] If this PR includes `.rbxl`, generated output, or other non-source artifacts, I explained why they are required.

## Validation

- [ ] `stylua --check .`
- [ ] `selene .`
- [ ] Additional verification steps are listed below if this PR needs more than static checks.

## Notes

- Manual test notes:
- Risks / follow-ups:
