### PR TITLE
feat(crowbar): unify F-key melee via HeldToolUseRequest; gate skip co…

### DIFF
--- a/packages/gameplay/src/Config/ToolItems.luau
+++ b/packages/gameplay/src/Config/ToolItems.luau
@@ -56,9 +56,9 @@ local ToolItems = {
         InitialState = 10,
         ConsumePerUse = 0,
         CooldownSeconds = 0.5,
-        -- 战斗参数
-        SwingRange = 6,
-        SwingArcDegrees = 70,
+        -- 战斗参数（迷宫与 Run 共用；Run 巡逻点常离玩家较远，略放大范围与弧）
+        SwingRange = 8,
+        SwingArcDegrees = 75,
         KnockbackStrength = 15,
         MeleeDamage = 1,
     },

--- a/packages/gameplay/src/HeldToolUseRequest.luau
+++ b/packages/gameplay/src/HeldToolUseRequest.luau
@@ -1,6 +1,8 @@
 --!strict
 -- Shared server path for RequestUseTool (maze + run): consume held state, apply category effects, status line.
--- Lazy-require Shared inside apply() to avoid Gameplay <-> Shared circular init (Runtime.InventoryService loads Gameplay).
+-- Cache Shared after first flashlight use to avoid repeated ReplicatedStorage walks (still lazy vs module-load to reduce circular-init risk).
+
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 export type HeldToolUseDependencies = {
     canManageInventory: (Player) -> boolean,
@@ -13,6 +15,16 @@ export type HeldToolUseDependencies = {
 }
 
 local HeldToolUseRequest = {}
+
+local sharedPackageCache: any? = nil
+
+local function getSharedPackage(): any
+    if sharedPackageCache == nil then
+        sharedPackageCache =
+            require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared'))
+    end
+    return sharedPackageCache
+end
 
 local function crowbarMeleeMissText(reason: unknown): string
     local code = if type(reason) == 'string' then reason else nil
@@ -133,10 +145,7 @@ function HeldToolUseRequest.apply(player: Player, deps: HeldToolUseDependencies)
 
     if updatedHeldItem.ToolCategory == 'Flashlight' then
         actionWord = 'flashed'
-        local Shared = require(
-            game:GetService('ReplicatedStorage'):WaitForChild('Packages'):WaitForChild('Shared')
-        )
-        local enabled = Shared.Runtime.HeldFlashlightHeadlight.toggle(player)
+        local enabled = getSharedPackage().Runtime.HeldFlashlightHeadlight.toggle(player)
         if enabled == nil then
             effectText = 'Head lamp could not be toggled (no head).'
         elseif enabled then

--- a/packages/gameplay/src/HeldToolUseRequest.luau
+++ b/packages/gameplay/src/HeldToolUseRequest.luau
@@ -1,0 +1,208 @@
+--!strict
+-- Shared server path for RequestUseTool (maze + run): consume held state, apply category effects, status line.
+-- Lazy-require Shared inside apply() to avoid Gameplay <-> Shared circular init (Runtime.InventoryService loads Gameplay).
+
+export type HeldToolUseDependencies = {
+    canManageInventory: (Player) -> boolean,
+    inventoryService: any,
+    monsterService: any?,
+    playerService: any,
+    setStatus: (string) -> (),
+    -- When false for Crowbar, skip consumeHeldItemState entirely (no durability step, no LastUsedAt cooldown).
+    shouldConsumeCrowbarOnUse: ((Player) -> boolean)?,
+}
+
+local HeldToolUseRequest = {}
+
+local function crowbarMeleeMissText(reason: unknown): string
+    local code = if type(reason) == 'string' then reason else nil
+    if code == 'ExpeditionInactive' then
+        return 'No hunt is active yet — open the ship door / start the round before swinging at monsters.'
+    elseif code == 'NoMonster' then
+        return 'Nothing dangerous is in the field to hit right now.'
+    elseif code == 'MissingMonsterPosition' then
+        return 'The threat has no position yet — try again in a moment.'
+    elseif code == 'OutOfRange' then
+        return 'That swing was too short — move closer and try again.'
+    elseif code == 'OutOfSwingArc' then
+        return 'You need to face the threat to connect.'
+    elseif code == 'PathBlocked' then
+        return 'Something solid blocks your swing.'
+    elseif code == 'BlockedLineOfSight' then
+        return 'You need a clear view of the threat.'
+    elseif code == 'InvalidFacing' then
+        return 'You need a clear facing direction to swing.'
+    elseif code == 'NoCharacter' or code == 'MissingHumanoidRoot' then
+        return 'You cannot swing without a ready character.'
+    elseif code == 'MonsterCombatStateMissing' then
+        return 'The threat is not ready to take damage yet.'
+    elseif code == 'InvalidPlayer' then
+        return 'That swing could not be applied.'
+    end
+
+    return string.format('The crowbar whiffs (%s).', tostring(reason))
+end
+
+function HeldToolUseRequest.apply(player: Player, deps: HeldToolUseDependencies)
+    if not deps.canManageInventory(player) then
+        return
+    end
+
+    local summary = deps.playerService:getSummary(player)
+    local playerState = summary and summary.PlayerState
+    if playerState and playerState.IsDead == true then
+        deps.setStatus(string.format('%s cannot use tools while dead.', player.DisplayName))
+        return
+    end
+
+    local inventorySummary = deps.inventoryService:getSummary(player)
+    local heldItem = inventorySummary and inventorySummary.HeldItem
+
+    if not heldItem then
+        deps.setStatus(
+            string.format('%s tried to use a tool, but hands are empty.', player.DisplayName)
+        )
+        return
+    end
+
+    if type(heldItem.CurrentState) ~= 'number' or type(heldItem.ConsumePerUse) ~= 'number' then
+        deps.setStatus(
+            string.format(
+                '%s cannot actively "use" %s (it is not a tool).',
+                player.DisplayName,
+                heldItem.Name
+            )
+        )
+        return
+    end
+
+    if heldItem.ConsumePerUse > 0 and heldItem.CurrentState < heldItem.ConsumePerUse then
+        deps.setStatus(
+            string.format(
+                '%s tried to use %s, but it has no %s left.',
+                player.DisplayName,
+                heldItem.Name,
+                heldItem.StateModel or 'power'
+            )
+        )
+        return
+    end
+
+    if heldItem.ToolCategory == 'Crowbar' and deps.shouldConsumeCrowbarOnUse ~= nil then
+        if not deps.shouldConsumeCrowbarOnUse(player) then
+            deps.setStatus(
+                string.format(
+                    '%s hefted the %s, but the hunt is not live yet — no swing was committed (no use or cooldown).',
+                    player.DisplayName,
+                    heldItem.Name
+                )
+            )
+            return
+        end
+    end
+
+    local consumeSuccess, consumeResult, cooldownRemaining =
+        deps.inventoryService:consumeHeldItemState(player, os.clock())
+    if not consumeSuccess then
+        if consumeResult == 'Cooldown' then
+            deps.setStatus(
+                string.format(
+                    '%s cannot use %s yet (cooldown %.1fs remaining).',
+                    player.DisplayName,
+                    heldItem.Name,
+                    math.max(cooldownRemaining or 0, 0)
+                )
+            )
+        else
+            deps.setStatus(
+                string.format(
+                    '%s could not use %s (%s).',
+                    player.DisplayName,
+                    heldItem.Name,
+                    tostring(consumeResult)
+                )
+            )
+        end
+        return
+    end
+
+    local updatedHeldItem = consumeResult
+
+    local actionWord = 'used'
+    local effectText = 'It worked!'
+
+    if updatedHeldItem.ToolCategory == 'Flashlight' then
+        actionWord = 'flashed'
+        local Shared = require(
+            game:GetService('ReplicatedStorage'):WaitForChild('Packages'):WaitForChild('Shared')
+        )
+        local enabled = Shared.Runtime.HeldFlashlightHeadlight.toggle(player)
+        if enabled == nil then
+            effectText = 'Head lamp could not be toggled (no head).'
+        elseif enabled then
+            effectText = 'Headlamp on.'
+        else
+            effectText = 'Headlamp off.'
+        end
+    elseif updatedHeldItem.ToolCategory == 'Crowbar' then
+        actionWord = 'swung'
+        effectText = 'A satisfying swoosh cuts the air!'
+
+        local damagePips = 1
+        if type(updatedHeldItem.MeleeDamage) == 'number' and updatedHeldItem.MeleeDamage >= 1 then
+            damagePips = math.floor(updatedHeldItem.MeleeDamage)
+        end
+
+        local monsterService = deps.monsterService
+        if not monsterService then
+            effectText = 'Monsters are not loaded yet — try again in a moment.'
+        else
+            local meleeOk, meleeResult = monsterService:tryApplyPlayerMeleeHit(player, {
+                DamagePips = damagePips,
+                SwingArcDegrees = updatedHeldItem.SwingArcDegrees,
+                SwingRange = updatedHeldItem.SwingRange,
+            })
+            if meleeOk then
+                if meleeResult and meleeResult.Killed then
+                    effectText = 'The crowbar connects — the threat goes down!'
+                elseif meleeResult and type(meleeResult.RemainingHitPoints) == 'number' then
+                    effectText = string.format(
+                        'The crowbar connects! Foe stamina: ~%d.',
+                        meleeResult.RemainingHitPoints
+                    )
+                end
+            else
+                effectText = crowbarMeleeMissText(meleeResult)
+            end
+        end
+    elseif updatedHeldItem.ToolCategory == 'Potion' then
+        actionWord = 'drank'
+        local healPips = 1
+        if
+            type(updatedHeldItem.HealHealthPips) == 'number'
+            and updatedHeldItem.HealHealthPips >= 1
+        then
+            healPips = math.floor(updatedHeldItem.HealHealthPips)
+        end
+        local healOk, healResult = deps.playerService:healHealthPips(player, healPips)
+        if healOk then
+            effectText = string.format('The brew steadies you — health pips: %d.', healResult)
+        else
+            effectText = string.format('The brew has no effect (%s).', tostring(healResult))
+        end
+    end
+
+    deps.setStatus(
+        string.format(
+            '%s %s the %s. %s (%s remaining: %d)',
+            player.DisplayName,
+            actionWord,
+            updatedHeldItem.Name,
+            effectText,
+            updatedHeldItem.StateModel or 'state',
+            updatedHeldItem.CurrentState
+        )
+    )
+end
+
+return HeldToolUseRequest

--- a/packages/gameplay/src/HeldToolUseRequest.luau
+++ b/packages/gameplay/src/HeldToolUseRequest.luau
@@ -1,6 +1,7 @@
 --!strict
 -- Shared server path for RequestUseTool (maze + run): consume held state, apply category effects, status line.
--- Cache Shared after first flashlight use to avoid repeated ReplicatedStorage walks (still lazy vs module-load to reduce circular-init risk).
+-- PR #289 (gemini-code-assist medium): cache Shared ModuleScript + required table after first flashlight use —
+-- avoids WaitForChild on every toggle; defer resolution to first use to reduce circular-init risk vs eager module-load.
 
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
@@ -16,12 +17,15 @@ export type HeldToolUseDependencies = {
 
 local HeldToolUseRequest = {}
 
+local sharedModuleScript: Instance? = nil
 local sharedPackageCache: any? = nil
 
-local function getSharedPackage(): any
+local function getSharedRuntimePackage(): any
     if sharedPackageCache == nil then
-        sharedPackageCache =
-            require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared'))
+        if sharedModuleScript == nil then
+            sharedModuleScript = ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared')
+        end
+        sharedPackageCache = require(sharedModuleScript)
     end
     return sharedPackageCache
 end
@@ -145,7 +149,7 @@ function HeldToolUseRequest.apply(player: Player, deps: HeldToolUseDependencies)
 
     if updatedHeldItem.ToolCategory == 'Flashlight' then
         actionWord = 'flashed'
-        local enabled = getSharedPackage().Runtime.HeldFlashlightHeadlight.toggle(player)
+        local enabled = getSharedRuntimePackage().Runtime.HeldFlashlightHeadlight.toggle(player)
         if enabled == nil then
             effectText = 'Head lamp could not be toggled (no head).'
         elseif enabled then

--- a/packages/shared/src/Client/HeldToolVisual.luau
+++ b/packages/shared/src/Client/HeldToolVisual.luau
@@ -7,7 +7,8 @@ local ItemPresentation = Gameplay.Config.ItemPresentation
 
 local CLONE_NAME = 'HeldToolVisualClone'
 
--- One in-flight cosmetic swing per character (avoids cross-talk if multiple controllers share the module).
+-- PR #289 (gemini-code-assist high): one in-flight cosmetic swing cleanup per character — a single module-level
+-- slot would let two characters overwrite each other's restore callbacks.
 local swingCleanupByCharacter: { [Model]: () -> () } = {}
 
 local HeldToolVisual = {}

--- a/packages/shared/src/Client/HeldToolVisual.luau
+++ b/packages/shared/src/Client/HeldToolVisual.luau
@@ -1,10 +1,13 @@
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local RunService = game:GetService('RunService')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
 local ItemPresentation = Gameplay.Config.ItemPresentation
 
 local CLONE_NAME = 'HeldToolVisualClone'
+
+local activeSwingCleanup: (() -> ())? = nil
 
 local HeldToolVisual = {}
 HeldToolVisual.CLONE_NAME = CLONE_NAME
@@ -15,6 +18,10 @@ local function getHandPart(character: Model): BasePart?
 end
 
 function HeldToolVisual.clear(character: Model?)
+    if activeSwingCleanup then
+        activeSwingCleanup()
+    end
+
     if not character then
         return
     end
@@ -161,6 +168,109 @@ function HeldToolVisual.sync(character: Model?, heldItem: any?)
     elseif clone:IsA('Tool') then
         tryWeldToHand(hand, clone)
     end
+end
+
+local function hasHandHandleWeld(hand: BasePart, handle: BasePart): boolean
+    for _, inst in handle:GetChildren() do
+        if inst:IsA('WeldConstraint') then
+            local w = inst :: WeldConstraint
+            if (w.Part0 == hand and w.Part1 == handle) or (w.Part1 == hand and w.Part0 == handle) then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+-- Cosmetic only: breaks the hand↔handle weld briefly, rotates the handle, then re-welds.
+-- Server hit detection stays on RequestUseTool; do not use this for gameplay authority.
+function HeldToolVisual.playCrowbarSwingFeedback(character: Model?)
+    if not character then
+        return
+    end
+
+    if activeSwingCleanup then
+        activeSwingCleanup()
+    end
+
+    local hand = getHandPart(character)
+    if not hand then
+        return
+    end
+
+    local clone = hand:FindFirstChild(CLONE_NAME)
+    if not clone then
+        return
+    end
+
+    local handle = clone:FindFirstChild('Handle', true)
+    if not (handle and handle:IsA('BasePart')) then
+        return
+    end
+
+    local handWeld: WeldConstraint? = nil
+    for _, inst in handle:GetChildren() do
+        if inst:IsA('WeldConstraint') then
+            local w = inst :: WeldConstraint
+            if (w.Part0 == hand and w.Part1 == handle) or (w.Part1 == hand and w.Part0 == handle) then
+                handWeld = w
+                break
+            end
+        end
+    end
+    if not handWeld then
+        return
+    end
+
+    handWeld:Destroy()
+    local offset = hand.CFrame:ToObjectSpace(handle.CFrame)
+    local duration = 0.22
+    local elapsed = 0.0
+
+    local connection: RBXScriptConnection?
+    local finished = false
+
+    local function restoreWeld()
+        if finished then
+            return
+        end
+        finished = true
+        activeSwingCleanup = nil
+        if connection then
+            connection:Disconnect()
+            connection = nil
+        end
+        if handle.Parent and hand.Parent then
+            handle.CFrame = hand.CFrame * offset
+            if not hasHandHandleWeld(hand, handle) then
+                local restored = Instance.new('WeldConstraint')
+                restored.Part0 = hand
+                restored.Part1 = handle
+                restored.Parent = handle
+            end
+        end
+    end
+
+    activeSwingCleanup = restoreWeld
+
+    connection = RunService.Heartbeat:Connect(function(dt)
+        if not handle.Parent or not hand.Parent then
+            restoreWeld()
+            return
+        end
+
+        elapsed += dt
+        if elapsed >= duration then
+            restoreWeld()
+            return
+        end
+
+        local alpha = elapsed / duration
+        local swing = math.sin(alpha * math.pi)
+        local extra = CFrame.Angles(math.rad(58) * swing, math.rad(14) * swing, 0)
+        handle.CFrame = hand.CFrame * offset * extra
+    end)
 end
 
 return HeldToolVisual

--- a/packages/shared/src/Client/HeldToolVisual.luau
+++ b/packages/shared/src/Client/HeldToolVisual.luau
@@ -7,10 +7,19 @@ local ItemPresentation = Gameplay.Config.ItemPresentation
 
 local CLONE_NAME = 'HeldToolVisualClone'
 
-local activeSwingCleanup: (() -> ())? = nil
+-- One in-flight cosmetic swing per character (avoids cross-talk if multiple controllers share the module).
+local swingCleanupByCharacter: { [Model]: () -> () } = {}
 
 local HeldToolVisual = {}
 HeldToolVisual.CLONE_NAME = CLONE_NAME
+
+local function cancelSwingCleanupForCharacter(character: Model)
+    local cleanup = swingCleanupByCharacter[character]
+    if cleanup then
+        cleanup()
+        swingCleanupByCharacter[character] = nil
+    end
+end
 
 local function getHandPart(character: Model): BasePart?
     local hand = character:FindFirstChild('RightHand') or character:FindFirstChild('Right Arm')
@@ -18,8 +27,8 @@ local function getHandPart(character: Model): BasePart?
 end
 
 function HeldToolVisual.clear(character: Model?)
-    if activeSwingCleanup then
-        activeSwingCleanup()
+    if character then
+        cancelSwingCleanupForCharacter(character)
     end
 
     if not character then
@@ -174,7 +183,9 @@ local function hasHandHandleWeld(hand: BasePart, handle: BasePart): boolean
     for _, inst in handle:GetChildren() do
         if inst:IsA('WeldConstraint') then
             local w = inst :: WeldConstraint
-            if (w.Part0 == hand and w.Part1 == handle) or (w.Part1 == hand and w.Part0 == handle) then
+            if
+                (w.Part0 == hand and w.Part1 == handle) or (w.Part1 == hand and w.Part0 == handle)
+            then
                 return true
             end
         end
@@ -190,9 +201,7 @@ function HeldToolVisual.playCrowbarSwingFeedback(character: Model?)
         return
     end
 
-    if activeSwingCleanup then
-        activeSwingCleanup()
-    end
+    cancelSwingCleanupForCharacter(character)
 
     local hand = getHandPart(character)
     if not hand then
@@ -213,7 +222,9 @@ function HeldToolVisual.playCrowbarSwingFeedback(character: Model?)
     for _, inst in handle:GetChildren() do
         if inst:IsA('WeldConstraint') then
             local w = inst :: WeldConstraint
-            if (w.Part0 == hand and w.Part1 == handle) or (w.Part1 == hand and w.Part0 == handle) then
+            if
+                (w.Part0 == hand and w.Part1 == handle) or (w.Part1 == hand and w.Part0 == handle)
+            then
                 handWeld = w
                 break
             end
@@ -236,7 +247,7 @@ function HeldToolVisual.playCrowbarSwingFeedback(character: Model?)
             return
         end
         finished = true
-        activeSwingCleanup = nil
+        swingCleanupByCharacter[character] = nil
         if connection then
             connection:Disconnect()
             connection = nil
@@ -252,7 +263,7 @@ function HeldToolVisual.playCrowbarSwingFeedback(character: Model?)
         end
     end
 
-    activeSwingCleanup = restoreWeld
+    swingCleanupByCharacter[character] = restoreWeld
 
     connection = RunService.Heartbeat:Connect(function(dt)
         if not handle.Parent or not hand.Parent then

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -1258,138 +1258,20 @@ end
 
 -- === 新增：处理道具使用的逻辑（这是本次手术最核心的部位） ===
 function MazeSessionService:_handleUseTool(player)
-    if not self:_canManageInventory(player) then
-        return
-    end
-
-    local playerState = self.PlayerService:getSummary(player).PlayerState
-    if playerState.IsDead == true then
-        self:_setStatus(string.format('%s cannot use tools while dead.', player.DisplayName))
-        return
-    end
-
-    -- 1. 检查手里有没有拿东西
-    local inventorySummary = self.InventoryService:getSummary(player)
-    local heldItem = inventorySummary and inventorySummary.HeldItem
-
-    if not heldItem then
-        self:_setStatus(
-            string.format('%s tried to use a tool, but hands are empty.', player.DisplayName)
-        )
-        return
-    end
-
-    -- 2. 检查这东西有没有“状态/耐久”（ConsumePerUse 允许为 0 表示不消耗型工具）
-    if type(heldItem.CurrentState) ~= 'number' or type(heldItem.ConsumePerUse) ~= 'number' then
-        self:_setStatus(
-            string.format(
-                '%s cannot actively "use" %s (it is not a tool).',
-                player.DisplayName,
-                heldItem.Name
-            )
-        )
-        return
-    end
-
-    -- 3. 检查有没有没电/报废（仅当每次使用会扣耐久时）
-    if heldItem.ConsumePerUse > 0 and heldItem.CurrentState < heldItem.ConsumePerUse then
-        self:_setStatus(
-            string.format(
-                '%s tried to use %s, but it has no %s left.',
-                player.DisplayName,
-                heldItem.Name,
-                heldItem.StateModel or 'power'
-            )
-        )
-        return
-    end
-
-    -- 4. 真正“使用”它：扣除耐久并同步到实际背包状态
-    local consumeSuccess, consumeResult, cooldownRemaining =
-        self.InventoryService:consumeHeldItemState(player, os.clock())
-    if not consumeSuccess then
-        if consumeResult == 'Cooldown' then
-            self:_setStatus(
-                string.format(
-                    '%s cannot use %s yet (cooldown %.1fs remaining).',
-                    player.DisplayName,
-                    heldItem.Name,
-                    math.max(cooldownRemaining or 0, 0)
-                )
-            )
-        else
-            self:_setStatus(
-                string.format(
-                    '%s could not use %s (%s).',
-                    player.DisplayName,
-                    heldItem.Name,
-                    tostring(consumeResult)
-                )
-            )
-        end
-        return
-    end
-
-    local updatedHeldItem = consumeResult
-
-    local actionWord = 'used'
-    local effectText = 'It worked!'
-
-    if updatedHeldItem.ToolCategory == 'Flashlight' then
-        actionWord = 'flashed'
-        effectText = 'The area is illuminated.'
-    elseif updatedHeldItem.ToolCategory == 'Crowbar' then
-        actionWord = 'swung'
-        effectText = 'A satisfying swoosh cuts the air!'
-
-        local damagePips = 1
-        if type(updatedHeldItem.MeleeDamage) == 'number' and updatedHeldItem.MeleeDamage >= 1 then
-            damagePips = math.floor(updatedHeldItem.MeleeDamage)
-        end
-
-        local meleeOk, meleeResult = self.MonsterService:tryApplyPlayerMeleeHit(player, {
-            DamagePips = damagePips,
-            SwingArcDegrees = updatedHeldItem.SwingArcDegrees,
-            SwingRange = updatedHeldItem.SwingRange,
-        })
-        if meleeOk then
-            if meleeResult and meleeResult.Killed then
-                effectText = 'The crowbar connects — the threat goes down!'
-            elseif meleeResult and type(meleeResult.RemainingHitPoints) == 'number' then
-                effectText = string.format(
-                    'The crowbar connects! Foe stamina: ~%d.',
-                    meleeResult.RemainingHitPoints
-                )
-            end
-        end
-    elseif updatedHeldItem.ToolCategory == 'Potion' then
-        actionWord = 'drank'
-        local healPips = 1
-        if
-            type(updatedHeldItem.HealHealthPips) == 'number'
-            and updatedHeldItem.HealHealthPips >= 1
-        then
-            healPips = math.floor(updatedHeldItem.HealHealthPips)
-        end
-        local healOk, healResult = self.PlayerService:healHealthPips(player, healPips)
-        if healOk then
-            effectText = string.format('The brew steadies you — health pips: %d.', healResult)
-        else
-            effectText = string.format('The brew has no effect (%s).', tostring(healResult))
-        end
-    end
-
-    self:_setStatus(
-        string.format(
-            '%s %s the %s. %s (%s remaining: %d)',
-            player.DisplayName,
-            actionWord,
-            updatedHeldItem.Name,
-            effectText,
-            updatedHeldItem.StateModel or 'state',
-            updatedHeldItem.CurrentState
-        )
-    )
+    Gameplay.HeldToolUseRequest.apply(player, {
+        canManageInventory = function(p)
+            return self:_canManageInventory(p)
+        end,
+        inventoryService = self.InventoryService,
+        monsterService = self.MonsterService,
+        playerService = self.PlayerService,
+        setStatus = function(message)
+            self:_setStatus(message)
+        end,
+        shouldConsumeCrowbarOnUse = function(_p)
+            return self.RunTracker:getState() == 'Expedition'
+        end,
+    })
 end
 -- =======================================================
 

--- a/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
+++ b/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
@@ -13,6 +13,7 @@ local UI = require(Packages:WaitForChild('UI'))
 local ItemPresentation = Gameplay.Config.ItemPresentation
 
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
+local HeldToolVisual = Shared.Client.HeldToolVisual
 local heldItemController = Shared.Client.HeldItemController.new(localPlayer)
 local Theme = UI.Hud.Theme
 local REMOTE_WAIT_TIMEOUT_SECONDS = 10
@@ -30,6 +31,7 @@ local visibleBackpackItems = {}
 local didReceiveInitialSnapshot = false
 local lastToolUseRequestAt = -math.huge
 local heldToolCooldownSeconds = 0.2
+local mazeInventoryForSwing: { [string]: any }? = nil
 
 local function presentationIconSuffix(itemEntry: { [string]: any }?)
     if type(itemEntry) ~= 'table' then
@@ -293,6 +295,10 @@ actionInputConnection = UserInputService.InputBegan:Connect(function(input, game
         end
 
         lastToolUseRequestAt = now
+        local heldForSwing = mazeInventoryForSwing and mazeInventoryForSwing.HeldItem
+        if heldForSwing and heldForSwing.ToolCategory == 'Crowbar' then
+            HeldToolVisual.playCrowbarSwingFeedback(localPlayer.Character)
+        end
         Remotes.MazeAction:FireServer({
             Type = 'RequestUseTool',
         })
@@ -404,6 +410,7 @@ local function connectMazeRemotes(remotes)
         objectiveLabel.Text = string.format('Objective: %s', snapshot.Objective or '--')
 
         local inventory = snapshot.Inventory or {}
+        mazeInventoryForSwing = inventory
         visibleBackpackItems = inventory.BackpackItems or {}
         heldItemController:applyInventory(inventory)
         inventoryLabel.Text = string.format(

--- a/places/run/src/ServerScriptService/Run/ItemFunctionality.luau
+++ b/places/run/src/ServerScriptService/Run/ItemFunctionality.luau
@@ -257,90 +257,7 @@ function ItemFunctionality.tetherMonster(player: Player, targetModel: Model): bo
     return true
 end
 
--- ====================
--- 道具 3: 撬棍
--- ====================
-
--- 撬开箱子/门
-function ItemFunctionality.pryOpen(player: Player, targetPart: BasePart): boolean
-    if not heldMatchesToolCategory(player, 'Crowbar') then
-        return false
-    end
-
-    -- 验证距离(防止远程交互攻击)
-    local character = player.Character
-    if not character or not character.HumanoidRootPart then
-        return false
-    end
-
-    local characterPosition = character.HumanoidRootPart.Position
-    local targetPosition = targetPart.Position
-    local distance = (targetPosition - characterPosition).Magnitude
-    local MAX_INTERACTION_DISTANCE = 10 -- 撬开的距离需要比较近
-
-    if distance > MAX_INTERACTION_DISTANCE then
-        warn(player.Name .. ' 尝试从过远的距离撬开: ' .. tostring(distance))
-        return false
-    end
-
-    -- 检查目标是否已被撬开
-    if targetPart:GetAttribute('PriedOpen') then
-        return false
-    end
-
-    -- 撬棍动画
-    -- 创建撬棍视觉提示
-    local crowbarVisual = Instance.new('Part')
-    crowbarVisual.Name = 'CrowbarAnimation'
-    crowbarVisual.Size = Vector3.new(0.2, 4, 0.2)
-    crowbarVisual.Color = Color3.fromRGB(120, 120, 120)
-    crowbarVisual.Material = Enum.Material.Metal
-    crowbarVisual.CanCollide = false
-    crowbarVisual.Anchored = true
-
-    local pryTargetPosition = targetPart.Position + Vector3.new(0, 1, 0)
-    crowbarVisual.CFrame = CFrame.new(pryTargetPosition) * CFrame.Angles(math.rad(45), 0, 0)
-    crowbarVisual.Parent = workspace
-
-    -- 撬动动画
-    local pryTween = TweenService:Create(
-        crowbarVisual,
-        TweenInfo.new(0.5, Enum.EasingStyle.Back, Enum.EasingDirection.InOut),
-        { CFrame = crowbarVisual.CFrame * CFrame.Angles(math.rad(-30), 0, 0) }
-    )
-    pryTween:Play()
-
-    -- 撬开效果
-    task.delay(0.5, function()
-        -- 标记为已撬开
-        targetPart:SetAttribute('PriedOpen', true)
-
-        -- 移除目标(如果是锁)
-        local lock = targetPart:FindFirstChild('Lock')
-        if lock then
-            lock:Destroy()
-        end
-
-        -- 或者移动目标(如果是门/盖)
-        if targetPart.Name == 'ChestLid' then
-            local openTween = TweenService:Create(
-                targetPart,
-                TweenInfo.new(0.3, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
-                {
-                    CFrame = targetPart.CFrame
-                        * CFrame.Angles(math.rad(-45), 0, 0)
-                        * CFrame.new(0, 0.5, 0.5),
-                }
-            )
-            openTween:Play()
-        end
-
-        -- 移除视觉提示
-        crowbarVisual:Destroy()
-    end)
-
-    return true
-end
+-- Crowbar combat is server-only via Gameplay.HeldToolUseRequest (RequestUseTool). Pry/door legacy was removed.
 
 -- ====================
 -- 交互检测系统
@@ -406,8 +323,6 @@ Remotes.UseItemFunction.OnServerEvent:Connect(
             elseif actionType == 'tether' and target then
                 success = ItemFunctionality.tetherMonster(player, target)
             end
-        elseif itemName == 'Crowbar' and actionType == 'pry' and target then
-            success = ItemFunctionality.pryOpen(player, target)
         end
 
         if success then

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -1400,6 +1400,24 @@ function RunSessionService:_unequipItem(player)
     self:_setStatus(
         string.format('%s stowed %s back into the backpack.', player.DisplayName, result.Name)
     )
+    Shared.Runtime.HeldFlashlightHeadlight.syncHeldItem(player, nil)
+end
+
+function RunSessionService:_handleUseTool(player)
+    Gameplay.HeldToolUseRequest.apply(player, {
+        canManageInventory = function(p)
+            return self:_canManageInventory(p)
+        end,
+        inventoryService = self.InventoryService,
+        monsterService = self.MonsterService,
+        playerService = self.PlayerService,
+        setStatus = function(message)
+            self:_setStatus(message)
+        end,
+        shouldConsumeCrowbarOnUse = function(_p)
+            return self.CampSession.DangerActive == true
+        end,
+    })
 end
 
 function RunSessionService:_openGate(player)
@@ -2076,6 +2094,8 @@ function RunSessionService:start()
             self:_equipItem(player, payload.ItemInstanceId)
         elseif payload.Type == 'RequestUnequipItem' then
             self:_unequipItem(player)
+        elseif payload.Type == 'RequestUseTool' then
+            self:_handleUseTool(player)
         elseif payload.Type == 'RequestSprintStart' then
             self:_setPlayerSprinting(player, true)
         elseif payload.Type == 'RequestSprintStop' then

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -15,6 +15,7 @@ local Remotes = Shared.Network.Remotes.waitForScope(Shared.Network.Remotes.Scope
 local TODConfig = Shared.Config.SessionConfig.TOD
 local TODRemote = ReplicatedStorage:WaitForChild('Remotes'):WaitForChild('TODState')
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
+local HeldToolVisual = Shared.Client.HeldToolVisual
 local heldItemController = Shared.Client.HeldItemController.new(localPlayer)
 local Theme = UI.Hud.Theme
 
@@ -33,6 +34,8 @@ local actionInputConnection
 local sprintInputEndedConnection
 local isMenuMouseUnlockBound = false
 local visibleBackpackItems = {}
+local lastToolUseRequestAt = -math.huge
+local heldToolCooldownSeconds = 0.2
 local MENU_MOUSE_UNLOCK_STEP = 'RunMenuMouseUnlock'
 local MOUSE_TOGGLE_KEY = Enum.KeyCode.LeftAlt
 local teamPages = 0
@@ -930,6 +933,25 @@ actionInputConnection = UserInputService.InputBegan:Connect(function(input, game
         return
     end
 
+    if input.KeyCode == Enum.KeyCode.F then
+        if not isRunLaunched then
+            return
+        end
+        local now = os.clock()
+        if now - lastToolUseRequestAt < heldToolCooldownSeconds then
+            return
+        end
+        lastToolUseRequestAt = now
+        local heldForSwing = inventorySummary and inventorySummary.HeldItem
+        if heldForSwing and heldForSwing.ToolCategory == 'Crowbar' then
+            HeldToolVisual.playCrowbarSwingFeedback(localPlayer.Character)
+        end
+        Remotes.RunAction:FireServer({
+            Type = 'RequestUseTool',
+        })
+        return
+    end
+
     if input.KeyCode == MOUSE_TOGGLE_KEY then
         isMouseFree = not isMouseFree
         syncMouseMode()
@@ -1203,6 +1225,12 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
     )
 
     local heldItem = inventory.HeldItem
+    if heldItem and type(heldItem.CooldownSeconds) == 'number' then
+        heldToolCooldownSeconds = math.max(heldItem.CooldownSeconds, 0)
+    else
+        heldToolCooldownSeconds = 0.2
+    end
+
     local inventoryDetailLines = {
         heldItem and string.format(
             'Held: %s | %d KG | %d value%s',

--- a/tests/src/Shared/HeldToolVisual.spec.luau
+++ b/tests/src/Shared/HeldToolVisual.spec.luau
@@ -45,4 +45,19 @@ return function()
             )
         end)
     end
+
+    do
+        local charA = makeMinimalCharacter()
+        local charB = makeMinimalCharacter()
+        local crowbar = ToolItems['tool-crowbar']
+        assert(crowbar ~= nil, 'tool-crowbar should exist')
+        HeldToolVisual.sync(charA, crowbar)
+        HeldToolVisual.sync(charB, crowbar)
+        HeldToolVisual.playCrowbarSwingFeedback(charA)
+        HeldToolVisual.playCrowbarSwingFeedback(charB)
+        HeldToolVisual.clear(charA)
+        HeldToolVisual.clear(charB)
+        charA:Destroy()
+        charB:Destroy()
+    end
 end


### PR DESCRIPTION
…nsume

## 摘要
- 撬棍在 Run / 迷宫均通过 RequestUseTool → HeldToolUseRequest 统一处理近战。
- 远征未开始时不提交挥击：不占冷却、不写入 LastUsedAt（Run：DangerActive；迷宫：Expedition）。
- 删除 Run 侧撬棍撬门 legacy（ItemFunctionality / UseItemFunction pry）。
- 客户端撬棍挥击反馈（HeldToolVisual），命中仍以服务端为准。
- 调整共用 ToolItems 撬棍距离/扇形；补充未命中/服务未就绪等状态文案。

## 自测
- [ ] Run：开门前 F — 不消耗、无冷却。
- [ ] Run：开门后 F — 命中/未命中提示合理。
- [ ] 迷宫：远征开关与预期一致。

## Summary

- What changed?
- Why is this change needed?
- Any prototype-only exceptions or follow-up work?

## Roblox Integration Checklist

- [ ] The change updates the active runtime source under `packages/**`, or I explained why another source path had to change.
- [ ] If Studio tree structure changed, I updated the relevant `default.project.json` in the same PR.
- [ ] If I changed Remote names, replicated schema, or visibility behavior, I updated all linked producers/consumers/tests in the same PR.
- [ ] If I changed non-trivial shared/gameplay behavior, I added or updated deterministic coverage under `tests/src/Shared`, or I explained why no test change was needed.
- [ ] If I touched `SessionConfig.PlaceIds` or any other real-environment configuration, I documented the required rollout or environment follow-up.
- [ ] If this PR includes `.rbxl`, generated output, or other non-source artifacts, I explained why they are required.

## Validation

- [ ] `stylua --check .`
- [ ] `selene .`
- [ ] Additional verification steps are listed below if this PR needs more than static checks.

## Notes

- Manual test notes:
- Risks / follow-ups:
