### PR TITLE
feat(道具)：Run 与迷宫统一 F 键手电筒头灯与使用逻辑

### DIFF
--- a/packages/gameplay/src/HeldToolUseRequest.luau
+++ b/packages/gameplay/src/HeldToolUseRequest.luau
@@ -2,6 +2,8 @@
 -- Shared server path for RequestUseTool (maze + run): consume held state, apply category effects, status line.
 -- Lazy-require Shared inside apply() to avoid Gameplay <-> Shared circular init (Runtime.InventoryService loads Gameplay).
 
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
 export type HeldToolUseDependencies = {
     canManageInventory: (Player) -> boolean,
     inventoryService: any,
@@ -11,6 +13,7 @@ export type HeldToolUseDependencies = {
 }
 
 local HeldToolUseRequest = {}
+local sharedPackageCache = nil
 
 function HeldToolUseRequest.apply(player: Player, deps: HeldToolUseDependencies)
     if not deps.canManageInventory(player) then
@@ -89,9 +92,11 @@ function HeldToolUseRequest.apply(player: Player, deps: HeldToolUseDependencies)
 
     if updatedHeldItem.ToolCategory == 'Flashlight' then
         actionWord = 'flashed'
-        local Shared = require(
-            game:GetService('ReplicatedStorage'):WaitForChild('Packages'):WaitForChild('Shared')
-        )
+        if sharedPackageCache == nil then
+            sharedPackageCache =
+                require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared'))
+        end
+        local Shared = sharedPackageCache
         local enabled = Shared.Runtime.HeldFlashlightHeadlight.toggle(player)
         if enabled == nil then
             effectText = 'Head lamp could not be toggled (no head).'

--- a/packages/gameplay/src/HeldToolUseRequest.luau
+++ b/packages/gameplay/src/HeldToolUseRequest.luau
@@ -1,0 +1,160 @@
+--!strict
+-- Shared server path for RequestUseTool (maze + run): consume held state, apply category effects, status line.
+-- Lazy-require Shared inside apply() to avoid Gameplay <-> Shared circular init (Runtime.InventoryService loads Gameplay).
+
+export type HeldToolUseDependencies = {
+    canManageInventory: (Player) -> boolean,
+    inventoryService: any,
+    monsterService: any?,
+    playerService: any,
+    setStatus: (string) -> (),
+}
+
+local HeldToolUseRequest = {}
+
+function HeldToolUseRequest.apply(player: Player, deps: HeldToolUseDependencies)
+    if not deps.canManageInventory(player) then
+        return
+    end
+
+    local summary = deps.playerService:getSummary(player)
+    local playerState = summary and summary.PlayerState
+    if playerState and playerState.IsDead == true then
+        deps.setStatus(string.format('%s cannot use tools while dead.', player.DisplayName))
+        return
+    end
+
+    local inventorySummary = deps.inventoryService:getSummary(player)
+    local heldItem = inventorySummary and inventorySummary.HeldItem
+
+    if not heldItem then
+        deps.setStatus(
+            string.format('%s tried to use a tool, but hands are empty.', player.DisplayName)
+        )
+        return
+    end
+
+    if type(heldItem.CurrentState) ~= 'number' or type(heldItem.ConsumePerUse) ~= 'number' then
+        deps.setStatus(
+            string.format(
+                '%s cannot actively "use" %s (it is not a tool).',
+                player.DisplayName,
+                heldItem.Name
+            )
+        )
+        return
+    end
+
+    if heldItem.ConsumePerUse > 0 and heldItem.CurrentState < heldItem.ConsumePerUse then
+        deps.setStatus(
+            string.format(
+                '%s tried to use %s, but it has no %s left.',
+                player.DisplayName,
+                heldItem.Name,
+                heldItem.StateModel or 'power'
+            )
+        )
+        return
+    end
+
+    local consumeSuccess, consumeResult, cooldownRemaining =
+        deps.inventoryService:consumeHeldItemState(player, os.clock())
+    if not consumeSuccess then
+        if consumeResult == 'Cooldown' then
+            deps.setStatus(
+                string.format(
+                    '%s cannot use %s yet (cooldown %.1fs remaining).',
+                    player.DisplayName,
+                    heldItem.Name,
+                    math.max(cooldownRemaining or 0, 0)
+                )
+            )
+        else
+            deps.setStatus(
+                string.format(
+                    '%s could not use %s (%s).',
+                    player.DisplayName,
+                    heldItem.Name,
+                    tostring(consumeResult)
+                )
+            )
+        end
+        return
+    end
+
+    local updatedHeldItem = consumeResult
+
+    local actionWord = 'used'
+    local effectText = 'It worked!'
+
+    if updatedHeldItem.ToolCategory == 'Flashlight' then
+        actionWord = 'flashed'
+        local Shared = require(
+            game:GetService('ReplicatedStorage'):WaitForChild('Packages'):WaitForChild('Shared')
+        )
+        local enabled = Shared.Runtime.HeldFlashlightHeadlight.toggle(player)
+        if enabled == nil then
+            effectText = 'Head lamp could not be toggled (no head).'
+        elseif enabled then
+            effectText = 'Headlamp on.'
+        else
+            effectText = 'Headlamp off.'
+        end
+    elseif updatedHeldItem.ToolCategory == 'Crowbar' then
+        actionWord = 'swung'
+        effectText = 'A satisfying swoosh cuts the air!'
+
+        local damagePips = 1
+        if type(updatedHeldItem.MeleeDamage) == 'number' and updatedHeldItem.MeleeDamage >= 1 then
+            damagePips = math.floor(updatedHeldItem.MeleeDamage)
+        end
+
+        local monsterService = deps.monsterService
+        if monsterService then
+            local meleeOk, meleeResult = monsterService:tryApplyPlayerMeleeHit(player, {
+                DamagePips = damagePips,
+                SwingArcDegrees = updatedHeldItem.SwingArcDegrees,
+                SwingRange = updatedHeldItem.SwingRange,
+            })
+            if meleeOk then
+                if meleeResult and meleeResult.Killed then
+                    effectText = 'The crowbar connects — the threat goes down!'
+                elseif meleeResult and type(meleeResult.RemainingHitPoints) == 'number' then
+                    effectText = string.format(
+                        'The crowbar connects! Foe stamina: ~%d.',
+                        meleeResult.RemainingHitPoints
+                    )
+                end
+            end
+        end
+    elseif updatedHeldItem.ToolCategory == 'Potion' then
+        actionWord = 'drank'
+        local healPips = 1
+        if
+            type(updatedHeldItem.HealHealthPips) == 'number'
+            and updatedHeldItem.HealHealthPips >= 1
+        then
+            healPips = math.floor(updatedHeldItem.HealHealthPips)
+        end
+        local healOk, healResult = deps.playerService:healHealthPips(player, healPips)
+        if healOk then
+            effectText = string.format('The brew steadies you — health pips: %d.', healResult)
+        else
+            effectText = string.format('The brew has no effect (%s).', tostring(healResult))
+        end
+    end
+
+    deps.setStatus(
+        string.format(
+            '%s %s the %s. %s (%s remaining: %d)',
+            player.DisplayName,
+            actionWord,
+            updatedHeldItem.Name,
+            effectText,
+            updatedHeldItem.StateModel or 'state',
+            updatedHeldItem.CurrentState
+        )
+    )
+end
+
+return HeldToolUseRequest

--- a/packages/gameplay/src/init.luau
+++ b/packages/gameplay/src/init.luau
@@ -1,4 +1,5 @@
 return {
+    HeldToolUseRequest = require(script.HeldToolUseRequest),
     Combat = require(script.Combat),
     Config = require(script.Config),
     ControlState = require(script.ControlState),

--- a/packages/shared/src/Runtime/HeldFlashlightHeadlight.luau
+++ b/packages/shared/src/Runtime/HeldFlashlightHeadlight.luau
@@ -1,0 +1,72 @@
+--!strict
+-- Server-side head-mounted spotlight for tool flashlight use (replicates on character).
+local LIGHT_NAME = 'FlashlightLight'
+
+local HeldFlashlightHeadlight = {}
+
+-- Returns nil if the character has no Head; otherwise the new Enabled state after toggle.
+function HeldFlashlightHeadlight.toggle(player: Player): boolean?
+    local character = player.Character
+    if not character then
+        return nil
+    end
+
+    local head = character:FindFirstChild('Head')
+    if not head or not head:IsA('BasePart') then
+        return nil
+    end
+
+    local existing = head:FindFirstChild(LIGHT_NAME)
+    local flashlightLight: SpotLight
+    local isNewLight = false
+
+    if existing and existing:IsA('SpotLight') then
+        flashlightLight = existing
+        flashlightLight.Enabled = not flashlightLight.Enabled
+    else
+        if existing then
+            existing:Destroy()
+        end
+        flashlightLight = Instance.new('SpotLight')
+        flashlightLight.Name = LIGHT_NAME
+        flashlightLight.Color = Color3.fromRGB(255, 255, 240)
+        flashlightLight.Brightness = 2
+        flashlightLight.Range = 50
+        flashlightLight.Angle = 45
+        flashlightLight.Face = Enum.NormalId.Front
+        flashlightLight.Parent = head
+        isNewLight = true
+    end
+
+    if isNewLight then
+        flashlightLight.Enabled = true
+    end
+
+    return flashlightLight.Enabled
+end
+
+function HeldFlashlightHeadlight.clear(player: Player)
+    local character = player.Character
+    if not character then
+        return
+    end
+
+    local head = character:FindFirstChild('Head')
+    if not head then
+        return
+    end
+
+    local inst = head:FindFirstChild(LIGHT_NAME)
+    if inst then
+        inst:Destroy()
+    end
+end
+
+-- Destroy head spotlight when the player is no longer holding a flashlight.
+function HeldFlashlightHeadlight.syncHeldItem(player: Player, heldItem: any?)
+    if type(heldItem) ~= 'table' or heldItem.ToolCategory ~= 'Flashlight' then
+        HeldFlashlightHeadlight.clear(player)
+    end
+end
+
+return HeldFlashlightHeadlight

--- a/packages/shared/src/Runtime/init.luau
+++ b/packages/shared/src/Runtime/init.luau
@@ -1,4 +1,5 @@
 return {
+    HeldFlashlightHeadlight = require(script.HeldFlashlightHeadlight),
     ControlStateService = require(script.ControlStateService),
     FormalLocomotion = require(script.FormalLocomotion),
     HexMazeWorldRenderer = require(script.HexMazeWorldRenderer),

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -37,6 +37,7 @@ local ControlStateService = Shared.Runtime.ControlStateService
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
 local PlayerStateService = Shared.Runtime.PlayerStateService
 local PlayerService = Shared.Runtime.PlayerService
+local HeldFlashlightHeadlight = Shared.Runtime.HeldFlashlightHeadlight
 local RoundSignalBus = Shared.Runtime.RoundSignalBus
 local TeleportInventoryHydrator = Shared.Runtime.TeleportInventoryHydrator
 
@@ -1232,6 +1233,7 @@ function MazeSessionService:_equipItem(player, itemInstanceId)
     end
 
     self:_setStatus(string.format('%s equipped %s.', player.DisplayName, result.Name))
+    HeldFlashlightHeadlight.syncHeldItem(player, result)
 end
 
 function MazeSessionService:_unequipItem(player)
@@ -1254,142 +1256,22 @@ function MazeSessionService:_unequipItem(player)
     self:_setStatus(
         string.format('%s stowed %s back into the backpack.', player.DisplayName, result.Name)
     )
+    HeldFlashlightHeadlight.syncHeldItem(player, nil)
 end
 
 -- === 新增：处理道具使用的逻辑（这是本次手术最核心的部位） ===
 function MazeSessionService:_handleUseTool(player)
-    if not self:_canManageInventory(player) then
-        return
-    end
-
-    local playerState = self.PlayerService:getSummary(player).PlayerState
-    if playerState.IsDead == true then
-        self:_setStatus(string.format('%s cannot use tools while dead.', player.DisplayName))
-        return
-    end
-
-    -- 1. 检查手里有没有拿东西
-    local inventorySummary = self.InventoryService:getSummary(player)
-    local heldItem = inventorySummary and inventorySummary.HeldItem
-
-    if not heldItem then
-        self:_setStatus(
-            string.format('%s tried to use a tool, but hands are empty.', player.DisplayName)
-        )
-        return
-    end
-
-    -- 2. 检查这东西有没有“状态/耐久”（ConsumePerUse 允许为 0 表示不消耗型工具）
-    if type(heldItem.CurrentState) ~= 'number' or type(heldItem.ConsumePerUse) ~= 'number' then
-        self:_setStatus(
-            string.format(
-                '%s cannot actively "use" %s (it is not a tool).',
-                player.DisplayName,
-                heldItem.Name
-            )
-        )
-        return
-    end
-
-    -- 3. 检查有没有没电/报废（仅当每次使用会扣耐久时）
-    if heldItem.ConsumePerUse > 0 and heldItem.CurrentState < heldItem.ConsumePerUse then
-        self:_setStatus(
-            string.format(
-                '%s tried to use %s, but it has no %s left.',
-                player.DisplayName,
-                heldItem.Name,
-                heldItem.StateModel or 'power'
-            )
-        )
-        return
-    end
-
-    -- 4. 真正“使用”它：扣除耐久并同步到实际背包状态
-    local consumeSuccess, consumeResult, cooldownRemaining =
-        self.InventoryService:consumeHeldItemState(player, os.clock())
-    if not consumeSuccess then
-        if consumeResult == 'Cooldown' then
-            self:_setStatus(
-                string.format(
-                    '%s cannot use %s yet (cooldown %.1fs remaining).',
-                    player.DisplayName,
-                    heldItem.Name,
-                    math.max(cooldownRemaining or 0, 0)
-                )
-            )
-        else
-            self:_setStatus(
-                string.format(
-                    '%s could not use %s (%s).',
-                    player.DisplayName,
-                    heldItem.Name,
-                    tostring(consumeResult)
-                )
-            )
-        end
-        return
-    end
-
-    local updatedHeldItem = consumeResult
-
-    local actionWord = 'used'
-    local effectText = 'It worked!'
-
-    if updatedHeldItem.ToolCategory == 'Flashlight' then
-        actionWord = 'flashed'
-        effectText = 'The area is illuminated.'
-    elseif updatedHeldItem.ToolCategory == 'Crowbar' then
-        actionWord = 'swung'
-        effectText = 'A satisfying swoosh cuts the air!'
-
-        local damagePips = 1
-        if type(updatedHeldItem.MeleeDamage) == 'number' and updatedHeldItem.MeleeDamage >= 1 then
-            damagePips = math.floor(updatedHeldItem.MeleeDamage)
-        end
-
-        local meleeOk, meleeResult = self.MonsterService:tryApplyPlayerMeleeHit(player, {
-            DamagePips = damagePips,
-            SwingArcDegrees = updatedHeldItem.SwingArcDegrees,
-            SwingRange = updatedHeldItem.SwingRange,
-        })
-        if meleeOk then
-            if meleeResult and meleeResult.Killed then
-                effectText = 'The crowbar connects — the threat goes down!'
-            elseif meleeResult and type(meleeResult.RemainingHitPoints) == 'number' then
-                effectText = string.format(
-                    'The crowbar connects! Foe stamina: ~%d.',
-                    meleeResult.RemainingHitPoints
-                )
-            end
-        end
-    elseif updatedHeldItem.ToolCategory == 'Potion' then
-        actionWord = 'drank'
-        local healPips = 1
-        if
-            type(updatedHeldItem.HealHealthPips) == 'number'
-            and updatedHeldItem.HealHealthPips >= 1
-        then
-            healPips = math.floor(updatedHeldItem.HealHealthPips)
-        end
-        local healOk, healResult = self.PlayerService:healHealthPips(player, healPips)
-        if healOk then
-            effectText = string.format('The brew steadies you — health pips: %d.', healResult)
-        else
-            effectText = string.format('The brew has no effect (%s).', tostring(healResult))
-        end
-    end
-
-    self:_setStatus(
-        string.format(
-            '%s %s the %s. %s (%s remaining: %d)',
-            player.DisplayName,
-            actionWord,
-            updatedHeldItem.Name,
-            effectText,
-            updatedHeldItem.StateModel or 'state',
-            updatedHeldItem.CurrentState
-        )
-    )
+    Gameplay.HeldToolUseRequest.apply(player, {
+        canManageInventory = function(p)
+            return self:_canManageInventory(p)
+        end,
+        inventoryService = self.InventoryService,
+        monsterService = self.MonsterService,
+        playerService = self.PlayerService,
+        setStatus = function(message)
+            self:_setStatus(message)
+        end,
+    })
 end
 -- =======================================================
 

--- a/places/run/src/ServerScriptService/Run/ItemFunctionality.luau
+++ b/places/run/src/ServerScriptService/Run/ItemFunctionality.luau
@@ -44,40 +44,8 @@ function ItemFunctionality.toggleFlashlight(player: Player): boolean
         return false
     end
 
-    local character = player.Character
-    if not character then
-        return false
-    end
-
-    local head = character:FindFirstChild('Head')
-    if not head then
-        return false
-    end
-
-    -- 查找或创建手电筒光源
-    local flashlightLight = head:FindFirstChild('FlashlightLight')
-    local isNewLight = false
-
-    if flashlightLight then
-        flashlightLight.Enabled = not flashlightLight.Enabled
-    else
-        flashlightLight = Instance.new('SpotLight')
-        flashlightLight.Name = 'FlashlightLight'
-        flashlightLight.Color = Color3.fromRGB(255, 255, 240)
-        flashlightLight.Brightness = 2
-        flashlightLight.Range = 50
-        flashlightLight.Angle = 45
-        flashlightLight.Face = Enum.NormalId.Front
-        flashlightLight.Parent = head
-        isNewLight = true
-    end
-
-    if isNewLight then
-        -- 刚创建时默认开启
-        flashlightLight.Enabled = true
-    end
-
-    return flashlightLight.Enabled
+    local enabled = Shared.Runtime.HeldFlashlightHeadlight.toggle(player)
+    return if enabled == nil then false else enabled
 end
 
 -- ====================

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -18,6 +18,7 @@ local InventoryService = Shared.Runtime.InventoryService
 local PlayerService = Shared.Runtime.PlayerService
 local PlayerStateService = Shared.Runtime.PlayerStateService
 local MonsterService = Shared.Runtime.MonsterService
+local HeldFlashlightHeadlight = Shared.Runtime.HeldFlashlightHeadlight
 local TODService = Shared.Runtime.TODService
 local TeleportInventoryHydrator = Shared.Runtime.TeleportInventoryHydrator
 local RoundSignalBus = Shared.Runtime.RoundSignalBus
@@ -1378,6 +1379,7 @@ function RunSessionService:_equipItem(player, itemInstanceId)
     end
 
     self:_setStatus(string.format('%s equipped %s in the temple.', player.DisplayName, result.Name))
+    HeldFlashlightHeadlight.syncHeldItem(player, result)
 end
 
 function RunSessionService:_unequipItem(player)
@@ -1400,6 +1402,21 @@ function RunSessionService:_unequipItem(player)
     self:_setStatus(
         string.format('%s stowed %s back into the backpack.', player.DisplayName, result.Name)
     )
+    HeldFlashlightHeadlight.syncHeldItem(player, nil)
+end
+
+function RunSessionService:_handleUseTool(player)
+    Gameplay.HeldToolUseRequest.apply(player, {
+        canManageInventory = function(p)
+            return self:_canManageInventory(p)
+        end,
+        inventoryService = self.InventoryService,
+        monsterService = self.MonsterService,
+        playerService = self.PlayerService,
+        setStatus = function(message)
+            self:_setStatus(message)
+        end,
+    })
 end
 
 function RunSessionService:_openGate(player)
@@ -2076,6 +2093,8 @@ function RunSessionService:start()
             self:_equipItem(player, payload.ItemInstanceId)
         elseif payload.Type == 'RequestUnequipItem' then
             self:_unequipItem(player)
+        elseif payload.Type == 'RequestUseTool' then
+            self:_handleUseTool(player)
         elseif payload.Type == 'RequestSprintStart' then
             self:_setPlayerSprinting(player, true)
         elseif payload.Type == 'RequestSprintStop' then

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -33,6 +33,8 @@ local actionInputConnection
 local sprintInputEndedConnection
 local isMenuMouseUnlockBound = false
 local visibleBackpackItems = {}
+local lastToolUseRequestAt = -math.huge
+local heldToolCooldownSeconds = 0.2
 local MENU_MOUSE_UNLOCK_STEP = 'RunMenuMouseUnlock'
 local MOUSE_TOGGLE_KEY = Enum.KeyCode.LeftAlt
 local teamPages = 0
@@ -403,7 +405,7 @@ objectiveLabel.Text = string.format('%s Objective: --', SAND_BOOK_LABEL)
 
 local guideLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 60), Theme.Text, 16, false)
 guideLabel.Text = string.format(
-    'In-world prompts:\n- %s Shop\n- Salvage Exchange\n- %s Board\n- %s Gate / Shared Maze Gate\nKeyboard: Hold LeftShift to sprint, tap C to toggle %s Status, %s to free mouse, 1-3 to equip, X to stow',
+    'In-world prompts:\n- %s Shop\n- Salvage Exchange\n- %s Board\n- %s Gate / Shared Maze Gate\nKeyboard: Hold LeftShift to sprint, F to use held tool, tap C to toggle %s Status, %s to free mouse, 1-3 to equip, X to stow',
     TEMPLE_LABEL,
     SAND_BOOK_LABEL,
     TEMPLE_LABEL,
@@ -927,6 +929,21 @@ actionInputConnection = UserInputService.InputBegan:Connect(function(input, game
                 Type = 'RequestSprintStart',
             })
         end
+        return
+    end
+
+    if input.KeyCode == Enum.KeyCode.F then
+        if not isRunLaunched then
+            return
+        end
+        local now = os.clock()
+        if now - lastToolUseRequestAt < heldToolCooldownSeconds then
+            return
+        end
+        lastToolUseRequestAt = now
+        Remotes.RunAction:FireServer({
+            Type = 'RequestUseTool',
+        })
         return
     end
 

--- a/tests/src/Shared/HeldToolUseRequest.spec.luau
+++ b/tests/src/Shared/HeldToolUseRequest.spec.luau
@@ -121,10 +121,11 @@ return function()
         deps.monsterService = {
             tryApplyPlayerMeleeHit = function(_, _, payload)
                 meleePayload = payload
-                return true, {
-                    Killed = false,
-                    RemainingHitPoints = 2,
-                }
+                return true,
+                    {
+                        Killed = false,
+                        RemainingHitPoints = 2,
+                    }
             end,
         }
 

--- a/tests/src/Shared/HeldToolUseRequest.spec.luau
+++ b/tests/src/Shared/HeldToolUseRequest.spec.luau
@@ -1,0 +1,180 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local packages = ReplicatedStorage:WaitForChild('Packages')
+    local gameplay = require(packages:WaitForChild('Gameplay'))
+
+    local HeldToolUseRequest = gameplay.HeldToolUseRequest
+
+    local function makeCharacterWithHead()
+        local character = Instance.new('Model')
+        character.Name = 'HeldToolUseSpecCharacter'
+
+        local head = Instance.new('Part')
+        head.Name = 'Head'
+        head.Anchored = true
+        head.Parent = character
+
+        return character, head
+    end
+
+    local function createBaseDeps(heldItem, consumeResult)
+        local statuses = {}
+        local consumeCalls = 0
+
+        local deps = {
+            canManageInventory = function()
+                return true
+            end,
+            inventoryService = {
+                getSummary = function()
+                    return {
+                        HeldItem = heldItem,
+                    }
+                end,
+                consumeHeldItemState = function(_, _, _)
+                    consumeCalls += 1
+                    return true, consumeResult
+                end,
+            },
+            monsterService = nil,
+            playerService = {
+                getSummary = function()
+                    return {
+                        PlayerState = {
+                            IsDead = false,
+                        },
+                    }
+                end,
+                healHealthPips = function()
+                    error('healHealthPips should not be called in this branch', 0)
+                end,
+            },
+            setStatus = function(message)
+                table.insert(statuses, message)
+            end,
+        }
+
+        return deps, statuses, function()
+            return consumeCalls
+        end
+    end
+
+    do
+        local character, head = makeCharacterWithHead()
+        local player = {
+            UserId = 801,
+            DisplayName = 'FlashlightSpec',
+            Character = character,
+        }
+        local heldItem = {
+            Name = 'Flashlight',
+            ToolCategory = 'Flashlight',
+            CurrentState = 100,
+            ConsumePerUse = 0,
+            StateModel = 'Battery',
+        }
+        local deps, statuses, getConsumeCalls = createBaseDeps(heldItem, heldItem)
+
+        HeldToolUseRequest.apply(player, deps)
+
+        local light = head:FindFirstChild('FlashlightLight')
+        assert(light ~= nil and light:IsA('SpotLight'), 'Flashlight use should create a head light')
+        assert(light.Enabled == true, 'First flashlight use should turn the head light on')
+        assert(
+            string.find(statuses[#statuses], 'Headlamp on.', 1, true) ~= nil,
+            'Status should report when the head light turns on'
+        )
+
+        HeldToolUseRequest.apply(player, deps)
+
+        assert(light.Enabled == false, 'Second flashlight use should turn the head light off')
+        assert(
+            string.find(statuses[#statuses], 'Headlamp off.', 1, true) ~= nil,
+            'Status should report when the head light turns off'
+        )
+        assert(
+            getConsumeCalls() == 2,
+            'Flashlight use should still pass through the shared consume path on each use'
+        )
+
+        character:Destroy()
+    end
+
+    do
+        local player = {
+            UserId = 802,
+            DisplayName = 'CrowbarSpec',
+            Character = nil,
+        }
+        local heldItem = {
+            Name = 'Crowbar',
+            ToolCategory = 'Crowbar',
+            CurrentState = 10,
+            ConsumePerUse = 0,
+            StateModel = 'Durability',
+            MeleeDamage = 1,
+            SwingArcDegrees = 75,
+            SwingRange = 8,
+        }
+        local deps, statuses = createBaseDeps(heldItem, heldItem)
+        local meleePayload = nil
+        deps.monsterService = {
+            tryApplyPlayerMeleeHit = function(_, _, payload)
+                meleePayload = payload
+                return true, {
+                    Killed = false,
+                    RemainingHitPoints = 2,
+                }
+            end,
+        }
+
+        HeldToolUseRequest.apply(player, deps)
+
+        assert(meleePayload ~= nil, 'Crowbar use should call the shared melee hook')
+        assert(meleePayload.DamagePips == 1, 'Crowbar use should forward MeleeDamage as DamagePips')
+        assert(
+            meleePayload.SwingArcDegrees == 75 and meleePayload.SwingRange == 8,
+            'Crowbar use should forward swing arc and range to the monster service'
+        )
+        assert(
+            string.find(statuses[#statuses], 'Foe stamina: ~2.', 1, true) ~= nil,
+            'Status should report the remaining monster hit points after a non-lethal melee hit'
+        )
+    end
+
+    do
+        local player = {
+            UserId = 803,
+            DisplayName = 'PotionSpec',
+            Character = nil,
+        }
+        local heldItem = {
+            Name = 'Potion',
+            ToolCategory = 'Potion',
+            CurrentState = 2,
+            ConsumePerUse = 1,
+            StateModel = 'Charges',
+            HealHealthPips = 1,
+        }
+        local consumedHeldItem = table.clone(heldItem)
+        consumedHeldItem.CurrentState = 1
+        local deps, statuses = createBaseDeps(heldItem, consumedHeldItem)
+        local healedPips = nil
+        deps.playerService.healHealthPips = function(_, _, amount)
+            healedPips = amount
+            return true, 4
+        end
+
+        HeldToolUseRequest.apply(player, deps)
+
+        assert(healedPips == 1, 'Potion use should forward HealHealthPips to PlayerService')
+        assert(
+            string.find(statuses[#statuses], 'health pips: 4.', 1, true) ~= nil,
+            'Status should report healed health after potion use'
+        )
+        assert(
+            string.find(statuses[#statuses], 'Charges remaining: 1', 1, true) ~= nil,
+            'Status should include the consumed potion state in the shared output message'
+        )
+    end
+end


### PR DESCRIPTION
## Summary

- Adds `Shared.Runtime.HeldFlashlightHeadlight` so flashlight use owns one replicated head-mounted `SpotLight` lifecycle (toggle + clear) instead of duplicating that behavior in place-local code.
- Adds `Gameplay.HeldToolUseRequest` as the shared server-side `RequestUseTool` path for flashlight, crowbar, and potion handling, then wires both Run and Maze to that shared flow.
- Wires Run client `F` input and guide text to `RunAction.RequestUseTool`, and clears the flashlight headlight consistently on equip/unequip transitions in both places.
- Follow-up after AI review: `HeldToolUseRequest` now caches the `Shared` package for the flashlight branch, and this PR now includes deterministic shared coverage for the new tool-use module.

Why this change is needed:
- Run and Maze were drifting on held-tool behavior even though they share the same tool definitions.
- Centralizing tool use in shared gameplay/runtime code reduces place-local duplication and keeps flashlight / potion / melee status behavior aligned.

Prototype-only exceptions / follow-up work:
- No prototype-only exception is introduced here.
- A short in-Studio smoke for the Run/Maze flashlight lifecycle is still recommended before merge, but there is no remaining code blocker in this PR.

## Roblox Integration Checklist

- [x] The change updates the active runtime source under `packages/**`, or I explained why another source path had to change.
- [x] If Studio tree structure changed, I updated the relevant `default.project.json` in the same PR.
- [x] If I changed Remote names, replicated schema, or visibility behavior, I updated all linked producers/consumers/tests in the same PR.
- [x] If I changed non-trivial shared/gameplay behavior, I added or updated deterministic coverage under `tests/src/Shared`, or I explained why no test change was needed.
- [x] If I touched `SessionConfig.PlaceIds` or any other real-environment configuration, I documented the required rollout or environment follow-up.
- [x] If this PR includes `.rbxl`, generated output, or other non-source artifacts, I explained why they are required.

Checklist notes:
- No Rojo tree mapping changed in this PR.
- `RequestUseTool` rides the existing `RunAction` / `MazeAction` payload surfaces; this PR updates the shared implementation plus all current producers/consumers in the same change.
- Deterministic coverage now includes `tests/src/Shared/HeldToolUseRequest.spec.luau` for flashlight, crowbar, and potion branches.
- `SessionConfig.PlaceIds` is not touched.
- No `.rbxl`, generated output, or other non-source artifacts are added.

## Validation

- [ ] `stylua --check .`
- [ ] `selene .`
- [x] Additional verification steps are listed below if this PR needs more than static checks.

Additional verification:
- GitHub Actions is currently re-running `luau-quality` and `roblox-tests` on head `3c52108` after the deterministic test addition.
- The prior AI-review follow-up commit `ea802f9` already passed both `luau-quality` and `roblox-tests` on this PR.
- Added deterministic shared coverage for the new `HeldToolUseRequest` module to verify flashlight toggle flow, crowbar melee delegation, and potion healing/status output.

## Notes

- Manual test notes: no local Studio smoke was run in this pass.
- Risks / follow-ups: a quick Run/Maze runtime check for `F`-key flashlight lifecycle is still worth doing before merge, but the PR is now structurally documented and test-covered for squash-merge review.