### PR TITLE
checkpoint: run/maze mission-loop refactor (5 rounds, clue items, fixed maze)

### DIFF
--- a/packages/gameplay/src/Config/ItemFields.luau
+++ b/packages/gameplay/src/Config/ItemFields.luau
@@ -16,10 +16,36 @@ local function cloneLightConfig(lightConfig: any): any
     }
 end
 
+local function normalizeItemCategory(itemEntry: any): string
+    if type(itemEntry.ItemCategory) == 'string' and itemEntry.ItemCategory ~= '' then
+        return itemEntry.ItemCategory
+    end
+
+    if type(itemEntry.ToolCategory) == 'string' and itemEntry.ToolCategory ~= '' then
+        return 'Tool'
+    end
+
+    return 'Loot'
+end
+
+local function normalizeMissionCount(itemEntry: any, itemCategory: string): number
+    if type(itemEntry.MissionCount) == 'number' then
+        return itemEntry.MissionCount
+    end
+
+    if itemCategory == 'Loot' then
+        return 1
+    end
+
+    return 0
+end
+
 function ItemFields.copyItemEntry(itemEntry: any): any
     if type(itemEntry) ~= 'table' then
         return nil
     end
+
+    local itemCategory = normalizeItemCategory(itemEntry)
 
     return {
         InstanceId = itemEntry.InstanceId,
@@ -44,6 +70,13 @@ function ItemFields.copyItemEntry(itemEntry: any): any
         KnockbackStrength = itemEntry.KnockbackStrength,
         MeleeDamage = itemEntry.MeleeDamage,
         HealHealthPips = itemEntry.HealHealthPips,
+        ItemCategory = itemCategory,
+        MissionCount = normalizeMissionCount(itemEntry, itemCategory),
+        ReadableTitle = itemEntry.ReadableTitle,
+        ReadableText = itemEntry.ReadableText,
+        ClueId = itemEntry.ClueId,
+        ThreatHintId = itemEntry.ThreatHintId,
+        SourceMarkerId = itemEntry.SourceMarkerId,
     }
 end
 
@@ -51,6 +84,8 @@ function ItemFields.normalizeItemEntryForLoad(rawItemEntry: any): any
     if type(rawItemEntry) ~= 'table' or type(rawItemEntry.InstanceId) ~= 'number' then
         return nil
     end
+
+    local itemCategory = normalizeItemCategory(rawItemEntry)
 
     return {
         InstanceId = rawItemEntry.InstanceId,
@@ -75,6 +110,13 @@ function ItemFields.normalizeItemEntryForLoad(rawItemEntry: any): any
         KnockbackStrength = rawItemEntry.KnockbackStrength,
         MeleeDamage = rawItemEntry.MeleeDamage,
         HealHealthPips = rawItemEntry.HealHealthPips,
+        ItemCategory = itemCategory,
+        MissionCount = normalizeMissionCount(rawItemEntry, itemCategory),
+        ReadableTitle = rawItemEntry.ReadableTitle,
+        ReadableText = rawItemEntry.ReadableText,
+        ClueId = rawItemEntry.ClueId,
+        ThreatHintId = rawItemEntry.ThreatHintId,
+        SourceMarkerId = rawItemEntry.SourceMarkerId,
     }
 end
 
@@ -101,6 +143,13 @@ ItemFields.ENTRY_FIELD_NAMES = table.freeze({
     'KnockbackStrength',
     'MeleeDamage',
     'HealHealthPips',
+    'ItemCategory',
+    'MissionCount',
+    'ReadableTitle',
+    'ReadableText',
+    'ClueId',
+    'ThreatHintId',
+    'SourceMarkerId',
 })
 
 return ItemFields

--- a/packages/gameplay/src/Config/Items.luau
+++ b/packages/gameplay/src/Config/Items.luau
@@ -1,9 +1,7 @@
 local Config = script.Parent
 
--- 引入探索道具武器库
 local ToolItems = require(Config:WaitForChild('ToolItems'))
 
--- 这是原本的基础物资列表
 local BaseItems = {
     {
         Id = 'ugc-gen-token',
@@ -11,6 +9,8 @@ local BaseItems = {
         Weight = 1,
         Value = 4,
         Color = Color3.fromRGB(121, 195, 255),
+        ItemCategory = 'Loot',
+        MissionCount = 1,
     },
     {
         Id = 'scrap-bolt',
@@ -18,6 +18,8 @@ local BaseItems = {
         Weight = 1,
         Value = 8,
         Color = Color3.fromRGB(148, 163, 184),
+        ItemCategory = 'Loot',
+        MissionCount = 1,
     },
     {
         Id = 'signal-core',
@@ -25,6 +27,8 @@ local BaseItems = {
         Weight = 2,
         Value = 18,
         Color = Color3.fromRGB(80, 227, 194),
+        ItemCategory = 'Loot',
+        MissionCount = 1,
     },
     {
         Id = 'reactor-shell',
@@ -32,6 +36,8 @@ local BaseItems = {
         Weight = 4,
         Value = 42,
         Color = Color3.fromRGB(248, 196, 113),
+        ItemCategory = 'Loot',
+        MissionCount = 1,
     },
     {
         Id = 'glow-orb',
@@ -44,10 +50,11 @@ local BaseItems = {
             Range = 18,
             Color = Color3.fromRGB(170, 240, 255),
         },
+        ItemCategory = 'Loot',
+        MissionCount = 1,
     },
 }
 
--- === 自动合并逻辑：把 ToolItems 里的手电筒和撬棍也加进来 ===
 local FinalItems = table.clone(BaseItems)
 
 for _, toolData in pairs(ToolItems) do

--- a/packages/gameplay/src/Config/ToolItems.luau
+++ b/packages/gameplay/src/Config/ToolItems.luau
@@ -2,31 +2,31 @@
 -- IconAssetId: Roblox image asset id only, or full rbxassetid:// URI; empty = UI uses Color fallback.
 -- ToolTemplateName: optional Model/Tool name under ReplicatedStorage.Assets.ToolTemplates (see place default.project.json).
 local ToolItems = {
-    -- 手电筒：照明消耗电量
     ['tool-flashlight'] = {
         Id = 'tool-flashlight',
         Name = 'Flashlight',
         Description = '在黑暗中照亮路径。本配置下使用不消耗电量。',
         ToolCategory = 'Flashlight',
+        ItemCategory = 'Tool',
+        MissionCount = 0,
         Weight = 1,
         Value = 0,
         Color = Color3.fromRGB(148, 163, 184),
         IsEquipable = true,
         IconAssetId = '',
         ToolTemplateName = 'ToolFlashlight',
-        -- 状态属性
         StateModel = 'Battery',
         InitialState = 100,
         ConsumePerUse = 0,
         CooldownSeconds = 0,
     },
-
-    -- 绳索：攀爬 / 套索等营地交互（与 ToolCategory == 'Rope' 对齐）
     ['tool-rope'] = {
         Id = 'tool-rope',
         Name = 'Rope',
         Description = '攀爬高处、跨越断层、固定目标。',
         ToolCategory = 'Rope',
+        ItemCategory = 'Tool',
+        MissionCount = 0,
         Weight = 2,
         Value = 0,
         Color = Color3.fromRGB(180, 160, 120),
@@ -38,37 +38,35 @@ local ToolItems = {
         ConsumePerUse = 0,
         CooldownSeconds = 0.5,
     },
-
-    -- 撬棍：近战挥舞击退怪物
     ['tool-crowbar'] = {
         Id = 'tool-crowbar',
         Name = 'Crowbar',
         Description = '近战挥舞可对前方怪物造成伤害。本配置下使用不消耗耐久。',
         ToolCategory = 'Crowbar',
+        ItemCategory = 'Tool',
+        MissionCount = 0,
         Weight = 3,
         Value = 0,
         Color = Color3.fromRGB(200, 200, 200),
         IsEquipable = true,
         IconAssetId = '',
         ToolTemplateName = 'ToolCrowbar',
-        -- 状态属性
         StateModel = 'Durability',
         InitialState = 10,
         ConsumePerUse = 0,
         CooldownSeconds = 0.5,
-        -- 战斗参数（迷宫与 Run 共用；Run 巡逻点常离玩家较远，略放大范围与弧）
         SwingRange = 8,
         SwingArcDegrees = 75,
         KnockbackStrength = 15,
         MeleeDamage = 1,
     },
-
-    -- 药水：迷宫内饮用，消耗次数并回复生命 pip（占位数值）
     ['tool-potion'] = {
         Id = 'tool-potion',
         Name = 'Potion',
         Description = '饮用消耗一次剂量并回复少量生命；仅在迷宫远征中作为工具使用。',
         ToolCategory = 'Potion',
+        ItemCategory = 'Tool',
+        MissionCount = 0,
         Weight = 1,
         Value = 0,
         Color = Color3.fromRGB(236, 72, 153),
@@ -79,7 +77,6 @@ local ToolItems = {
         InitialState = 3,
         ConsumePerUse = 1,
         CooldownSeconds = 1,
-        -- 每次成功饮用回复的生命 pip（迷宫 RequestUseTool）
         HealHealthPips = 1,
     },
 }

--- a/packages/gameplay/src/Inventory.luau
+++ b/packages/gameplay/src/Inventory.luau
@@ -17,13 +17,39 @@ local function cloneArray(items)
     return result
 end
 
-function Inventory.new(capacity)
-    local backpackItems = {}
+local function getItemCategory(itemEntry)
+    if type(itemEntry.ItemCategory) == 'string' and itemEntry.ItemCategory ~= '' then
+        return itemEntry.ItemCategory
+    end
 
+    if type(itemEntry.ToolCategory) == 'string' and itemEntry.ToolCategory ~= '' then
+        return 'Tool'
+    end
+
+    return 'Loot'
+end
+
+local function getMissionCount(itemEntry)
+    if type(itemEntry.MissionCount) == 'number' then
+        return itemEntry.MissionCount
+    end
+
+    if getItemCategory(itemEntry) == 'Loot' then
+        return 1
+    end
+
+    return 0
+end
+
+local function normalizeItemEntry(rawItemEntry)
+    return ItemFields.normalizeItemEntryForLoad(rawItemEntry)
+end
+
+function Inventory.new(capacity)
     return setmetatable({
         Capacity = capacity,
         Weight = 0,
-        BackpackItems = backpackItems,
+        BackpackItems = {},
         HeldItem = nil,
         NextItemInstanceId = 1,
     }, Inventory)
@@ -32,6 +58,11 @@ end
 function Inventory:getCount()
     local heldCount = self.HeldItem and 1 or 0
     return #self.BackpackItems + heldCount
+end
+
+function Inventory:_hasCapacityFor(additionalCount)
+    local nextCount = self:getCount() + (additionalCount or 1)
+    return nextCount <= self.Capacity
 end
 
 function Inventory:_buildItemEntry(itemDef)
@@ -52,7 +83,7 @@ function Inventory:_buildItemEntry(itemDef)
         ToolCategory = itemDef.ToolCategory,
         StateModel = itemDef.StateModel,
         InitialState = itemDef.InitialState,
-        CurrentState = itemDef.InitialState,
+        CurrentState = itemDef.CurrentState or itemDef.InitialState,
         ConsumePerUse = itemDef.ConsumePerUse,
         CooldownSeconds = itemDef.CooldownSeconds,
         LastUsedAt = itemDef.LastUsedAt,
@@ -61,21 +92,41 @@ function Inventory:_buildItemEntry(itemDef)
         KnockbackStrength = itemDef.KnockbackStrength,
         MeleeDamage = itemDef.MeleeDamage,
         HealHealthPips = itemDef.HealHealthPips,
+        ItemCategory = itemDef.ItemCategory,
+        MissionCount = itemDef.MissionCount,
+        ReadableTitle = itemDef.ReadableTitle,
+        ReadableText = itemDef.ReadableText,
+        ClueId = itemDef.ClueId,
+        ThreatHintId = itemDef.ThreatHintId,
+        SourceMarkerId = itemDef.SourceMarkerId,
     })
 end
 
-local function normalizeItemEntry(rawItemEntry)
-    return ItemFields.normalizeItemEntryForLoad(rawItemEntry)
-end
-
 function Inventory:add(itemDef)
-    if self.Weight + itemDef.Weight > self.Capacity then
-        return false, 'OverCapacity'
+    if not self:_hasCapacityFor(1) then
+        return false, 'InventoryFull'
     end
 
     local itemEntry = self:_buildItemEntry(itemDef)
     table.insert(self.BackpackItems, itemEntry)
-    self.Weight += itemDef.Weight
+    return true, cloneItemEntry(itemEntry)
+end
+
+function Inventory:addEntry(rawItemEntry)
+    if not self:_hasCapacityFor(1) then
+        return false, 'InventoryFull'
+    end
+
+    local itemEntry = normalizeItemEntry(rawItemEntry)
+    if itemEntry == nil then
+        return false, 'InvalidItemEntry'
+    end
+
+    if itemEntry.InstanceId >= self.NextItemInstanceId then
+        self.NextItemInstanceId = itemEntry.InstanceId + 1
+    end
+
+    table.insert(self.BackpackItems, itemEntry)
     return true, cloneItemEntry(itemEntry)
 end
 
@@ -127,7 +178,6 @@ function Inventory:consumeHeldItemState(nowSeconds)
         return false, 'NotConsumable'
     end
 
-    -- Cooldown check applies to all tools (including zero-consume)
     local now = type(nowSeconds) == 'number' and nowSeconds or os.clock()
     local cooldownSeconds = heldItem.CooldownSeconds
     if type(cooldownSeconds) == 'number' and cooldownSeconds > 0 then
@@ -137,7 +187,6 @@ function Inventory:consumeHeldItemState(nowSeconds)
         end
     end
 
-    -- Consume state only when ConsumePerUse > 0
     if heldItem.ConsumePerUse > 0 then
         if heldItem.CurrentState < heldItem.ConsumePerUse then
             return false, 'Depleted'
@@ -152,29 +201,59 @@ function Inventory:consumeHeldItemState(nowSeconds)
 end
 
 function Inventory:getTotalValue()
-    local totalValue = 0
+    return 0
+end
+
+function Inventory:_summarizeCategories()
+    local counts = {
+        LootCount = 0,
+        ClueCount = 0,
+        ToolCount = 0,
+        MissionCount = 0,
+    }
+
+    local function addItem(itemEntry)
+        if itemEntry == nil then
+            return
+        end
+
+        local itemCategory = getItemCategory(itemEntry)
+        if itemCategory == 'Clue' then
+            counts.ClueCount += 1
+        elseif itemCategory == 'Tool' then
+            counts.ToolCount += 1
+        else
+            counts.LootCount += 1
+        end
+
+        counts.MissionCount += getMissionCount(itemEntry)
+    end
 
     for _, itemEntry in ipairs(self.BackpackItems) do
-        totalValue += itemEntry.Value
+        addItem(itemEntry)
     end
 
-    if self.HeldItem ~= nil then
-        totalValue += self.HeldItem.Value
-    end
+    addItem(self.HeldItem)
 
-    return totalValue
+    return counts
 end
 
 function Inventory:getSummary()
+    local categoryCounts = self:_summarizeCategories()
+
     return {
         Capacity = self.Capacity,
-        Weight = self.Weight,
+        Weight = 0,
         Count = self:getCount(),
         BackpackCount = #self.BackpackItems,
         HeldCount = self.HeldItem and 1 or 0,
-        Value = self:getTotalValue(),
+        Value = 0,
         BackpackItems = cloneArray(self.BackpackItems),
         HeldItem = self.HeldItem and cloneItemEntry(self.HeldItem) or nil,
+        LootCount = categoryCounts.LootCount,
+        ClueCount = categoryCounts.ClueCount,
+        ToolCount = categoryCounts.ToolCount,
+        MissionCount = categoryCounts.MissionCount,
     }
 end
 
@@ -191,11 +270,8 @@ function Inventory:loadSummary(summary)
     local maxItemInstanceId = 0
     local function processItem(rawItemEntry)
         local itemEntry = normalizeItemEntry(rawItemEntry)
-        if itemEntry ~= nil then
-            self.Weight += itemEntry.Weight
-            if itemEntry.InstanceId > maxItemInstanceId then
-                maxItemInstanceId = itemEntry.InstanceId
-            end
+        if itemEntry ~= nil and itemEntry.InstanceId > maxItemInstanceId then
+            maxItemInstanceId = itemEntry.InstanceId
         end
 
         return itemEntry
@@ -250,7 +326,6 @@ function Inventory:consumeById(itemId)
     for index, itemEntry in ipairs(self.BackpackItems) do
         if itemEntry.Id == itemId then
             local consumed = table.remove(self.BackpackItems, index)
-            self.Weight -= consumed.Weight
             return true, cloneItemEntry(consumed)
         end
     end
@@ -258,11 +333,50 @@ function Inventory:consumeById(itemId)
     if self.HeldItem and self.HeldItem.Id == itemId then
         local consumed = self.HeldItem
         self.HeldItem = nil
-        self.Weight -= consumed.Weight
         return true, cloneItemEntry(consumed)
     end
 
     return false, 'ItemNotFound'
+end
+
+function Inventory:extractMissionCargo()
+    local extracted = {}
+    local remaining = {}
+    local missionCount = 0
+
+    for _, itemEntry in ipairs(self.BackpackItems) do
+        if getMissionCount(itemEntry) > 0 then
+            table.insert(extracted, cloneItemEntry(itemEntry))
+            missionCount += getMissionCount(itemEntry)
+        else
+            table.insert(remaining, itemEntry)
+        end
+    end
+
+    self.BackpackItems = remaining
+
+    if self.HeldItem and getMissionCount(self.HeldItem) > 0 then
+        table.insert(extracted, cloneItemEntry(self.HeldItem))
+        missionCount += getMissionCount(self.HeldItem)
+        self.HeldItem = nil
+    end
+
+    return extracted, missionCount
+end
+
+function Inventory:dropAllItems()
+    local dropped = {}
+
+    for _, itemEntry in ipairs(self.BackpackItems) do
+        table.insert(dropped, cloneItemEntry(itemEntry))
+    end
+
+    if self.HeldItem ~= nil then
+        table.insert(dropped, cloneItemEntry(self.HeldItem))
+    end
+
+    self:clear()
+    return dropped
 end
 
 function Inventory:sell(itemId)
@@ -273,7 +387,6 @@ function Inventory:sell(itemId)
     for index, itemEntry in ipairs(self.BackpackItems) do
         if itemEntry.Id == itemId then
             local sold = table.remove(self.BackpackItems, index)
-            self.Weight -= sold.Weight or 0
             return true, cloneItemEntry(sold), sold.Value or 0
         end
     end
@@ -281,7 +394,6 @@ function Inventory:sell(itemId)
     if self.HeldItem and self.HeldItem.Id == itemId then
         local sold = self.HeldItem
         self.HeldItem = nil
-        self.Weight -= sold.Weight or 0
         return true, cloneItemEntry(sold), sold.Value or 0
     end
 

--- a/packages/gameplay/src/Session/MazeRunTracker.luau
+++ b/packages/gameplay/src/Session/MazeRunTracker.luau
@@ -13,6 +13,11 @@ local function cloneSummary(summary)
         Weight = summary.Weight or 0,
         WasExtracted = summary.WasExtracted == true,
         WasSettled = summary.WasSettled == true,
+        CountedInSettlement = summary.CountedInSettlement ~= false,
+        LootItemCount = summary.LootItemCount or summary.MissionCount or summary.ItemCount or 0,
+        ClueCount = summary.ClueCount or 0,
+        ToolCount = summary.ToolCount or 0,
+        MissionCount = summary.MissionCount or summary.LootItemCount or summary.ItemCount or 0,
     }
 end
 

--- a/packages/shared/src/Config/SessionConfig.luau
+++ b/packages/shared/src/Config/SessionConfig.luau
@@ -4,7 +4,7 @@ local DEFAULT_PLACE_IDS = {
     Lobby = 99207062749924,
     Maze = 114148445477110,
     Run = 137478567439901,
-    Library = 0, -- TODO: 替换为实际的图书馆 Place ID
+    Library = 0,
 }
 local DEFAULT_DEBUG_LOCAL_MAZE_HANDOFF = false
 
@@ -60,10 +60,14 @@ local SessionConfig = {
     MinPlayers = 1,
     MaxPlayers = 4,
     DefaultSeed = 12345,
-    DefaultQuota = 120,
-    DefaultRunDurationSeconds = 180,
+    DefaultQuota = 12,
+    DefaultRunDurationSeconds = 15 * 60,
     SettlementDurationSeconds = 8,
     InventoryCapacity = 5,
+    Mission = table.freeze({
+        RoundCount = 5,
+        TargetItemCount = 12,
+    }),
     TOD = table.freeze({
         RoundMinutes = 15,
         StartHour = 7,

--- a/packages/shared/src/Runtime/InventoryService.luau
+++ b/packages/shared/src/Runtime/InventoryService.luau
@@ -36,6 +36,15 @@ function InventoryService:pickup(player, itemDef)
     return inventory:add(itemDef)
 end
 
+function InventoryService:pickupEntry(player, rawItemEntry)
+    local inventory = self:get(player)
+    if not inventory then
+        return false, 'MissingInventory'
+    end
+
+    return inventory:addEntry(rawItemEntry)
+end
+
 function InventoryService:equip(player, itemInstanceId)
     local inventory = self:get(player)
     if not inventory then
@@ -69,9 +78,26 @@ function InventoryService:deposit(player)
         return 0
     end
 
-    local totalValue = inventory:getTotalValue()
-    inventory:clear()
-    return totalValue
+    local _, missionCount = inventory:extractMissionCargo()
+    return missionCount
+end
+
+function InventoryService:extractMissionCargo(player)
+    local inventory = self:get(player)
+    if not inventory then
+        return {}, 0
+    end
+
+    return inventory:extractMissionCargo()
+end
+
+function InventoryService:dropAllItems(player)
+    local inventory = self:get(player)
+    if not inventory then
+        return {}
+    end
+
+    return inventory:dropAllItems()
 end
 
 function InventoryService:loadSummary(player, summary)
@@ -95,6 +121,10 @@ function InventoryService:getSummary(player)
             Value = 0,
             BackpackItems = {},
             HeldItem = nil,
+            LootCount = 0,
+            ClueCount = 0,
+            ToolCount = 0,
+            MissionCount = 0,
         }
     end
 

--- a/packages/shared/src/Session/CampMazeSessionContract.luau
+++ b/packages/shared/src/Session/CampMazeSessionContract.luau
@@ -1,6 +1,8 @@
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local ItemFields = require(Packages:WaitForChild('Gameplay')).Config.ItemFields
+local SessionConfig = require(script.Parent.Parent.Config.SessionConfig)
 
 local CampMazeSessionContract = {}
 local SessionPhase = require(script.Parent.SessionPhase)
@@ -11,11 +13,22 @@ local MAZE_STATUS = {
     Completed = 'completed',
 }
 
+local DEFAULT_MAX_ROUNDS = SessionConfig.Mission.RoundCount
+local DEFAULT_TARGET_ITEM_COUNT = SessionConfig.Mission.TargetItemCount
+
+local function cloneShallow(value)
+    if type(value) == 'table' then
+        return table.clone(value)
+    end
+
+    return value
+end
+
 local function cloneArray(list)
     local result = {}
 
     for index, entry in ipairs(list or {}) do
-        result[index] = table.clone(entry)
+        result[index] = cloneShallow(entry)
     end
 
     return result
@@ -29,6 +42,42 @@ local function cloneInventoryItem(itemEntry)
     return ItemFields.copyItemEntry(itemEntry)
 end
 
+local function summarizeItems(backpackItems, heldItem)
+    local lootCount = 0
+    local clueCount = 0
+    local toolCount = 0
+    local missionCount = 0
+
+    local function addItem(itemEntry)
+        if type(itemEntry) ~= 'table' then
+            return
+        end
+
+        local itemCategory = itemEntry.ItemCategory
+        if itemCategory == 'Clue' then
+            clueCount += 1
+        elseif itemCategory == 'Tool' then
+            toolCount += 1
+        else
+            lootCount += 1
+        end
+
+        if type(itemEntry.MissionCount) == 'number' then
+            missionCount += itemEntry.MissionCount
+        elseif itemCategory == 'Loot' or itemCategory == nil then
+            missionCount += 1
+        end
+    end
+
+    for _, itemEntry in ipairs(backpackItems) do
+        addItem(itemEntry)
+    end
+
+    addItem(heldItem)
+
+    return lootCount, clueCount, toolCount, missionCount
+end
+
 local function cloneInventorySummary(summary)
     if type(summary) ~= 'table' then
         return nil
@@ -39,15 +88,22 @@ local function cloneInventorySummary(summary)
         backpackItems[index] = cloneInventoryItem(itemEntry)
     end
 
+    local heldItem = cloneInventoryItem(summary.HeldItem)
+    local lootCount, clueCount, toolCount, missionCount = summarizeItems(backpackItems, heldItem)
+
     return {
         Capacity = summary.Capacity or 0,
         Weight = summary.Weight or 0,
-        Count = summary.Count or 0,
+        Count = summary.Count or (#backpackItems + (if heldItem then 1 else 0)),
         BackpackCount = summary.BackpackCount or #backpackItems,
-        HeldCount = summary.HeldCount or (summary.HeldItem and 1 or 0),
+        HeldCount = summary.HeldCount or (if heldItem then 1 else 0),
         Value = summary.Value or 0,
         BackpackItems = backpackItems,
-        HeldItem = cloneInventoryItem(summary.HeldItem),
+        HeldItem = heldItem,
+        LootCount = summary.LootCount or lootCount,
+        ClueCount = summary.ClueCount or clueCount,
+        ToolCount = summary.ToolCount or toolCount,
+        MissionCount = summary.MissionCount or missionCount,
     }
 end
 
@@ -120,6 +176,92 @@ local function clonePendingUgcMonsterPayload(payload)
     }
 end
 
+local function clonePosition(position)
+    if typeof(position) == 'Vector3' then
+        return {
+            X = position.X,
+            Y = position.Y,
+            Z = position.Z,
+        }
+    end
+
+    if type(position) == 'table' then
+        return {
+            X = position.X or position[1] or 0,
+            Y = position.Y or position[2] or 0,
+            Z = position.Z or position[3] or 0,
+        }
+    end
+
+    return nil
+end
+
+local function cloneDropNodes(dropNodes)
+    local cloned = {}
+
+    for index, dropNode in ipairs(dropNodes or {}) do
+        if type(dropNode) == 'table' then
+            local entries = {}
+            for entryIndex, itemEntry in ipairs(dropNode.Entries or {}) do
+                entries[entryIndex] = cloneInventoryItem(itemEntry)
+            end
+
+            cloned[index] = {
+                DropNodeId = dropNode.DropNodeId,
+                Label = dropNode.Label,
+                Position = clonePosition(dropNode.Position),
+                Entries = entries,
+            }
+        end
+    end
+
+    return cloned
+end
+
+local function clonePersistentWorldState(persistentWorldState)
+    local state = persistentWorldState or {}
+
+    return {
+        CollectedLootRoomIds = cloneArray(state.CollectedLootRoomIds),
+        DropNodes = cloneDropNodes(state.DropNodes),
+    }
+end
+
+local function cloneReturnedSummary(summary)
+    if type(summary) ~= 'table' then
+        return nil
+    end
+
+    return {
+        UserId = summary.UserId,
+        Name = summary.Name,
+        ReturnReason = summary.ReturnReason,
+        Value = summary.Value or 0,
+        ItemCount = summary.ItemCount or 0,
+        Weight = summary.Weight or 0,
+        WasExtracted = summary.WasExtracted == true,
+        WasSettled = summary.WasSettled == true,
+        CountedInSettlement = summary.CountedInSettlement ~= false,
+        LootItemCount = summary.LootItemCount or summary.MissionCount or summary.ItemCount or 0,
+        ClueCount = summary.ClueCount or 0,
+        ToolCount = summary.ToolCount or 0,
+        MissionCount = summary.MissionCount or summary.LootItemCount or summary.ItemCount or 0,
+    }
+end
+
+local function cloneReturnedSummaries(summaries)
+    local cloned = {}
+
+    for _, summary in ipairs(summaries or {}) do
+        local clonedSummary = cloneReturnedSummary(summary)
+        if clonedSummary ~= nil then
+            table.insert(cloned, clonedSummary)
+        end
+    end
+
+    return cloned
+end
+
 local function sortPlayers(players)
     table.sort(players, function(left, right)
         if left.UserId == right.UserId then
@@ -152,7 +294,7 @@ local function updateMazeStatus(nextSession)
         return
     end
 
-    if nextSession.MazeAccessCode then
+    if nextSession.MazeAccessCode or #nextSession.PlayersInMaze > 0 then
         nextSession.MazeStatus = MAZE_STATUS.Active
         return
     end
@@ -177,8 +319,19 @@ function CampMazeSessionContract.normalizeCampSession(session)
         MazeStatus = session and session.MazeStatus or MAZE_STATUS.Idle,
         MazeAccessCode = session and session.MazeAccessCode or nil,
         PlayersInMaze = cloneArray(session and session.PlayersInMaze or {}),
-        ReturnedPlayerSummaries = cloneArray(session and session.ReturnedPlayerSummaries or {}),
+        ReturnedPlayerSummaries = cloneReturnedSummaries(
+            session and session.ReturnedPlayerSummaries or {}
+        ),
         SessionClosed = session ~= nil and session.SessionClosed == true or false,
+        CurrentRound = session and session.CurrentRound or 1,
+        MaxRounds = session and session.MaxRounds or DEFAULT_MAX_ROUNDS,
+        BankedItemCount = session and session.BankedItemCount or 0,
+        TargetItemCount = session and session.TargetItemCount or DEFAULT_TARGET_ITEM_COUNT,
+        RoundOutcome = session and session.RoundOutcome or nil,
+        SessionOutcome = session and session.SessionOutcome or nil,
+        PersistentWorldState = clonePersistentWorldState(
+            session and session.PersistentWorldState or nil
+        ),
     }
 
     sortPlayers(normalized.PlayersInMaze)
@@ -240,6 +393,10 @@ function CampMazeSessionContract.buildReturnSummary(params)
         WasExtracted = params.WasExtracted == true,
         WasSettled = params.WasSettled == true,
         CountedInSettlement = params.CountedInSettlement ~= false,
+        LootItemCount = params.LootItemCount or params.MissionCount or params.ItemCount or 0,
+        ClueCount = params.ClueCount or 0,
+        ToolCount = params.ToolCount or 0,
+        MissionCount = params.MissionCount or params.LootItemCount or params.ItemCount or 0,
     }
 end
 
@@ -263,6 +420,7 @@ function CampMazeSessionContract.markRoundStarted(session, params)
     nextSession.SettlementReason = nil
     nextSession.SettlementTriggeredByUserId = nil
     nextSession.SettlementTriggeredByName = nil
+    nextSession.RoundOutcome = nil
     nextSession.SessionClosed = false
     nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
     return nextSession
@@ -278,6 +436,7 @@ function CampMazeSessionContract.markSettlementTriggered(session, params)
     nextSession.SettlementReason = resolved.SettlementReason or 'settlement'
     nextSession.SettlementTriggeredByUserId = resolved.TriggeredByUserId
     nextSession.SettlementTriggeredByName = resolved.TriggeredByName
+    nextSession.RoundOutcome = resolved.RoundOutcome or nextSession.RoundOutcome
     nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
     return nextSession
 end
@@ -363,7 +522,7 @@ function CampMazeSessionContract.applyReturn(session, summary, mazeCompleted)
         end
     end
 
-    table.insert(nextSummaries, table.clone(summary))
+    table.insert(nextSummaries, cloneReturnedSummary(summary))
     sortPlayers(nextPlayers)
     sortSummaries(nextSummaries)
     nextSession.ReturnedPlayerSummaries = nextSummaries
@@ -377,6 +536,35 @@ function CampMazeSessionContract.applyReturn(session, summary, mazeCompleted)
 
     nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
 
+    return nextSession
+end
+
+function CampMazeSessionContract.recordBankedItems(session, itemCount)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    local count = math.max(0, math.floor(tonumber(itemCount) or 0))
+    nextSession.BankedItemCount += count
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
+end
+
+function CampMazeSessionContract.setPersistentWorldState(session, persistentWorldState)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    nextSession.PersistentWorldState = clonePersistentWorldState(persistentWorldState)
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
+end
+
+function CampMazeSessionContract.markRoundOutcome(session, roundOutcome)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    nextSession.RoundOutcome = roundOutcome
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
+end
+
+function CampMazeSessionContract.markSessionOutcome(session, sessionOutcome)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    nextSession.SessionOutcome = sessionOutcome
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
     return nextSession
 end
 
@@ -395,7 +583,13 @@ function CampMazeSessionContract.resetForNextRound(session)
     nextSession.MazeAccessCode = nil
     nextSession.PlayersInMaze = {}
     nextSession.ReturnedPlayerSummaries = {}
+    nextSession.RoundOutcome = nil
     nextSession.SessionClosed = false
+
+    if nextSession.SessionOutcome == nil then
+        nextSession.CurrentRound = math.min(nextSession.CurrentRound + 1, nextSession.MaxRounds)
+    end
+
     nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
 
     return nextSession
@@ -415,6 +609,11 @@ function CampMazeSessionContract.buildLobbyToRunTeleportData(params)
             MazeAccessCode = nil,
             PlayersInMaze = {},
             ReturnedPlayerSummaries = {},
+            CurrentRound = params.CurrentRound or 1,
+            MaxRounds = params.MaxRounds or DEFAULT_MAX_ROUNDS,
+            BankedItemCount = params.BankedItemCount or 0,
+            TargetItemCount = params.TargetItemCount or DEFAULT_TARGET_ITEM_COUNT,
+            PersistentWorldState = params.PersistentWorldState,
         }),
         Entry = {
             Kind = 'LobbyLaunch',
@@ -473,7 +672,7 @@ function CampMazeSessionContract.buildMazeToRunTeleportData(params)
         CampSession = CampMazeSessionContract.normalizeCampSession(params.CampSession),
         MazeReturn = {
             MazeCompleted = params.MazeCompleted == true,
-            Summaries = cloneArray(params.Summaries),
+            Summaries = cloneReturnedSummaries(params.Summaries),
         },
         PlayerInventories = clonePlayerInventories(params.PlayerInventories),
     }
@@ -491,7 +690,7 @@ function CampMazeSessionContract.findReturnSummary(teleportData, userId)
 
     for _, summary in ipairs(mazeReturn.Summaries or {}) do
         if summary.UserId == userId then
-            return summary
+            return cloneReturnedSummary(summary)
         end
     end
 

--- a/packages/shared/src/Session/SessionPhase.luau
+++ b/packages/shared/src/Session/SessionPhase.luau
@@ -2,8 +2,10 @@ local SessionPhase = table.freeze({
     RunPrep = 'RunPrep',
     RunField = 'RunField',
     MazeActive = 'MazeActive',
-    Debrief = 'Debrief',
+    RunIntermission = 'RunIntermission',
+    FinalDebrief = 'FinalDebrief',
     SessionClosed = 'SessionClosed',
+    Debrief = 'FinalDebrief',
 })
 
 function SessionPhase.resolveFromCampSession(session)
@@ -13,8 +15,12 @@ function SessionPhase.resolveFromCampSession(session)
     local roundStarted = normalizedSession.RoundStarted == true
     local dangerActive = normalizedSession.DangerActive == true
     local settlementReason = normalizedSession.SettlementReason
+    local roundOutcome = normalizedSession.RoundOutcome
+    local sessionOutcome = normalizedSession.SessionOutcome
     local returnedSummaries = normalizedSession.ReturnedPlayerSummaries or {}
     local playersInMaze = normalizedSession.PlayersInMaze or {}
+    local currentRound = normalizedSession.CurrentRound or 1
+    local maxRounds = normalizedSession.MaxRounds or currentRound
 
     if normalizedSession.SessionClosed == true then
         return SessionPhase.SessionClosed
@@ -24,12 +30,32 @@ function SessionPhase.resolveFromCampSession(session)
         return SessionPhase.MazeActive
     end
 
+    if type(sessionOutcome) == 'string' and sessionOutcome ~= '' then
+        return SessionPhase.FinalDebrief
+    end
+
     if type(settlementReason) == 'string' and settlementReason ~= '' then
-        return SessionPhase.Debrief
+        if currentRound >= maxRounds then
+            return SessionPhase.FinalDebrief
+        end
+
+        return SessionPhase.RunIntermission
+    end
+
+    if type(roundOutcome) == 'string' and roundOutcome ~= '' then
+        if currentRound >= maxRounds then
+            return SessionPhase.FinalDebrief
+        end
+
+        return SessionPhase.RunIntermission
     end
 
     if mazeStatus == 'completed' or #returnedSummaries > 0 then
-        return SessionPhase.Debrief
+        if currentRound >= maxRounds then
+            return SessionPhase.FinalDebrief
+        end
+
+        return SessionPhase.RunIntermission
     end
 
     if gateOpen or roundStarted or dangerActive then

--- a/places/maze/NOW.md
+++ b/places/maze/NOW.md
@@ -2,23 +2,23 @@
 
 ## Current Focus
 
-- Keep maze as a dedicated expedition runtime instead of letting run absorb more
-  maze logic.
-- Keep maze-to-run return behavior explicit and reviewable as the place evolves.
+- Keep maze as the fixed authored expedition layer for the new 5-round mission.
+- Preserve mission persistence: collected loot stays gone, dropped packs can be
+  recovered later, and clue items travel back and forth with players.
+- Present loot success in item counts, not value/weight language.
 
 ## Open Questions
 
-- When to stop reusing the run-flavored remote surface and define a clearer maze
-  transport contract
+- When to split the still-shared run-flavored remote surface into a clearer
+  maze-specific transport contract.
 
 ## Temporary Exceptions
 
-- Maze still uses `RunAction`, `RunSnapshot`, and `PrivateState`. Treat that as
-  transitional coupling, not as the target end state for a fully decoupled
-  place.
+- Maze still emits a few compatibility inventory/session fields so older clients
+  and harnesses keep working during the mission-loop migration.
 
 ## Near-Term Cleanup
 
-- If maze grows more unique UI or state, separate the expedition-facing
-  transport shape before the current run snapshot turns into a catch-all
-  payload.
+- Add more authored threat-tell nodes that explicitly echo wilderness clue text.
+- Replace remaining direct-boot wording that still sounds like a one-off
+  expedition instead of a multi-round mission.

--- a/places/maze/VIBE.md
+++ b/places/maze/VIBE.md
@@ -4,27 +4,32 @@
 
 ### Gameplay Template
 
-- `maze` is the expedition place in the published flow `Run -> Maze -> Run`.
-- The player experience here is first-person maze exploration, loot collection,
-  extraction pressure, and a settlement handoff back to run.
-- This place should feel like a focused expedition runtime, not a second camp.
+- `maze` is the fixed authored high-risk loot layer in the published flow
+  `Run -> Maze -> Run`.
+- The same logical maze persists across all 5 rounds of a mission.
+- Players should feel information pressure here: clues found in `run` help them
+  interpret threat tells, but do not hard-gate entry.
+- Success is not about raw value; it is about safely extracting enough loot
+  items back to the ship before the final round ends.
 
 ### Mental Model
 
 - Server authority lives in `MazeSessionService` and `MazeWorldBuilder`.
 - Client presentation and expedition input live in `MazeClient.client.luau`.
-- `maze` owns maze-side authored world setup, expedition progression,
-  loot/extract flow, and the return trigger back into run.
-- `maze` does not own run-side settlement rules or host/start game logic.
+- `maze` owns authored world scan/bind, loot pickup, death drops, persistent
+  drop recovery, extraction, and return-to-run handoff.
+- `maze` does not own ship-side intermission, host/start logic, or final mission
+  debrief presentation.
 
 ### Key State Flow
 
 1. Players arrive with maze teleport data from run.
-2. `MazeSessionService` merges and validates the incoming camp session.
-3. The maze world is built and expedition snapshots are pushed to clients.
-4. Players interact with maze objectives and extraction flow.
-5. Return summaries are built and sent back through the shared contract.
-6. Players teleport back into run for settlement or early-return handling.
+2. `MazeSessionService` merges the shared mission session.
+3. The authored maze world is rebuilt and persistent loot/drop state is applied.
+4. Players loot, dodge threats, recover drops, and return or get forced out.
+5. Banked loot counts and remaining inventory are sent back through the shared
+   contract.
+6. Later rounds rebuild the same logical maze state from shared persistence.
 
 ## Agent First
 
@@ -34,6 +39,8 @@
 - Main service: `places/maze/src/ServerScriptService/Maze/MazeSessionService.luau`
 - Main world builder:
   `places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau`
+- Scene bindings:
+  `MazeScene.luau`, `MazeLootNode.luau`, `MazeInteractionRegistry.luau`
 - Main client:
   `places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau`
 - Place project file: `places/maze/default.project.json`
@@ -47,6 +54,7 @@ Owner zone:
 Direct dependency zone:
 
 - `packages/shared/src/Session/CampMazeSessionContract.luau`
+- `packages/shared/src/Runtime/MazeWorldScanner.luau`
 - `packages/shared/src/Network/Remotes.luau`
 - `packages/shared/src/Config/SessionConfig.luau`
 - `packages/shared/src/Runtime/**`
@@ -54,14 +62,12 @@ Direct dependency zone:
 
 No-touch zone:
 
-- `places/run/**` unless the issue is explicitly about the maze return seam
-- shared contract files when changing teleport shape, return summary semantics,
-  remote naming, or replicated snapshot meaning
+- `places/run/**` unless the issue is explicitly about the return seam
+- shared contract files when changing teleport shape, persistent-world state, or
+  return summary semantics
 
 Boundary interfaces:
 
-- Remotes currently reused from the run surface:
-  `RunAction`, `RunSnapshot`, `PrivateState`
 - Shared handoff:
   `CampMazeSessionContract.buildMazeToCampTeleportData`,
   `CampMazeSessionContract.buildReturnSummary`,
@@ -70,28 +76,26 @@ Boundary interfaces:
   `SessionConfig.PlaceIds.Run`
 - Deterministic tests:
   `tests/src/Shared/CampMazeSessionContract.spec.luau`,
-  `tests/src/Shared/Remotes.spec.luau`,
-  `tests/src/Shared/MazeModuleAssetContract.spec.luau`
+  `tests/src/Shared/Inventory.spec.luau`,
+  `tests/src/Shared/MazeRunTracker.spec.luau`
 
 ### When To Start In Contract Instead
 
-- If maze needs new return summary data
-- If maze should stop speaking through the current run-flavored remote surface
-- If the maze-to-run teleport payload or reconciliation rules change
-- If snapshot fields become a shared expectation outside the maze code domain
+- If maze needs new persistent-world state fields
+- If loot/clue return summaries change meaning
+- If the maze-to-run teleport payload changes shape
+- If snapshot fields become shared expectations outside maze code
 
 ### Validation
 
 - `stylua --check .`
 - `selene .`
-- `rojo build places/maze/default.project.json -o .\\tmp\\maze.rbxlx`
+- `rojo build places/maze/default.project.json -o .\tmp\maze.rbxlx`
 - If shared handoff behavior changed:
-  `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`
+  `rojo build tests/default.project.json -o .\tmp\roblox_experience-tests.rbxlx`
 
 ## Notes
 
-- Keep maze-specific behavior inside maze modules whenever possible.
-- `MazeStaticWorld` is the formal runtime source for expedition content.
-- If a change makes the maze client or service read more and more like a run
-  clone, the seam is probably in the wrong place and should move toward
-  `contract` first.
+- The live maze path is authored-world scan/bind, not procgen.
+- Loot already banked at the ship must not respawn in later rounds.
+- Death drops and unrecovered clue items are part of the persistent mission state.

--- a/places/maze/src/ServerScriptService/Maze/MazeLootNode.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeLootNode.luau
@@ -21,6 +21,8 @@ function MazeLootNode:markCollected()
     if promptPart then
         promptPart:Destroy()
     end
+
+    self.Prompt = nil
 end
 
 return MazeLootNode

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -231,6 +231,22 @@ function MazeSessionService:_replaceDropNodeState(nextDropNodes)
     self:_setPersistentWorldState(state)
 end
 
+function MazeSessionService:_reserveDynamicDropNodeId()
+    local nextId = self.NextDynamicDropNodeId or 1
+    local state = self:_getPersistentWorldState()
+
+    for _, dropNodeState in ipairs(state.DropNodes or {}) do
+        local existingId =
+            tonumber(string.match(tostring(dropNodeState.DropNodeId or ''), '^DynamicDrop_(%d+)$'))
+        if existingId ~= nil and existingId >= nextId then
+            nextId = existingId + 1
+        end
+    end
+
+    self.NextDynamicDropNodeId = nextId + 1
+    return string.format('DynamicDrop_%d', nextId)
+end
+
 function MazeSessionService:_markLootCollected(roomId)
     local state = self:_getPersistentWorldState()
     local collectedLootRoomIds = state.CollectedLootRoomIds or {}
@@ -344,10 +360,8 @@ function MazeSessionService:_createPersistentDropNode(entries, position, label)
         return
     end
 
-    local dropNodeId = string.format('DynamicDrop_%d', self.NextDynamicDropNodeId)
-    self.NextDynamicDropNodeId += 1
-
     local state = self:_getPersistentWorldState()
+    local dropNodeId = self:_reserveDynamicDropNodeId()
     local dropNodes = state.DropNodes or {}
     table.insert(dropNodes, {
         DropNodeId = dropNodeId,

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -212,6 +212,222 @@ function MazeSessionService:_emitDiagnostic(event, fields)
     print(string.format('%s | %s', prefix, fieldString))
 end
 
+function MazeSessionService:_getPersistentWorldState()
+    return self.CampSession.PersistentWorldState
+        or {
+            CollectedLootRoomIds = {},
+            DropNodes = {},
+        }
+end
+
+function MazeSessionService:_setPersistentWorldState(persistentWorldState)
+    self.CampSession =
+        CampMazeSessionContract.setPersistentWorldState(self.CampSession, persistentWorldState)
+end
+
+function MazeSessionService:_replaceDropNodeState(nextDropNodes)
+    local state = self:_getPersistentWorldState()
+    state.DropNodes = nextDropNodes
+    self:_setPersistentWorldState(state)
+end
+
+function MazeSessionService:_markLootCollected(roomId)
+    local state = self:_getPersistentWorldState()
+    local collectedLootRoomIds = state.CollectedLootRoomIds or {}
+
+    for _, collectedRoomId in ipairs(collectedLootRoomIds) do
+        if collectedRoomId == roomId then
+            return
+        end
+    end
+
+    table.insert(collectedLootRoomIds, roomId)
+    table.sort(collectedLootRoomIds)
+    state.CollectedLootRoomIds = collectedLootRoomIds
+    self:_setPersistentWorldState(state)
+end
+
+function MazeSessionService:_destroyDynamicDropNode(dropNodeId)
+    local dynamicNode = self.DynamicDropNodesById[dropNodeId]
+    if dynamicNode == nil then
+        return
+    end
+
+    if dynamicNode.Connection and dynamicNode.Connection.Disconnect then
+        dynamicNode.Connection:Disconnect()
+    end
+    if dynamicNode.Part and dynamicNode.Part.Parent then
+        dynamicNode.Part:Destroy()
+    end
+    self.DynamicDropNodesById[dropNodeId] = nil
+end
+
+function MazeSessionService:_destroyDynamicDropNodes()
+    for dropNodeId in pairs(self.DynamicDropNodesById) do
+        self:_destroyDynamicDropNode(dropNodeId)
+    end
+end
+
+function MazeSessionService:_dropNodePositionToVector3(position)
+    if typeof(position) == 'Vector3' then
+        return position
+    end
+
+    if type(position) == 'table' then
+        return Vector3.new(
+            position.X or position[1] or 0,
+            position.Y or position[2] or 0,
+            position.Z or position[3] or 0
+        )
+    end
+
+    return self.World and self.World.ReturnHoldCFrame.Position or Vector3.zero
+end
+
+function MazeSessionService:_buildDropNodePart(dropNodeState)
+    local position = self:_dropNodePositionToVector3(dropNodeState.Position)
+    local part = Instance.new('Part')
+    part.Name = dropNodeState.DropNodeId
+    part.Anchored = true
+    part.CanCollide = false
+    part.Transparency = 0.15
+    part.Material = Enum.Material.Metal
+    part.Color = Color3.fromRGB(142, 236, 255)
+    part.Size = Vector3.new(2.5, 2.5, 2.5)
+    part.CFrame = CFrame.new(position + Vector3.new(0, 1.5, 0))
+    part.Parent = self.World.Root
+
+    local prompt = Instance.new('ProximityPrompt')
+    prompt.ActionText = 'Recover'
+    prompt.ObjectText = dropNodeState.Label or 'Dropped Pack'
+    prompt.MaxActivationDistance = 10
+    prompt.RequiresLineOfSight = false
+    prompt.Parent = part
+
+    return part, prompt
+end
+
+function MazeSessionService:_spawnDynamicDropNode(dropNodeState)
+    if not (self.World and self.World.Root) then
+        return
+    end
+
+    local part, prompt = self:_buildDropNodePart(dropNodeState)
+    local connection = prompt.Triggered:Connect(function(player)
+        self:_pickupDropNode(player, dropNodeState.DropNodeId)
+    end)
+
+    self.DynamicDropNodesById[dropNodeState.DropNodeId] = {
+        Part = part,
+        Connection = connection,
+    }
+end
+
+function MazeSessionService:_applyPersistentWorldStateToWorld()
+    local state = self:_getPersistentWorldState()
+
+    for _, roomId in ipairs(state.CollectedLootRoomIds or {}) do
+        local lootNode = self.World and self.World:getLootNode(roomId)
+        if lootNode and lootNode.Collected ~= true then
+            lootNode:markCollected()
+        end
+    end
+
+    self:_destroyDynamicDropNodes()
+    for _, dropNodeState in ipairs(state.DropNodes or {}) do
+        self:_spawnDynamicDropNode(dropNodeState)
+    end
+end
+
+function MazeSessionService:_createPersistentDropNode(entries, position, label)
+    if entries == nil or #entries == 0 then
+        return
+    end
+
+    local dropNodeId = string.format('DynamicDrop_%d', self.NextDynamicDropNodeId)
+    self.NextDynamicDropNodeId += 1
+
+    local state = self:_getPersistentWorldState()
+    local dropNodes = state.DropNodes or {}
+    table.insert(dropNodes, {
+        DropNodeId = dropNodeId,
+        Label = label,
+        Position = {
+            X = position.X,
+            Y = position.Y,
+            Z = position.Z,
+        },
+        Entries = entries,
+    })
+    state.DropNodes = dropNodes
+    self:_setPersistentWorldState(state)
+    self:_spawnDynamicDropNode(dropNodes[#dropNodes])
+end
+
+function MazeSessionService:_pickupDropNode(player, dropNodeId)
+    if not self.RunTracker:isPlayerActive(player.UserId) then
+        return
+    end
+
+    local state = self:_getPersistentWorldState()
+    local nextDropNodes = {}
+    local pickedCount = 0
+    local pickedAny = false
+
+    for _, dropNodeState in ipairs(state.DropNodes or {}) do
+        if dropNodeState.DropNodeId == dropNodeId then
+            local remainingEntries = {}
+            for _, itemEntry in ipairs(dropNodeState.Entries or {}) do
+                local success = self.InventoryService:pickupEntry(player, itemEntry)
+                if success == true then
+                    pickedAny = true
+                    pickedCount += 1
+                else
+                    table.insert(remainingEntries, itemEntry)
+                end
+            end
+
+            if #remainingEntries > 0 then
+                table.insert(nextDropNodes, {
+                    DropNodeId = dropNodeState.DropNodeId,
+                    Label = dropNodeState.Label,
+                    Position = dropNodeState.Position,
+                    Entries = remainingEntries,
+                })
+            end
+        else
+            table.insert(nextDropNodes, dropNodeState)
+        end
+    end
+
+    if not pickedAny then
+        self:_setStatus(
+            string.format(
+                '%s found a dropped pack but has no room to recover it.',
+                player.DisplayName
+            )
+        )
+        return
+    end
+
+    self:_destroyDynamicDropNode(dropNodeId)
+    self:_replaceDropNodeState(nextDropNodes)
+    for _, dropNodeState in ipairs(nextDropNodes) do
+        if dropNodeState.DropNodeId == dropNodeId then
+            self:_spawnDynamicDropNode(dropNodeState)
+            break
+        end
+    end
+
+    self:_setStatus(
+        string.format(
+            '%s recovered %d dropped item(s) from the maze floor.',
+            player.DisplayName,
+            pickedCount
+        )
+    )
+end
+
 function MazeSessionService:_getWorldBuildMetadataFields()
     local metadata = self.WorldBuildMetadata or {}
     return {
@@ -390,9 +606,16 @@ function MazeSessionService.new(options)
         Quota = SessionConfig.DefaultQuota,
         RunDurationSeconds = SessionConfig.DefaultRunDurationSeconds,
         InventoryCapacity = SessionConfig.InventoryCapacity,
+        Mission = {
+            RoundCount = SessionConfig.Mission.RoundCount,
+            TargetItemCount = SessionConfig.Mission.TargetItemCount,
+        },
     }
     self.Remotes = Remotes
     self.CampSession = CampMazeSessionContract.newCampSession({
+        CurrentRound = 1,
+        MaxRounds = SessionConfig.Mission.RoundCount,
+        TargetItemCount = SessionConfig.Mission.TargetItemCount,
         MazeAccessCode = 'local-debug-maze',
         MazeStatus = CampMazeSessionContract.MazeStatus.Active,
     })
@@ -453,6 +676,8 @@ function MazeSessionService.new(options)
     self.PendingUgcMonsterPayloads = {}
     self.CorpsesByUserId = {}
     self.DeathSummaryByUserId = {}
+    self.DynamicDropNodesById = {}
+    self.NextDynamicDropNodeId = 1
     self.BootPhase = 'New'
     self.SurfacePalette = Shared.Runtime.MazeLightingProfile.SurfacePalette
     self.RoundSignalBus = runtimeOptions.RoundSignalBus or RoundSignalBus.new()
@@ -627,10 +852,21 @@ function MazeSessionService:_mergeTeleportData(teleportData, resetInventoryServi
             self.SessionData.InventoryCapacity = incoming.InventoryCapacity
             self.InventoryService.Capacity = incoming.InventoryCapacity
         end
+        if type(incoming.Mission) == 'table' then
+            if type(incoming.Mission.RoundCount) == 'number' then
+                self.SessionData.Mission.RoundCount = incoming.Mission.RoundCount
+            end
+            if type(incoming.Mission.TargetItemCount) == 'number' then
+                self.SessionData.Mission.TargetItemCount = incoming.Mission.TargetItemCount
+                self.SessionData.Quota = incoming.Mission.TargetItemCount
+            end
+        end
     end
 
     self.CampSession = nextSession
     self.IsDirectBoot = false
+    self.CampSession.MaxRounds = self.SessionData.Mission.RoundCount
+    self.CampSession.TargetItemCount = self.SessionData.Mission.TargetItemCount
     self.Status = 'Maze session is live. Explore, loot, and find an extraction point.'
     self:_subscribeToRoundSignals()
     result.AcceptedBeforeBuild = self:_markAcceptedTeleportData(teleportData)
@@ -892,14 +1128,18 @@ end
 
 function MazeSessionService:_getObjectiveFor()
     if self.RoundClosureInProgress or self.CampSession.SettlementReason ~= nil then
-        return 'Camp has triggered settlement. Hold position until the forced return to camp completes.'
+        return 'The round is closing. Hold position until the return to the ship completes.'
     end
 
-    if self.RunTracker.IsCompleted then
-        return 'The maze run is complete. Review the returned summaries back in camp.'
+    if self.CampSession.SessionOutcome == 'success' then
+        return 'Mission complete. The maze is done for this run; head back to the ship for final debrief.'
     end
 
-    return 'Collect loot, survive the maze, and use a return marker whenever you want to head back to camp.'
+    if self.CampSession.SessionOutcome == 'failure' then
+        return 'This was the last round and the crew missed the quota. Return to the ship for final debrief.'
+    end
+
+    return 'Read the room, dodge the threat, grab loot, and bring it back to the ship alive.'
 end
 
 function MazeSessionService:_broadcastSnapshot()
@@ -928,6 +1168,10 @@ function MazeSessionService:_broadcastSnapshot()
         PlayersInMaze = self.CampSession.PlayersInMaze,
         ReturnedPlayerSummaries = returnedSummaries,
         SessionClosed = self.CampSession.SessionClosed,
+        CurrentRound = self.CampSession.CurrentRound,
+        MaxRounds = self.CampSession.MaxRounds,
+        RoundOutcome = self.CampSession.RoundOutcome,
+        SessionOutcome = self.CampSession.SessionOutcome,
     }
     local sessionPhase = SessionPhase.resolveFromCampSession(sessionPhaseInput)
     local worldBuildFields = self:_getWorldBuildMetadataFields()
@@ -945,6 +1189,12 @@ function MazeSessionService:_broadcastSnapshot()
             DangerActive = self.CampSession.DangerActive == true,
             RoundTimeRemainingSeconds = roundTimeRemainingSeconds,
             SettlementReason = self.CampSession.SettlementReason,
+            CurrentRound = self.CampSession.CurrentRound,
+            MaxRounds = self.CampSession.MaxRounds,
+            BankedItemCount = self.CampSession.BankedItemCount,
+            TargetItemCount = self.CampSession.TargetItemCount,
+            RoundOutcome = self.CampSession.RoundOutcome,
+            SessionOutcome = self.CampSession.SessionOutcome,
             Inventory = self.InventoryService:getSummary(player),
             Movement = self:_getMovementSummaryFor(player),
             ControlState = self.ControlStateService:getSummary(player),
@@ -980,6 +1230,7 @@ function MazeSessionService:_rebuildWorld()
     end
 
     clearDefaultWorkspaceShell()
+    self:_destroyDynamicDropNodes()
 
     if self.WorldInteractions then
         self.WorldInteractions:disconnectAll()
@@ -988,6 +1239,7 @@ function MazeSessionService:_rebuildWorld()
 
     self.World = MazeWorldBuilder.build()
     self:_recordWorldBuildMetadata()
+    self:_applyPersistentWorldStateToWorld()
     self:_setBootPhase('BindWorldInteractions')
     self.WorldInteractions = self.World:bindInteractions({
         OnReturnHold = function(player)
@@ -1029,23 +1281,43 @@ function MazeSessionService:_toggleDoor(player, doorwayId)
     end
 end
 
-function MazeSessionService:_buildSummaryFor(player, returnReason, wasSettled, countInventory)
-    local inventorySummary = self.InventoryService:getSummary(player)
+function MazeSessionService:_buildSummaryFor(
+    player,
+    returnReason,
+    wasSettled,
+    countInventory,
+    overrides
+)
+    local inventorySummary = overrides and overrides.InventorySummary
+        or self.InventoryService:getSummary(player)
     local shouldCountInventory = countInventory ~= false
-    local value = shouldCountInventory and inventorySummary.Value or 0
-    local itemCount = shouldCountInventory and inventorySummary.Count or 0
-    local weight = shouldCountInventory and inventorySummary.Weight or 0
+    local lootItemCount = shouldCountInventory
+            and (overrides and overrides.LootItemCount or inventorySummary.LootCount or 0)
+        or 0
+    local clueCount = shouldCountInventory
+            and (overrides and overrides.ClueCount or inventorySummary.ClueCount or 0)
+        or 0
+    local toolCount = shouldCountInventory
+            and (overrides and overrides.ToolCount or inventorySummary.ToolCount or 0)
+        or 0
+    local missionCount = shouldCountInventory
+            and (overrides and overrides.MissionCount or inventorySummary.MissionCount or lootItemCount)
+        or 0
 
     return CampMazeSessionContract.buildReturnSummary({
         UserId = player.UserId,
         Name = player.DisplayName,
         ReturnReason = returnReason,
-        Value = value,
-        ItemCount = itemCount,
-        Weight = weight,
+        Value = 0,
+        ItemCount = shouldCountInventory and (lootItemCount + clueCount + toolCount) or 0,
+        Weight = 0,
         WasExtracted = returnReason == 'extracted' or returnReason == 'settled',
         WasSettled = wasSettled == true,
         CountedInSettlement = shouldCountInventory,
+        LootItemCount = lootItemCount,
+        ClueCount = clueCount,
+        ToolCount = toolCount,
+        MissionCount = missionCount,
     })
 end
 
@@ -1067,6 +1339,10 @@ function MazeSessionService:_buildPlayerInventories(players, countInventory)
                     Value = 0,
                     BackpackItems = {},
                     HeldItem = nil,
+                    LootCount = 0,
+                    ClueCount = 0,
+                    ToolCount = 0,
+                    MissionCount = 0,
                 },
         })
     end
@@ -1076,6 +1352,16 @@ function MazeSessionService:_buildPlayerInventories(players, countInventory)
     end)
 
     return playerInventories
+end
+
+function MazeSessionService:_bankMissionLootForPlayer(player)
+    local inventorySummary = self.InventoryService:getSummary(player)
+    local _, bankedCount = self.InventoryService:extractMissionCargo(player)
+    if bankedCount > 0 then
+        self.CampSession = CampMazeSessionContract.recordBankedItems(self.CampSession, bankedCount)
+    end
+
+    return inventorySummary, bankedCount
 end
 
 function MazeSessionService:_canReturnToCamp()
@@ -1125,9 +1411,14 @@ function MazeSessionService:_forceCloseToCamp(reason, countInventories)
                         or self:_buildSummaryFor(player, 'death', false, false)
                 )
             else
+                local inventorySummary, bankedCount = self:_bankMissionLootForPlayer(player)
                 table.insert(
                     summaries,
-                    self:_buildSummaryFor(player, reason or 'settled', true, countInventories)
+                    self:_buildSummaryFor(player, reason or 'settled', true, countInventories, {
+                        InventorySummary = inventorySummary,
+                        LootItemCount = bankedCount,
+                        MissionCount = bankedCount,
+                    })
                 )
             end
         end
@@ -1315,17 +1606,27 @@ end
 function MazeSessionService:_handlePlayerDeath(player, damageKind)
     self:_spawnCorpseForPlayer(player)
     self:_clearPlayerMovement(player)
+
+    local droppedEntries = self.InventoryService:dropAllItems(player)
+    local character = player.Character
+    local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+    local dropPosition = rootPart and rootPart.Position or self.World.ReturnHoldCFrame.Position
+    self:_createPersistentDropNode(
+        droppedEntries,
+        dropPosition,
+        string.format('%s Pack', player.DisplayName)
+    )
+
     self.DeathSummaryByUserId[player.UserId] = self:_buildSummaryFor(player, 'death', false, false)
     self:_publishMazePresence()
 
-    local character = player.Character
     if character and character.Parent and self.World then
         character:PivotTo(self.World.ReturnHoldCFrame)
     end
 
     self:_setStatus(
         string.format(
-            '%s took %s damage and died, leaving a corpse behind.',
+            '%s took %s damage and died, dropping their pack in the maze.',
             player.DisplayName,
             string.lower(damageKind)
         )
@@ -1404,14 +1705,15 @@ function MazeSessionService:_pickupLoot(player, roomId)
     end
 
     lootEntry:markCollected()
+    self:_markLootCollected(roomId)
 
     local inventorySummary = self.InventoryService:getSummary(player)
     self:_setStatus(
         string.format(
-            '%s collected %s. Inventory value now %d.',
+            '%s collected %s. They are now carrying %d loot item(s).',
             player.DisplayName,
             lootEntry.ItemDef.Name,
-            inventorySummary.Value
+            inventorySummary.LootCount or 0
         )
     )
 end
@@ -1436,7 +1738,12 @@ function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason, _in
         return
     end
 
-    local summary = self:_buildSummaryFor(player, returnReason, false)
+    local inventorySummary, bankedCount = self:_bankMissionLootForPlayer(player)
+    local summary = self:_buildSummaryFor(player, returnReason, false, true, {
+        InventorySummary = inventorySummary,
+        LootItemCount = bankedCount,
+        MissionCount = bankedCount,
+    })
     local recorded, reason = self.RunTracker:recordReturn(summary)
     if not recorded then
         if reason == 'MissingActivePlayer' then
@@ -1460,9 +1767,9 @@ function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason, _in
     if self:_teleportToCamp({ player }, { summary }, mazeCompleted, true) then
         self:_setStatus(
             string.format(
-                '%s returned to the run maze gate with %d value (%s).',
+                '%s returned to the run maze gate with %d banked loot item(s) (%s).',
                 player.DisplayName,
-                summary.Value,
+                bankedCount,
                 summary.ReturnReason
             )
         )
@@ -1476,9 +1783,9 @@ function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason, _in
 
     self:_setStatus(
         string.format(
-            '%s reached a return marker with %d value, but the handoff back to run failed.',
+            '%s reached a return marker with %d banked loot item(s), but the handoff back to run failed.',
             player.DisplayName,
-            summary.Value
+            bankedCount
         )
     )
 end

--- a/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
+++ b/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
@@ -414,13 +414,13 @@ local function connectMazeRemotes(remotes)
         visibleBackpackItems = inventory.BackpackItems or {}
         heldItemController:applyInventory(inventory)
         inventoryLabel.Text = string.format(
-            'Inventory: %d total | %d backpack | %d held | %d/%d KG | %d value',
+            'Inventory: %d total | %d loot | %d clue | %d tool | %d/%d slots',
             inventory.Count or 0,
-            inventory.BackpackCount or 0,
-            inventory.HeldCount or 0,
-            inventory.Weight or 0,
-            inventory.Capacity or 0,
-            inventory.Value or 0
+            inventory.LootCount or 0,
+            inventory.ClueCount or 0,
+            inventory.ToolCount or 0,
+            inventory.Count or 0,
+            inventory.Capacity or 0
         )
 
         local heldItem = inventory.HeldItem
@@ -432,10 +432,9 @@ local function connectMazeRemotes(remotes)
 
         local detailLines = {
             heldItem and string.format(
-                'Held: %s | %d KG | %d value%s%s',
+                'Held: %s | %s%s%s',
                 heldItem.Name,
-                heldItem.Weight,
-                heldItem.Value,
+                heldItem.ItemCategory or 'Loot',
                 heldItem.Light and ' | Glow active' or '',
                 presentationIconSuffix(heldItem)
             ) or 'Held: Empty hands',
@@ -450,11 +449,10 @@ local function connectMazeRemotes(remotes)
                 table.insert(
                     detailLines,
                     string.format(
-                        '- [%d] %s | %d KG | %d value%s',
+                        '- [%d] %s | %s%s',
                         itemIndex,
                         itemEntry.Name,
-                        itemEntry.Weight,
-                        itemEntry.Value,
+                        itemEntry.ItemCategory or 'Loot',
                         presentationIconSuffix(itemEntry)
                     )
                 )
@@ -498,9 +496,9 @@ local function connectMazeRemotes(remotes)
                 table.insert(
                     returnedLines,
                     string.format(
-                        '- %s: %d value (%s)',
+                        '- %s: %d loot item(s) (%s)',
                         entry.Name,
-                        entry.Value or 0,
+                        entry.LootItemCount or entry.MissionCount or 0,
                         entry.ReturnReason or 'unknown'
                     )
                 )

--- a/places/run/NOW.md
+++ b/places/run/NOW.md
@@ -2,22 +2,25 @@
 
 ## Current Focus
 
-- Keep `run` as the orchestration place without letting it absorb maze-only
-  logic or contract-only shape decisions.
-- Keep `RunSessionService` as an orchestrator over authored scene objects and
-  transition adapters instead of a god object.
+- Keep `run` centered on ship orchestration + wilderness clue discovery for the
+  new 5-round mission loop.
+- Retire player-facing `Book of Sand` / `Pages` language in favor of banked loot,
+  round count, and mission outcome language.
+- Preserve authored clue markers and tower sightline as the main first-round
+  teaching layer.
 
 ## Open Questions
 
-- When the currently shared `RunAction`, `RunSnapshot`, and `PrivateState`
-  remote surface should split into a clearer run-vs-maze contract
+- When the shared `RunAction` / `RunSnapshot` / `PrivateState` surface should be
+  renamed to reflect cross-place mission semantics instead of legacy run naming.
 
 ## Temporary Exceptions
 
-- Maze currently reuses the run remote set. Treat that as active coupling to pay
-  down through `contract`, not as an endorsed long-term design.
+- Run still emits a few compatibility fields (`TeamPages`, `BookGoalAmount`) so
+  older clients and harnesses do not break while migration finishes.
 
 ## Near-Term Cleanup
 
-- Any future seam cleanup should start by shrinking `RunSessionService`
-  responsibilities instead of adding more cross-place branching inside it.
+- Split remaining legacy camp/store UI assumptions away from the ship mission UI.
+- Add richer authored wilderness clue content now that the clue-item pipeline is
+  in place.

--- a/places/run/VIBE.md
+++ b/places/run/VIBE.md
@@ -4,29 +4,31 @@
 
 ### Gameplay Template
 
-- `run` is the camp and expedition hub of the published flow
-  `Run (entry) -> Maze -> Run`.
-- The player loop here is: arrive at camp, start the run, explore the outdoor
-  shell, enter maze, receive returning players, settle, and reset.
-- This place is the orchestration center of the current vertical slice.
+- `run` is the ship camp, wilderness clue layer, and between-round staging layer in
+  the published flow `Run -> Maze -> Run`.
+- Players spawn at the ship, notice the distant tower, choose how much
+  wilderness scouting to do, then enter the maze.
+- The wilderness is not filler: it contains authored clue markers that help
+  players interpret maze threats and information gaps.
+- After each maze round, survivors return to the ship, bank loot automatically,
+  regroup, and prepare for the next round.
 
 ### Mental Model
 
-- Server authority lives in `RunSessionService` and its supporting
-  builders/services.
+- Server authority lives in `RunSessionService` and its authored-world adapters.
 - Client presentation and input live in `RunClient.client.luau`.
-- `run` owns camp session orchestration, authored world assembly, the
-  player-facing run snapshot, and the run-to-maze transition handoff.
-- `run` does not own maze-side expedition logic or the shared handoff schema.
+- `run` owns ship-side mission orchestration, wilderness clue discovery,
+  round resets, and the run-to-maze transition handoff.
+- `run` does not own maze-side loot persistence or maze threat behavior.
 
 ### Key State Flow
 
 1. Players arrive with optional teleport data from maze.
-2. `RunSessionService` reconciles the incoming session state.
-3. The place starts or resumes the camp session and broadcasts snapshots.
-4. Players request maze entry through the run gate.
-5. Run teleports players to maze through the dedicated run-to-maze transition.
-6. Returned summaries are applied and run progresses toward settlement.
+2. `RunSessionService` reconciles the shared mission session.
+3. Players explore the ship/wilderness layer and discover private clue items.
+4. The host opens the ship door to begin a round and unlock danger + maze entry.
+5. Players enter maze through the tower path and later return to the ship.
+6. The mission advances across 5 rounds until the loot quota succeeds or fails.
 
 ## Agent First
 
@@ -34,9 +36,9 @@
 
 - Server bootstrap: `places/run/src/ServerScriptService/Bootstrap.server.luau`
 - Main service: `places/run/src/ServerScriptService/Run/RunSessionService.luau`
-- Supporting builders and services:
-  `RunWorldBuilder.luau`, `RunScene.luau`, `RunToMazeTransition.luau`,
-  `InventoryService.luau`, `MonsterService.luau`, `RoleService.luau`
+- Authored world layer:
+  `RunWorldBuilder.luau`, `RunScene.luau`, `RunInteractionRegistry.luau`,
+  `RunClueMarker.luau`, `RunToMazeTransition.luau`
 - Main client:
   `places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau`
 - Place project file: `places/run/default.project.json`
@@ -59,10 +61,9 @@ Direct dependency zone:
 
 No-touch zone:
 
-- `places/lobby/**` — lobby has been removed; if re-adding a lobby layer is needed, start with `packages/shared/VIBE.md`
 - `places/maze/**` unless the issue is explicitly about the run-to-maze seam
-- shared contract files when changing handoff schema, remote names, or return
-  summary meaning
+- shared contract files when changing handoff schema, round-loop semantics, or
+  replicated snapshot meaning
 
 Boundary interfaces:
 
@@ -74,28 +75,26 @@ Boundary interfaces:
   `SessionConfig.PlaceIds`
 - Deterministic tests:
   `tests/src/Shared/CampMazeSessionContract.spec.luau`,
-  `tests/src/Shared/MazeEntryAvailability.spec.luau`,
-  `tests/src/Shared/Remotes.spec.luau`
+  `tests/src/Shared/Inventory.spec.luau`,
+  `tests/src/Shared/SessionPhase.spec.luau`
 
 ### When To Start In Contract Instead
 
-- If run needs new teleport payload fields
-- If run and maze should stop sharing the current
-  `RunAction` / `RunSnapshot` / `PrivateState` remotes
-- If return summaries or camp-session reconciliation rules change
-- If the meaning of place-id availability changes across places
+- If run needs new mission-loop session fields
+- If run and maze should change how loot/clue summaries cross places
+- If return summaries or round outcome meaning changes
+- If the shared run/maze remote surface changes shape
 
 ### Validation
 
 - `stylua --check .`
 - `selene .`
-- `rojo build places/run/default.project.json -o .\\tmp\\run.rbxlx`
+- `rojo build places/run/default.project.json -o .\tmp\run.rbxlx`
 - If shared handoff behavior changed:
-  `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`
+  `rojo build tests/default.project.json -o .\tmp\roblox_experience-tests.rbxlx`
 
 ## Notes
 
-- `run` is the easiest place to accidentally turn into a god object. Prefer
-  extracting local modules or contract-first seams over piling unrelated duties
-  into `RunSessionService`.
-- `RunStaticWorld` is the formal runtime source for camp and wilderness content.
+- `run` now presents a multi-round mission board, not a `Book of Sand` goal loop.
+- Clues are physical personal inventory items by default; they are not auto-shared.
+- The tower/maze pull should stay visually obvious even when clue content grows.

--- a/places/run/src/ServerScriptService/Run/RunClueMarker.luau
+++ b/places/run/src/ServerScriptService/Run/RunClueMarker.luau
@@ -1,0 +1,39 @@
+local RunClueMarker = {}
+RunClueMarker.__index = RunClueMarker
+
+function RunClueMarker.new(part)
+    local prompt = part:FindFirstChildOfClass('ProximityPrompt')
+    if prompt == nil then
+        error(string.format('Run clue marker %s is missing a ProximityPrompt.', part.Name), 0)
+    end
+
+    local clueId = part:GetAttribute('ClueId') or part.Name
+    local sourceMarkerId = part:GetAttribute('SourceMarkerId') or part.Name
+    local readableTitle = part:GetAttribute('ReadableTitle')
+        or part:GetAttribute('Title')
+        or part.Name
+    local readableText = part:GetAttribute('ReadableText')
+        or part:GetAttribute('Body')
+        or 'A weathered note hints that the maze threat is never where it first wants you to look.'
+    local threatHintId = part:GetAttribute('ThreatHintId')
+    local itemName = part:GetAttribute('ItemName') or readableTitle
+
+    return setmetatable({
+        Part = part,
+        Prompt = prompt,
+        ClueId = tostring(clueId),
+        SourceMarkerId = tostring(sourceMarkerId),
+        ReadableTitle = tostring(readableTitle),
+        ReadableText = tostring(readableText),
+        ThreatHintId = threatHintId and tostring(threatHintId) or nil,
+        ItemName = tostring(itemName),
+    }, RunClueMarker)
+end
+
+function RunClueMarker:bind(callback)
+    return self.Prompt.Triggered:Connect(function(player)
+        callback(player, self)
+    end)
+end
+
+return RunClueMarker

--- a/places/run/src/ServerScriptService/Run/RunInteractionRegistry.luau
+++ b/places/run/src/ServerScriptService/Run/RunInteractionRegistry.luau
@@ -8,15 +8,17 @@ function RunInteractionRegistry.new()
 end
 
 function RunInteractionRegistry:_track(connection)
-    table.insert(self.Connections, connection)
+    if connection ~= nil then
+        table.insert(self.Connections, connection)
+    end
 end
 
 function RunInteractionRegistry:bindScene(scene, handlers)
     self:_track(scene.Terminals.Shop:bind(function(player)
         handlers.OnShop(player)
     end))
-    self:_track(scene.Terminals.Book:bind(function(player)
-        handlers.OnBook(player)
+    self:_track(scene.Terminals.Objective:bind(function(player)
+        handlers.OnObjective(player)
     end))
     self:_track(scene.Terminals.Gate:bind(function(player)
         handlers.OnGate(player)
@@ -30,9 +32,9 @@ function RunInteractionRegistry:bindScene(scene, handlers)
         handlers.OnMazePortal(player)
     end))
 
-    if scene.Terminals.StartGame then
-        self:_track(scene.Terminals.StartGame:bind(function(player)
-            handlers.OnStartGame(player)
+    for _, clueMarker in ipairs(scene.ClueMarkers or {}) do
+        self:_track(clueMarker:bind(function(player, marker)
+            handlers.OnClueMarker(player, marker)
         end))
     end
 

--- a/places/run/src/ServerScriptService/Run/RunScene.luau
+++ b/places/run/src/ServerScriptService/Run/RunScene.luau
@@ -1,4 +1,5 @@
 local RunAreaResolver = require(script.Parent.RunAreaResolver)
+local RunClueMarker = require(script.Parent.RunClueMarker)
 local RunDoor = require(script.Parent.RunDoor)
 local RunInteractionRegistry = require(script.Parent.RunInteractionRegistry)
 local RunOceanTrigger = require(script.Parent.RunOceanTrigger)
@@ -210,6 +211,16 @@ function RunScene.new(root)
         table.insert(oceanTriggers, RunOceanTrigger.new(part))
     end
 
+    local clueMarkers = {}
+    for _, descendant in ipairs(root:GetDescendants()) do
+        if descendant:IsA('BasePart') and string.sub(descendant.Name, 1, 11) == 'ClueMarker_' then
+            table.insert(clueMarkers, RunClueMarker.new(descendant))
+        end
+    end
+    table.sort(clueMarkers, function(left, right)
+        return left.ClueId < right.ClueId
+    end)
+
     local self = setmetatable({
         Root = root,
         SpawnPoints = spawnPoints,
@@ -222,6 +233,7 @@ function RunScene.new(root)
         },
         ShipModel = shipModel,
         OceanTriggers = oceanTriggers,
+        ClueMarkers = clueMarkers,
         OutdoorThresholdZ = outdoorThresholdZ,
         AreaResolver = nil,
         SpawnCFramesByKind = spawnCFramesByKind,

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -11,20 +11,16 @@ local SessionConfig = Shared.Config.SessionConfig
 local Remotes = Shared.Network.Remotes.ensure()
 local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
 local MazeEntryAvailability = Shared.Session.MazeEntryAvailability
-local SessionSeedPolicy = Shared.Session.SessionSeedPolicy
 local ControlStateService = Shared.Runtime.ControlStateService
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
 local InventoryService = Shared.Runtime.InventoryService
 local PlayerService = Shared.Runtime.PlayerService
 local PlayerStateService = Shared.Runtime.PlayerStateService
-local MonsterService = Shared.Runtime.MonsterService
 local TODService = Shared.Runtime.TODService
 local TeleportInventoryHydrator = Shared.Runtime.TeleportInventoryHydrator
 local RoundSignalBus = Shared.Runtime.RoundSignalBus
 
 local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
-local RunWorldScanner = require(script.Parent.RunWorldScanner)
-local RunMonsterSpawnPolicy = require(script.Parent.RunMonsterSpawnPolicy)
 local RunSnapshotBuilder = require(script.Parent.RunSnapshotBuilder)
 local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
 local RunToMazeTransition = require(script.Parent.RunToMazeTransition)
@@ -35,11 +31,6 @@ local RunSessionService = {}
 RunSessionService.__index = RunSessionService
 
 local DEFAULT_WORKSPACE_SHELL_NAMES = { 'Baseplate', 'SpawnLocation' }
-local CAMP_SESSION_LOCK_WAIT_SECONDS = 0.05
-local MAZE_ENTRY_REQUEST_COOLDOWN_SECONDS = 0.35
-local MAZE_ENTRY_DISTANCE_BUFFER = 2
-local TERMINAL_INTERACTION_DISTANCE_BUFFER = 2
-local SNAPSHOT_INTERVAL_SECONDS = 0.25
 local LEGACY_TOOL_CATEGORY = table.freeze({
     Flashlight = 'Flashlight',
     Rope = 'Rope',
@@ -49,21 +40,17 @@ local RUN_MAZE_GATE_RETURN_REASONS = table.freeze({
     early_return = true,
     extracted = true,
 })
-local INITIAL_TEMPLE_STATUS = 'Select Enter Temple to enter the temple.'
-local BOOK_GOAL_AMOUNT = 120
+local INITIAL_TEMPLE_STATUS =
+    'Leave the ship, spot the tower, and decide when to push into the maze.'
 local OCEAN_SPLASH_MESSAGE = 'Sea spray crashes over you.'
 local OCEAN_SLOWDOWN_DELAY_SECONDS = 1
 local OCEAN_SLOWDOWN_WALK_SPEED = 12
 local OCEAN_DAMAGE_INTERVAL_SECONDS = 5
 local ROUND_RESET_DELAY_SECONDS = SessionConfig.SettlementDurationSeconds
 local ROUND_SETTLEMENT_REASON = table.freeze({
-    Book = 'book_settlement',
+    Book = 'ship_settlement',
     Timeout = 'timeout',
     AllDead = 'all_dead',
-})
-local DAMAGE_KIND_BY_PIPS = table.freeze({
-    [1] = Gameplay.PlayerState.DamageKind.Light,
-    [2] = Gameplay.PlayerState.DamageKind.Heavy,
 })
 local SHOP_ITEMS = {
     {
@@ -164,83 +151,6 @@ local function cloneArray(input)
     return result
 end
 
-local function buildShopPayload()
-    local payload = {}
-
-    for _, item in ipairs(SHOP_ITEMS) do
-        table.insert(payload, {
-            Id = item.Id,
-            Name = item.Name,
-            Price = item.Price,
-        })
-    end
-
-    return payload
-end
-
-local function getSellPrice(itemEntry)
-    return math.max(1, math.floor((itemEntry.Value or 0) + 0.5))
-end
-
-local function buildSellPayload(inventorySummary)
-    local items = {}
-
-    local function insertItem(itemEntry)
-        if not itemEntry then
-            return
-        end
-
-        table.insert(items, {
-            InstanceId = itemEntry.InstanceId,
-            Name = itemEntry.Name,
-            Price = getSellPrice(itemEntry),
-            Color = itemEntry.Color,
-        })
-    end
-
-    for _, itemEntry in ipairs(inventorySummary.BackpackItems or {}) do
-        insertItem(itemEntry)
-    end
-
-    insertItem(inventorySummary.HeldItem)
-
-    return items
-end
-
-local function removeItemFromSummary(summary, itemInstanceId)
-    if summary.HeldItem and summary.HeldItem.InstanceId == itemInstanceId then
-        local removed = summary.HeldItem
-        summary.HeldItem = nil
-        return removed
-    end
-
-    for index, itemEntry in ipairs(summary.BackpackItems or {}) do
-        if itemEntry.InstanceId == itemInstanceId then
-            local removed = itemEntry
-            table.remove(summary.BackpackItems, index)
-            return removed
-        end
-    end
-
-    return nil
-end
-
-local function runWithCampSessionLock(self, callback)
-    while self.CampSessionLock do
-        task.wait(CAMP_SESSION_LOCK_WAIT_SECONDS)
-    end
-
-    self.CampSessionLock = true
-    local results = table.pack(pcall(callback))
-    self.CampSessionLock = false
-
-    if not results[1] then
-        error(results[2], 0)
-    end
-
-    return table.unpack(results, 2, results.n)
-end
-
 function RunSessionService.new(options)
     local runtimeOptions = options or {}
     local self = setmetatable({}, RunSessionService)
@@ -252,8 +162,15 @@ function RunSessionService.new(options)
         Quota = SessionConfig.DefaultQuota,
         RunDurationSeconds = SessionConfig.DefaultRunDurationSeconds,
         InventoryCapacity = SessionConfig.InventoryCapacity,
+        Mission = {
+            RoundCount = SessionConfig.Mission.RoundCount,
+            TargetItemCount = SessionConfig.Mission.TargetItemCount,
+        },
     }
     self.CampSession = CampMazeSessionContract.newCampSession({
+        CurrentRound = 1,
+        MaxRounds = SessionConfig.Mission.RoundCount,
+        TargetItemCount = SessionConfig.Mission.TargetItemCount,
         SignalScope = string.format(
             'run:%s',
             if type(game.JobId) == 'string' and game.JobId ~= ''
@@ -281,8 +198,7 @@ function RunSessionService.new(options)
     self.MazeEntryReason =
         'Set SessionConfig.PlaceIds.Maze or SessionPlaceIdMaze before using the maze gate.'
     self.MazeEntryReasonCode = MazeEntryAvailability.ReasonCode.MazePlaceIdMissing
-    self.TeamPages = 0
-    self.BookGoalAmount = BOOK_GOAL_AMOUNT
+    self.CollectedRunClueMarkerIds = {}
     self.InventoryService = InventoryService.new(self.SessionData.InventoryCapacity)
     self.ControlStateService = ControlStateService.new()
     self.PlayerService = PlayerService.new()
@@ -474,7 +390,39 @@ function RunSessionService:_resetRoundPlayerState(player)
     self.PendingSpawnByUserId[player.UserId] = RunSpawnPoint.Kind.Spawn
 end
 
+function RunSessionService:_refreshSessionOutcomeForCurrentState()
+    if self.CampSession.SessionOutcome ~= nil then
+        return
+    end
+
+    if self.CampSession.CurrentRound < self.CampSession.MaxRounds then
+        return
+    end
+
+    if #self.CampSession.PlayersInMaze > 0 or (self.MazePresence.ActiveCount or 0) > 0 then
+        return
+    end
+
+    local outcome = if self.CampSession.BankedItemCount >= self.CampSession.TargetItemCount
+        then 'success'
+        else 'failure'
+    self.CampSession = CampMazeSessionContract.markSessionOutcome(self.CampSession, outcome)
+end
+
 function RunSessionService:_resetForNextRound()
+    if
+        self.CampSession.SessionOutcome == 'success'
+        or self.CampSession.SessionOutcome == 'failure'
+    then
+        self.RoundClosureInProgress = false
+        self.GateOpen = false
+        self.Status = if self.CampSession.SessionOutcome == 'success'
+            then 'Mission complete. The crew is back at the ship for the final debrief.'
+            else 'Mission failed. The crew is back at the ship for the final debrief.'
+        self:_broadcastSnapshot()
+        return
+    end
+
     self.RoundClosureInProgress = false
     self.GateOpen = false
     self.MazePresence = {
@@ -498,7 +446,11 @@ function RunSessionService:_resetForNextRound()
         end
     end
 
-    self.Status = 'Camp is safe. The host can open the ship door when the crew is ready.'
+    self.Status = string.format(
+        'Round %d of %d ready. Regroup at the ship, review clues, then head for the tower again.',
+        self.CampSession.CurrentRound,
+        self.CampSession.MaxRounds
+    )
     self:_broadcastSnapshot()
 end
 
@@ -513,19 +465,24 @@ function RunSessionService:_completeRound(reason, player, countInventories)
         SettlementReason = reason,
         TriggeredByUserId = player and player.UserId or nil,
         TriggeredByName = player and player.DisplayName or nil,
+        RoundOutcome = reason,
     })
     self.CampSession.GateOpen = false
     self.CampSession.RoundStarted = false
     self.CampSession.RoundEndTime = self:_getServerTimeNow()
+    self:_refreshSessionOutcomeForCurrentState()
     self.CampSession = CampMazeSessionContract.normalizeCampSession(self.CampSession)
 
     if reason == ROUND_SETTLEMENT_REASON.Book then
-        self.Status =
-            string.format('%s invoked the Book of Sand. The round is ending.', player.DisplayName)
+        self.Status = string.format(
+            '%s called the crew back to the ship. This round is ending.',
+            player.DisplayName
+        )
     elseif reason == ROUND_SETTLEMENT_REASON.AllDead then
-        self.Status = 'All active players have fallen. The round is ending.'
+        self.Status =
+            'Everyone went down. The round is ending and the ship is pulling the crew back.'
     else
-        self.Status = 'The round timer expired. The round is ending.'
+        self.Status = 'Time is up. The round is ending and the ship is recalling the crew.'
     end
 
     self:_publishRoundClosure(reason, player, countInventories)
@@ -848,6 +805,21 @@ function RunSessionService:_applySessionConfig(incoming)
         self.SessionData.InventoryCapacity = incoming.InventoryCapacity
         self.InventoryService.Capacity = incoming.InventoryCapacity
     end
+
+    local mission = incoming.Mission
+    if type(mission) == 'table' then
+        if type(mission.RoundCount) == 'number' then
+            self.SessionData.Mission.RoundCount = mission.RoundCount
+            self.CampSession.MaxRounds = mission.RoundCount
+        end
+        if type(mission.TargetItemCount) == 'number' then
+            self.SessionData.Mission.TargetItemCount = mission.TargetItemCount
+            self.CampSession.TargetItemCount = mission.TargetItemCount
+            self.SessionData.Quota = mission.TargetItemCount
+        end
+    end
+
+    self.CampSession = CampMazeSessionContract.normalizeCampSession(self.CampSession)
 end
 
 function RunSessionService:_hydratePlayerInventory(player, teleportData)
@@ -914,28 +886,31 @@ function RunSessionService:_loadSessionDataFromJoin()
 end
 
 function RunSessionService:_getReturnStatusText(playerDisplayName, summary, teleportData)
+    local lootCount = summary.LootItemCount or summary.MissionCount or summary.ItemCount or 0
+
     if RUN_MAZE_GATE_RETURN_REASONS[summary.ReturnReason] then
         return string.format(
-            '%s returned to the maze gate with %d value (%s).',
+            '%s made it back from the maze with %d loot item(s) and banked them at the ship.',
             playerDisplayName,
-            summary.Value or 0,
-            summary.ReturnReason or 'unknown'
+            lootCount
         )
     end
 
     if teleportData.MazeReturn and teleportData.MazeReturn.MazeCompleted == true then
         return string.format(
-            '%s returned from the completed maze run with %d value.',
+            '%s returned from the maze. The crew now has %d of %d required loot item(s).',
             playerDisplayName,
-            summary.Value or 0
+            self.CampSession.BankedItemCount,
+            self.CampSession.TargetItemCount
         )
     end
 
     return string.format(
-        '%s returned from the maze with %d value (%s).',
+        '%s returned from the maze with %d loot item(s). Banked total: %d/%d.',
         playerDisplayName,
-        summary.Value or 0,
-        summary.ReturnReason or 'unknown'
+        lootCount,
+        self.CampSession.BankedItemCount,
+        self.CampSession.TargetItemCount
     )
 end
 
@@ -955,6 +930,8 @@ function RunSessionService:_applyReturnedPlayersFromTeleportData(players, accept
         end
     end
 
+    self:_refreshSessionOutcomeForCurrentState()
+
     if #returnedPlayers == 1 then
         local returnedPlayer = returnedPlayers[1]
         self.Status = self:_getReturnStatusText(
@@ -963,9 +940,14 @@ function RunSessionService:_applyReturnedPlayersFromTeleportData(players, accept
             returnedPlayer.TeleportData
         )
     elseif #returnedPlayers > 1 then
-        self.Status = 'The crew returned from the maze. Review the temple summaries together.'
+        self.Status = string.format(
+            'The crew returned from the maze. Banked loot: %d/%d.',
+            self.CampSession.BankedItemCount,
+            self.CampSession.TargetItemCount
+        )
     else
-        self.Status = 'Temple is ready. Gather inside, then head outside when the group is ready.'
+        self.Status =
+            'The ship is ready. Explore the wilderness, read the signs, and choose when to push for the tower.'
     end
 end
 
@@ -996,6 +978,49 @@ function RunSessionService:_getReturnSpawnTargetForSummary(summary)
     return RunSpawnPoint.Kind.Return
 end
 
+function RunSessionService:_discoverClue(player, clueMarker)
+    if type(clueMarker) ~= 'table' then
+        return
+    end
+
+    local markerId = clueMarker.SourceMarkerId or clueMarker.ClueId
+    if self.CollectedRunClueMarkerIds[markerId] then
+        self:_toast(player, 'That clue has already been recovered.', 'Info')
+        return
+    end
+
+    local success, result = self.InventoryService:pickup(player, {
+        Id = string.format('run-clue-%s', clueMarker.ClueId),
+        Name = clueMarker.ItemName or clueMarker.ReadableTitle,
+        Description = 'Recovered clue from the wilderness.',
+        ItemCategory = 'Clue',
+        MissionCount = 0,
+        ReadableTitle = clueMarker.ReadableTitle,
+        ReadableText = clueMarker.ReadableText,
+        ClueId = clueMarker.ClueId,
+        ThreatHintId = clueMarker.ThreatHintId,
+        SourceMarkerId = markerId,
+    })
+    if not success then
+        self:_toast(player, 'Your pack is full. Drop something before taking the clue.', 'Error')
+        return
+    end
+
+    self.CollectedRunClueMarkerIds[markerId] = true
+    if clueMarker.Part and clueMarker.Part.Parent then
+        clueMarker.Part:Destroy()
+    end
+
+    self:_sendPrivate(player, {
+        Type = 'ClueDiscovered',
+        ClueId = result.ClueId,
+        Title = result.ReadableTitle,
+        Body = result.ReadableText,
+        ThreatHintId = result.ThreatHintId,
+    })
+    self:_setStatus(string.format('%s recovered a wilderness clue.', player.DisplayName))
+end
+
 function RunSessionService:_rebuildWorld()
     clearDefaultWorkspaceShell()
 
@@ -1009,7 +1034,17 @@ function RunSessionService:_rebuildWorld()
         self.World:openGate()
     end
 
-    -- Initialize MonsterService after World is built (needs self.World.Collision for canTraverse)
+    for _, clueMarker in ipairs(self.World.ClueMarkers or {}) do
+        local markerId = clueMarker.SourceMarkerId or clueMarker.ClueId
+        if
+            self.CollectedRunClueMarkerIds[markerId]
+            and clueMarker.Part
+            and clueMarker.Part.Parent
+        then
+            clueMarker.Part:Destroy()
+        end
+    end
+
     if not self.MonsterService then
         self.MonsterService = self:_createMonsterService()
     end
@@ -1022,7 +1057,7 @@ function RunSessionService:_rebuildWorld()
 
             self:_openShop(player)
         end,
-        OnBook = function(player)
+        OnObjective = function(player)
             self:_openObjectiveBoard(player)
         end,
         OnGate = function(player)
@@ -1031,6 +1066,11 @@ function RunSessionService:_rebuildWorld()
         OnMazePortal = function(player)
             if self:_canProcessMazeEntryRequest(player) then
                 self:_requestMazeEntry(player, false)
+            end
+        end,
+        OnClueMarker = function(player, clueMarker)
+            if self:_canManageInventory(player) then
+                self:_discoverClue(player, clueMarker)
             end
         end,
         OnOceanEntered = function(player, state)
@@ -1082,27 +1122,39 @@ function RunSessionService:_getReturnedSummaries()
 end
 
 function RunSessionService:_getObjectiveFor(player)
+    if self.CampSession.SessionOutcome == 'success' then
+        return 'Mission complete. Stay at the ship, compare what everyone learned, and review the final haul.'
+    end
+
+    if self.CampSession.SessionOutcome == 'failure' then
+        return 'Mission failed after five rounds. Review what went wrong and what clues were recovered.'
+    end
+
     if self:_isRoundClosing() then
-        return 'This round is closing. Survivors will regroup at camp for the next host start.'
+        return 'This round is closing. Survivors are regrouping at the ship before the next push.'
     end
 
     if not self:_isRoundStarted() then
         if self.CampSession.HostUserId == player.UserId then
-            return 'Open the ship door when the crew is ready. That starts danger, monster spawns, the timer, and maze access.'
+            return string.format(
+                'Open the ship door to begin round %d of %d. Players can still search the wilderness for clues before heading to the tower.',
+                self.CampSession.CurrentRound,
+                self.CampSession.MaxRounds
+            )
         end
 
-        return 'Camp is safe. Wait for the host to open the ship door before heading into danger or entering the maze.'
+        return 'Stay at the ship, check any recovered clues, then head into the wilderness or toward the tower when the host starts the round.'
     end
 
     if self:_isPlayerDead(player) then
-        return 'You are dead for this round. Your next spawn will be back at camp when the next round starts.'
+        return 'You are out for this round. You will respawn at the ship when the next round begins.'
     end
 
     if self:_isPlayerInCamp(player) then
-        return 'Use the Shop or Book of Sand, then step outside to fight, explore, or enter the maze whenever you are ready.'
+        return 'The round is live. Step into the wilderness for clues or head straight for the tower to enter the maze.'
     end
 
-    return 'The field is dangerous now. Fight, explore briefly, or enter the maze whenever you decide to push deeper.'
+    return 'Search the wilderness for warning signs, then enter the maze and bring loot back alive.'
 end
 
 function RunSessionService:_setStatus(status)
@@ -1110,20 +1162,44 @@ function RunSessionService:_setStatus(status)
     self:_broadcastSnapshot()
 end
 
+function RunSessionService:_getMissionSnapshot()
+    local roundTimeRemainingSeconds = self:_getRoundTimeRemainingSeconds()
+
+    return {
+        CurrentRound = self.CampSession.CurrentRound,
+        MaxRounds = self.CampSession.MaxRounds,
+        BankedItemCount = self.CampSession.BankedItemCount,
+        TargetItemCount = self.CampSession.TargetItemCount,
+        RoundOutcome = self.CampSession.RoundOutcome,
+        SessionOutcome = self.CampSession.SessionOutcome,
+        RoundStarted = self:_isRoundStarted(),
+        RoundTimeRemainingSeconds = roundTimeRemainingSeconds,
+        SettlementReason = self.CampSession.SettlementReason,
+    }
+end
+
 function RunSessionService:_getBookSnapshot()
+    local missionSnapshot = self:_getMissionSnapshot()
     local progress = 0
-    if self.BookGoalAmount > 0 then
-        progress = math.clamp(self.TeamPages / self.BookGoalAmount, 0, 1)
+    if missionSnapshot.TargetItemCount > 0 then
+        progress =
+            math.clamp(missionSnapshot.BankedItemCount / missionSnapshot.TargetItemCount, 0, 1)
     end
 
     return {
-        TeamPages = self.TeamPages,
-        BookGoalAmount = self.BookGoalAmount,
+        CurrentRound = missionSnapshot.CurrentRound,
+        MaxRounds = missionSnapshot.MaxRounds,
+        BankedItemCount = missionSnapshot.BankedItemCount,
+        TargetItemCount = missionSnapshot.TargetItemCount,
+        RoundOutcome = missionSnapshot.RoundOutcome,
+        SessionOutcome = missionSnapshot.SessionOutcome,
+        TeamPages = missionSnapshot.BankedItemCount,
+        BookGoalAmount = missionSnapshot.TargetItemCount,
         BookGoalProgress = progress,
-        BookGoalReached = self.TeamPages >= self.BookGoalAmount,
-        RoundStarted = self:_isRoundStarted(),
-        RoundTimeRemainingSeconds = self:_getRoundTimeRemainingSeconds(),
-        SettlementReason = self.CampSession.SettlementReason,
+        BookGoalReached = missionSnapshot.BankedItemCount >= missionSnapshot.TargetItemCount,
+        RoundStarted = missionSnapshot.RoundStarted,
+        RoundTimeRemainingSeconds = missionSnapshot.RoundTimeRemainingSeconds,
+        SettlementReason = missionSnapshot.SettlementReason,
     }
 end
 
@@ -1146,10 +1222,13 @@ function RunSessionService:_toast(player, message, tone)
 end
 
 function RunSessionService:_openShop(player)
+    local missionSnapshot = self:_getMissionSnapshot()
     self:_sendPrivate(player, {
         Type = 'OpenShop',
-        Items = buildShopPayload(),
-        TeamPages = self.TeamPages,
+        Items = {},
+        TeamPages = missionSnapshot.BankedItemCount,
+        BankedItemCount = missionSnapshot.BankedItemCount,
+        TargetItemCount = missionSnapshot.TargetItemCount,
         Inventory = self.InventoryService:getSummary(player),
         RoundStarted = self:_isRoundStarted(),
     })
@@ -1160,133 +1239,59 @@ function RunSessionService:_openSell(player)
 end
 
 function RunSessionService:_openObjectiveBoard(player)
-    local snapshot = self:_getBookSnapshot()
+    local snapshot = self:_getMissionSnapshot()
     local canSettle = self:_isRoundStarted()
         and not self:_isRoundClosing()
         and not self:_isPlayerDead(player)
         and self:_isPlayerInCamp(player)
     self:_sendPrivate(player, {
-        Type = 'OpenBook',
-        BookGoalAmount = snapshot.BookGoalAmount,
-        BookGoalProgress = snapshot.BookGoalProgress,
-        BookGoalReached = snapshot.BookGoalReached,
-        TeamPages = snapshot.TeamPages,
+        Type = 'OpenObjectiveBoard',
+        BoardType = 'MissionBoard',
+        CurrentRound = snapshot.CurrentRound,
+        MaxRounds = snapshot.MaxRounds,
+        BankedItemCount = snapshot.BankedItemCount,
+        TargetItemCount = snapshot.TargetItemCount,
+        RoundOutcome = snapshot.RoundOutcome,
+        SessionOutcome = snapshot.SessionOutcome,
+        TeamPages = snapshot.BankedItemCount,
+        BookGoalAmount = snapshot.TargetItemCount,
+        BookGoalProgress = snapshot.TargetItemCount > 0
+                and math.clamp(snapshot.BankedItemCount / snapshot.TargetItemCount, 0, 1)
+            or 0,
+        BookGoalReached = snapshot.BankedItemCount >= snapshot.TargetItemCount,
         RoundStarted = snapshot.RoundStarted,
         RoundTimeRemainingSeconds = snapshot.RoundTimeRemainingSeconds,
         SettlementReason = snapshot.SettlementReason,
         CanSettle = canSettle,
-        Items = buildSellPayload(self.InventoryService:getSummary(player)),
+        Items = {},
+        Inventory = self.InventoryService:getSummary(player),
     })
 end
 
-function RunSessionService:_handlePurchase(player, itemId)
+function RunSessionService:_handlePurchase(player, _itemId)
     if not self:_canManageInventory(player) then
         return
     end
-    if not self:_isPlayerNearTerminalPrompt(player, self.World and self.World.ShopPrompt) then
-        self:_toast(player, 'Move closer to the shop terminal.', 'Error')
-        return
-    end
-
-    local itemDef = SHOP_ITEM_BY_ID[itemId]
-    if not itemDef then
-        self:_toast(player, 'Unknown item.', 'Error')
-        return
-    end
-
-    if self.TeamPages < itemDef.Price then
-        self:_sendPrivate(player, {
-            Type = 'ShopResult',
-            Success = false,
-            Reason = 'InsufficientFunds',
-        })
-        return
-    end
-
-    local ok, reason = self.InventoryService:pickup(player, itemDef)
-    if not ok then
-        self:_sendPrivate(player, {
-            Type = 'ShopResult',
-            Success = false,
-            Reason = reason or 'InventoryFull',
-        })
-        return
-    end
-
-    local wasBelowGoal = self.TeamPages < self.BookGoalAmount
-    self.TeamPages -= itemDef.Price
 
     self:_sendPrivate(player, {
         Type = 'ShopResult',
-        Success = true,
-        ItemId = itemDef.Id,
-        TeamPages = self.TeamPages,
-        Inventory = self.InventoryService:getSummary(player),
+        Success = false,
+        Reason = 'StoreRetired',
     })
-
-    self:_broadcastSnapshot()
-
-    if wasBelowGoal and self.TeamPages >= self.BookGoalAmount then
-        local snapshot = self:_getBookSnapshot()
-        self:_broadcastPrivate({
-            Type = 'GoalReached',
-            TeamPages = snapshot.TeamPages,
-        })
-    end
 end
 
-function RunSessionService:_handleSell(player, itemInstanceId)
+function RunSessionService:_handleSell(player, _itemInstanceId)
     if not self:_canManageInventory(player) then
         return
     end
-    if not self:_isPlayerNearTerminalPrompt(player, self.World and self.World.BookPrompt) then
-        self:_toast(player, 'Move closer to the Book of Sand.', 'Error')
-        return
-    end
-
-    if type(itemInstanceId) ~= 'number' then
-        self:_toast(player, 'Invalid item.', 'Error')
-        return
-    end
-
-    local inventorySummary = self.InventoryService:getSummary(player)
-    local removedItem = removeItemFromSummary(inventorySummary, itemInstanceId)
-    if not removedItem then
-        self:_toast(player, 'Item not found.', 'Error')
-        return
-    end
-
-    local ok, reason = self.InventoryService:loadSummary(player, inventorySummary)
-    if not ok then
-        self:_toast(
-            player,
-            string.format('Could not update inventory (%s).', tostring(reason)),
-            'Error'
-        )
-        return
-    end
-
-    local reward = getSellPrice(removedItem)
-    local wasBelowGoal = self.TeamPages < self.BookGoalAmount
-    self.TeamPages += reward
 
     self:_sendPrivate(player, {
         Type = 'BookExchangeResult',
-        Success = true,
-        ItemInstanceId = itemInstanceId,
-        Amount = reward,
-        TeamPages = self.TeamPages,
+        Success = false,
+        Reason = 'AutoBankOnly',
+        TeamPages = self.CampSession.BankedItemCount,
+        BankedItemCount = self.CampSession.BankedItemCount,
     })
-
-    self:_broadcastSnapshot()
-
-    if wasBelowGoal and self.TeamPages >= self.BookGoalAmount then
-        local snapshot = self:_getBookSnapshot()
-        self:_broadcastPrivate({
-            Type = 'GoalReached',
-            TeamPages = snapshot.TeamPages,
-        })
-    end
 end
 
 function RunSessionService:_resolveMazeEntryAvailability()
@@ -1427,9 +1432,16 @@ function RunSessionService:_openGate(player)
 
     self:_ensureHost()
 
+    if self.CampSession.SessionOutcome ~= nil then
+        self:_setStatus(
+            'This mission is already over. Review the final debrief at the ship instead of starting another round.'
+        )
+        return
+    end
+
     if self:_isRoundClosing() then
         self:_setStatus(
-            'The current round is already closing. Wait for the camp reset before starting again.'
+            'The current round is already closing. Wait for the ship regroup before starting again.'
         )
         return
     end
@@ -1454,502 +1466,20 @@ function RunSessionService:_openGate(player)
             RoundEndTime = roundEndTime,
             DangerActive = true,
         })
-        self:_syncCampSession()
         self.World:openGate()
-        self.TODService:start()
-        self:_beginExpedition()
-        self:_setStatus(
-            string.format(
-                '%s opened the ship door. Danger, monsters, the global timer, and maze entry are now live.',
-                player.DisplayName
-            )
+        self.Status = string.format(
+            '%s opened the ship door. Round %d of %d is live: search the wilderness, then head for the tower.',
+            player.DisplayName,
+            self.CampSession.CurrentRound,
+            self.CampSession.MaxRounds
         )
+        self:_broadcastSnapshot()
         return
     end
 
     self:_setStatus(
         string.format('%s checked the ship door. This round is already live.', player.DisplayName)
     )
-end
-
-function RunSessionService:_enterMaze(player)
-    runWithCampSessionLock(self, function()
-        if SessionConfig.PlaceIds.Maze == 0 then
-            self:_setStatus(
-                'Set SessionConfig.PlaceIds.Maze or SessionPlaceIdMaze before using the maze gate.'
-            )
-            return
-        end
-
-        if self.CampSession.MazeStatus == CampMazeSessionContract.MazeStatus.Completed then
-            self:_setStatus('The maze session is already complete for this temple.')
-            return
-        end
-
-        local result = self.RunToMazeTransition:enter({
-            Player = player,
-            CampSession = self.CampSession,
-            GateOpen = self.GateOpen,
-            SessionConfig = self.SessionData,
-            PlayerInventory = self.InventoryService:getSummary(player),
-            EnteringPlayer = {
-                UserId = player.UserId,
-                Name = player.DisplayName,
-            },
-            EntryReason = 'maze_gate',
-        })
-        if not result.Ok then
-            self.CampSession = result.CurrentSession or self.CampSession
-            self.MazeEntryMode = MazeEntryAvailability.Mode.Blocked
-            self.MazeEntryReasonCode = result.ReasonCode or result.FailureCode
-            self.MazeEntryReason = result.Reason
-            self:_setStatus(
-                string.format('%s could not enter the maze: %s', player.DisplayName, result.Reason)
-            )
-            return
-        end
-
-        self.MazeEntryMode = MazeEntryAvailability.Mode.Teleport
-        self.MazeEntryReasonCode = result.ReasonCode
-        self.MazeEntryReason = result.Reason
-        self.CampSession = result.NextSession
-        self:_setStatus(string.format('%s is entering the shared maze run.', player.DisplayName))
-    end)
-end
-
-function RunSessionService:_isPlayerNearMazePrompt(player)
-    return self:_isPlayerNearTerminalPrompt(
-        player,
-        self.World and self.World.MazePortal,
-        MAZE_ENTRY_DISTANCE_BUFFER
-    )
-end
-
-function RunSessionService:_isPlayerNearTerminalPrompt(player, terminalOrPrompt, distanceBuffer)
-    if not terminalOrPrompt then
-        return false
-    end
-
-    if type(terminalOrPrompt.isPlayerNear) == 'function' then
-        return terminalOrPrompt:isPlayerNear(
-            player,
-            distanceBuffer or TERMINAL_INTERACTION_DISTANCE_BUFFER
-        )
-    end
-
-    local prompt = terminalOrPrompt
-    local promptPart = prompt.Parent
-    if not promptPart or not promptPart:IsA('BasePart') then
-        return false
-    end
-
-    local character = player.Character
-    local rootPart = character and character:FindFirstChild('HumanoidRootPart')
-    if not rootPart or not rootPart:IsA('BasePart') then
-        return false
-    end
-
-    local maxDistance = prompt.MaxActivationDistance
-        + (distanceBuffer or TERMINAL_INTERACTION_DISTANCE_BUFFER)
-    return (rootPart.Position - promptPart.Position).Magnitude <= maxDistance
-end
-
-function RunSessionService:_requestMazeEntry(player, requireDistanceCheck)
-    if not self.IsLaunched or not self.World then
-        return
-    end
-
-    if requireDistanceCheck and not self:_isPlayerNearMazePrompt(player) then
-        return
-    end
-
-    local availability = self:_evaluateMazeEntry(player)
-    if availability.Mode == MazeEntryAvailability.Mode.Teleport then
-        self:_enterMaze(player)
-        return
-    end
-
-    self:_setStatus(
-        string.format(
-            '%s could not enter the maze: %s (code=%s, gameId=%d, placeId=%d, mazePlaceId=%d)',
-            player.DisplayName,
-            availability.Reason,
-            availability.ReasonCode or 'Unknown',
-            game.GameId,
-            game.PlaceId,
-            SessionConfig.PlaceIds.Maze
-        )
-    )
-end
-
--- =======================================================
--- Monster integration
--- =======================================================
-
--- Compile monster profile for Run (no MazeExecutable behavior filtering)
-function RunSessionService:_compileMonsterForRun(authorProfile)
-    local MonsterRuntimeProfile = Gameplay.Monsters.MonsterRuntimeProfile
-
-    local tuning = authorProfile.Tuning
-    local presentation = authorProfile.Executable.Presentation
-
-    local behaviors = {}
-    for _, intent in ipairs(authorProfile.Executable.BehaviorIntents or {}) do
-        if intent.Enabled ~= false then
-            behaviors[intent.Id] = true
-        end
-    end
-
-    local runtimeProfile = {
-        Id = authorProfile.Id,
-        Name = authorProfile.Name,
-        Presentation = table.freeze({
-            ModelAssetId = presentation.ModelAssetId,
-            RigType = presentation.RigType,
-            AnimationMode = presentation.AnimationMode,
-            ChaseLoopSoundAssetId = presentation.ChaseLoopSoundAssetId,
-        }),
-        AttackCooldownSeconds = tuning.AttackCooldownSeconds or 1,
-        AttackDamagePips = tuning.AttackDamagePips or 1,
-        AttackRange = tuning.AttackRange or 4,
-        Speed = tuning.Speed,
-        SightRange = tuning.SightRange,
-        PatrolSpeedMultiplier = tuning.PatrolSpeedMultiplier,
-        SpawnOffset = tuning.SpawnOffset or Vector3.new(0, 4, 0),
-        CombatHitPoints = tuning.CombatHitPoints or 1,
-        Behaviors = table.freeze(behaviors),
-        Effects = table.freeze({}),
-    }
-    runtimeProfile.Components =
-        Gameplay.Monsters.MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)
-    runtimeProfile = table.freeze(runtimeProfile)
-
-    local valid, reason = MonsterRuntimeProfile.validate(runtimeProfile)
-    if not valid then
-        error(string.format('Run monster profile invalid: %s', tostring(reason)), 0)
-    end
-
-    return runtimeProfile
-end
-
--- Build MonsterService with run-specific callbacks
-function RunSessionService:_createMonsterService()
-    local monsterProfile = self:_compileMonsterForRun(Gameplay.Config.Monsters[1])
-    local canTraverseFn = RunWorldScanner.buildCanTraverseFn(self.World)
-    local randomSource = Random.new(self.SessionData.Seed > 0 and self.SessionData.Seed or 42)
-
-    return MonsterService.new(
-        monsterProfile,
-        function()
-            return self.CampSession.DangerActive == true
-        end,
-        function(player)
-            return self:_isPlayerTargetableInField(player)
-        end,
-        canTraverseFn,
-        {
-            RandomSeed = self.SessionData.Seed,
-            RandomSource = randomSource,
-            OnAttackHit = function(player, damagePips, hitContext)
-                self:_applyPlayerDamage(player, damagePips)
-                if hitContext and hitContext.Effects then
-                    for _, effect in ipairs(hitContext.Effects) do
-                        self.PlayerStateService:applyEffect(
-                            player,
-                            effect.Id,
-                            effect.DurationSeconds
-                        )
-                    end
-                end
-            end,
-        }
-    )
-end
-
-function RunSessionService:_applyPlayerDamage(player, damagePips)
-    if not self:_isPlayerTargetableInField(player) then
-        return
-    end
-    local damageKind = DAMAGE_KIND_BY_PIPS[damagePips]
-    if damageKind == nil then
-        return
-    end
-    local success, result = self.PlayerService:applyDamage(player, damageKind)
-    if not success then
-        warn(
-            ('[RunSessionService] applyDamage failed for %s: %s'):format(
-                player.DisplayName,
-                tostring(result)
-            )
-        )
-        return
-    end
-
-    local summary = self.PlayerService:getSummary(player)
-    if summary and summary.Health and summary.Health.IsDead then
-        self:_setStatus(
-            string.format(
-                '%s died in the run field and will respawn at camp next round.',
-                player.DisplayName
-            )
-        )
-        self:_toast(player, 'You are out for this round.', 'Error')
-        self:_maybeEndRoundForAllDeaths()
-    end
-end
-
--- Called when ShipDoors first opened: spawn monsters at eligible patrol points
-function RunSessionService:_beginExpedition()
-    if not self.MonsterService then
-        return
-    end
-
-    local allPositions = RunWorldScanner.scanSpawnPoints()
-    if #allPositions == 0 then
-        warn(
-            '[RunSessionService] No SpawnPoint_* found in RunStaticWorld — skipping monster spawn'
-        )
-        return
-    end
-
-    -- Get ship position for exclusion zone from world geometry
-    local shipPosition = nil
-    local shipCollision = self.World and self.World.Collision and self.World.Collision.Ship
-    if shipCollision and shipCollision:IsA('PVInstance') then
-        shipPosition = shipCollision:GetPivot().Position
-    end
-
-    local shipModel = self.World and self.World.ShipModel
-    if not shipPosition and shipModel and shipModel:IsA('PVInstance') then
-        shipPosition = shipModel:GetPivot().Position
-    end
-
-    if not shipPosition then
-        warn(
-            '[RunSessionService] Ship position not found (no collision shell or model) - skipping monster spawn'
-        )
-        return
-    end
-
-    local eligible = RunMonsterSpawnPolicy.collectEligiblePatrolPoints(allPositions, shipPosition)
-    if #eligible == 0 then
-        warn(
-            '[RunSessionService] No eligible patrol points after exclusion — skipping monster spawn'
-        )
-        return
-    end
-
-    local initialIndex = RunMonsterSpawnPolicy.selectInitialPatrolIndex(eligible)
-    self.MonsterService:spawn(eligible, initialIndex)
-end
-
--- =======================================================
--- End monster integration
--- =======================================================
-
-function RunSessionService:_canProcessMazeEntryRequest(player)
-    local now = os.clock()
-    local previous = self.LastMazeEntryRequestAtByUserId[player.UserId]
-    if previous and now - previous < MAZE_ENTRY_REQUEST_COOLDOWN_SECONDS then
-        return false
-    end
-
-    self.LastMazeEntryRequestAtByUserId[player.UserId] = now
-    return true
-end
-
-function RunSessionService:_launchRun(_player)
-    if self.IsLaunched then
-        return
-    end
-
-    self:_ensureHost()
-    self.GateOpen = self.CampSession.GateOpen == true
-    self:_syncCampSession()
-    self:_subscribeToRoundSignals()
-
-    self:_rebuildWorld()
-
-    self.IsLaunched = true
-    Players.CharacterAutoLoads = true
-
-    for _, player in ipairs(Players:GetPlayers()) do
-        player:LoadCharacter()
-    end
-
-    self:_startSnapshotLoop()
-    if self.CampSession.RoundStarted == true then
-        self:_setStatus('The shared round is already live. Regroup or push deeper as needed.')
-    else
-        self:_setStatus('Camp is safe. The host can open the ship door when the crew is ready.')
-    end
-end
-
-function RunSessionService:_getPlayerUpdateContext(player)
-    local character = player.Character
-    local humanoid = character and character:FindFirstChildOfClass('Humanoid')
-    local rootPart = humanoid and humanoid.RootPart
-    local currentPosition = rootPart and rootPart.Position or Vector3.zero
-
-    return {
-        CurrentPosition = currentPosition,
-        InputState = {},
-    }
-end
-
-function RunSessionService:_startSnapshotLoop()
-    if self.SnapshotThread then
-        return
-    end
-
-    self.SnapshotThread = task.spawn(function()
-        local previousTick = os.clock()
-
-        while true do
-            task.wait(SNAPSHOT_INTERVAL_SECONDS)
-
-            if self.IsLaunched then
-                local currentTick = os.clock()
-                local dt = currentTick - previousTick
-                previousTick = currentTick
-
-                for _, player in ipairs(Players:GetPlayers()) do
-                    local context = self:_getPlayerUpdateContext(player)
-                    self.PlayerService:update(player, dt, context)
-                    self:_syncPlayerMovement(player)
-                    self:_updateOceanPerPlayer(player, dt)
-                end
-
-                if
-                    self:_isRoundStarted()
-                    and not self.RoundClosureInProgress
-                    and (self:_getRoundTimeRemainingSeconds() or 0) <= 0
-                then
-                    self:_completeRound(ROUND_SETTLEMENT_REASON.Timeout, nil, true)
-                end
-
-                self:_maybeEndRoundForAllDeaths()
-                self:_broadcastSnapshot()
-            else
-                previousTick = os.clock()
-            end
-        end
-    end)
-end
-
-function RunSessionService:_setPlayerSprinting(player, isSprinting)
-    if not self.IsLaunched then
-        return
-    end
-
-    local playerState = self.PlayerService:getSummary(player)
-    local success, result
-    if isSprinting then
-        success, result = self.ControlStateService:requestSprintStart(player, playerState)
-    else
-        success, result = self.ControlStateService:requestSprintStop(player)
-    end
-
-    if not success then
-        if result == 'StaminaDepleted' then
-            self:_setStatus(string.format('%s is too exhausted to sprint.', player.DisplayName))
-        elseif result == 'Dead' then
-            self:_setStatus(string.format('%s cannot sprint while dead.', player.DisplayName))
-        end
-        self:_syncPlayerMovement(player)
-        return
-    end
-
-    self:_syncPlayerMovement(player)
-end
-
-function RunSessionService:_handlePlayerTeleportData(player)
-    local teleportData = self:_readTeleportData(player)
-    if not teleportData then
-        return
-    end
-
-    local _, accepted = self:_applyIncomingCampSession(teleportData)
-    if not accepted then
-        return
-    end
-
-    self:_applySessionConfig(teleportData.SessionConfig)
-    self:_hydratePlayerInventory(player, teleportData)
-
-    local summary = CampMazeSessionContract.findReturnSummary(teleportData, player.UserId)
-    if summary then
-        self.PendingSpawnByUserId[player.UserId] = self:_getReturnSpawnTargetForSummary(summary)
-        self.Status = self:_getReturnStatusText(player.DisplayName, summary, teleportData)
-        return
-    end
-
-    self.CampSession = CampMazeSessionContract.prunePlayer(self.CampSession, player.UserId, {
-        PreserveMazeEntry = CampMazeSessionContract.isPlayerInMaze(self.CampSession, player.UserId),
-    })
-    self.GateOpen = self.CampSession.GateOpen
-    self.Status = string.format('%s joined the temple session.', player.DisplayName)
-end
-
-function RunSessionService:_ensureAuthoritativeSessionSeed()
-    local seed, issuedNewSeed = SessionSeedPolicy.ensureAuthoritativeSeed({
-        CurrentSeed = self.SessionData.Seed,
-        DefaultSeed = SessionConfig.DefaultSeed,
-        HasAuthoritativeSeed = self.HasAuthoritativeSessionSeed,
-        RandomSource = self.SessionSeedRandom or Random.new(),
-    })
-
-    self.SessionData.Seed = seed
-    if issuedNewSeed then
-        self.HasAuthoritativeSessionSeed = true
-    end
-end
-
-function RunSessionService:_emptyInventorySummary()
-    return {
-        Capacity = self.SessionData.InventoryCapacity,
-        Weight = 0,
-        Count = 0,
-        BackpackCount = 0,
-        HeldCount = 0,
-        Value = 0,
-        BackpackItems = {},
-        HeldItem = nil,
-    }
-end
-
-function RunSessionService:_inventorySummaryFor(player)
-    if not self.IsLaunched then
-        return self:_emptyInventorySummary()
-    end
-
-    return self.InventoryService:getSummary(player)
-end
-
-function RunSessionService:_getLegacyHeldItemShim(player, legacyToolName)
-    if type(legacyToolName) ~= 'string' then
-        return nil
-    end
-
-    local expectedCategory = LEGACY_TOOL_CATEGORY[legacyToolName]
-    if not expectedCategory then
-        return nil
-    end
-
-    local held = self:_inventorySummaryFor(player).HeldItem
-    if not held or held.ToolCategory ~= expectedCategory then
-        return nil
-    end
-
-    return {
-        Name = held.Name,
-        Type = 'Tool',
-        Description = held.Description or '',
-        IsEquipped = true,
-        IsActive = false,
-        IconAssetId = held.IconAssetId or '',
-        Color = held.Color,
-    }
 end
 
 function RunSessionService:_bindItemRemotes()
@@ -2106,11 +1636,7 @@ function RunSessionService:start()
             if not self:_isRoundStarted() then
                 self:_toast(player, 'The round has not started yet.', 'Error')
             elseif not self:_isPlayerInCamp(player) then
-                self:_toast(
-                    player,
-                    'Return to camp before using the Book of Sand to settle.',
-                    'Error'
-                )
+                self:_toast(player, 'Return to the ship before ending the round.', 'Error')
             elseif self:_isPlayerDead(player) then
                 self:_toast(player, 'Dead players cannot trigger settlement.', 'Error')
             else

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -11,9 +11,11 @@ local SessionConfig = Shared.Config.SessionConfig
 local Remotes = Shared.Network.Remotes.ensure()
 local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
 local MazeEntryAvailability = Shared.Session.MazeEntryAvailability
+local SessionSeedPolicy = Shared.Session.SessionSeedPolicy
 local ControlStateService = Shared.Runtime.ControlStateService
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
 local InventoryService = Shared.Runtime.InventoryService
+local MonsterService = Shared.Runtime.MonsterService
 local PlayerService = Shared.Runtime.PlayerService
 local PlayerStateService = Shared.Runtime.PlayerStateService
 local TODService = Shared.Runtime.TODService
@@ -21,6 +23,8 @@ local TeleportInventoryHydrator = Shared.Runtime.TeleportInventoryHydrator
 local RoundSignalBus = Shared.Runtime.RoundSignalBus
 
 local RunSpawnPoint = require(script.Parent.RunSpawnPoint)
+local RunWorldScanner = require(script.Parent.RunWorldScanner)
+local RunMonsterSpawnPolicy = require(script.Parent.RunMonsterSpawnPolicy)
 local RunSnapshotBuilder = require(script.Parent.RunSnapshotBuilder)
 local RunStaticWorldContract = require(script.Parent.RunStaticWorldContract)
 local RunToMazeTransition = require(script.Parent.RunToMazeTransition)
@@ -31,6 +35,11 @@ local RunSessionService = {}
 RunSessionService.__index = RunSessionService
 
 local DEFAULT_WORKSPACE_SHELL_NAMES = { 'Baseplate', 'SpawnLocation' }
+local CAMP_SESSION_LOCK_WAIT_SECONDS = 0.05
+local MAZE_ENTRY_REQUEST_COOLDOWN_SECONDS = 0.35
+local MAZE_ENTRY_DISTANCE_BUFFER = 2
+local TERMINAL_INTERACTION_DISTANCE_BUFFER = 2
+local SNAPSHOT_INTERVAL_SECONDS = 0.25
 local LEGACY_TOOL_CATEGORY = table.freeze({
     Flashlight = 'Flashlight',
     Rope = 'Rope',
@@ -51,6 +60,10 @@ local ROUND_SETTLEMENT_REASON = table.freeze({
     Book = 'ship_settlement',
     Timeout = 'timeout',
     AllDead = 'all_dead',
+})
+local DAMAGE_KIND_BY_PIPS = table.freeze({
+    [1] = Gameplay.PlayerState.DamageKind.Light,
+    [2] = Gameplay.PlayerState.DamageKind.Heavy,
 })
 local SHOP_ITEMS = {
     {
@@ -149,6 +162,22 @@ local function cloneArray(input)
     end
 
     return result
+end
+
+local function runWithCampSessionLock(self, callback)
+    while self.CampSessionLock do
+        task.wait(CAMP_SESSION_LOCK_WAIT_SECONDS)
+    end
+
+    self.CampSessionLock = true
+    local results = table.pack(pcall(callback))
+    self.CampSessionLock = false
+
+    if not results[1] then
+        error(results[2], 0)
+    end
+
+    return table.unpack(results, 2, results.n)
 end
 
 function RunSessionService.new(options)
@@ -1466,7 +1495,10 @@ function RunSessionService:_openGate(player)
             RoundEndTime = roundEndTime,
             DangerActive = true,
         })
+        self:_syncCampSession()
         self.World:openGate()
+        self.TODService:start()
+        self:_beginExpedition()
         self.Status = string.format(
             '%s opened the ship door. Round %d of %d is live: search the wilderness, then head for the tower.',
             player.DisplayName,
@@ -1552,6 +1584,473 @@ function RunSessionService:_bindItemRemotes()
         self.InventoryService:consumeHeldItemState(player, os.clock())
         self:_broadcastSnapshot()
     end)
+end
+
+function RunSessionService:_isPlayerNearTerminalPrompt(player, terminalOrPrompt, distanceBuffer)
+    if not terminalOrPrompt then
+        return false
+    end
+
+    if type(terminalOrPrompt.isPlayerNear) == 'function' then
+        return terminalOrPrompt:isPlayerNear(
+            player,
+            distanceBuffer or TERMINAL_INTERACTION_DISTANCE_BUFFER
+        )
+    end
+
+    local prompt = terminalOrPrompt
+    local promptPart = prompt.Parent
+    if not promptPart or not promptPart:IsA('BasePart') then
+        return false
+    end
+
+    local character = player.Character
+    local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+    if not rootPart or not rootPart:IsA('BasePart') then
+        return false
+    end
+
+    local maxDistance = prompt.MaxActivationDistance
+        + (distanceBuffer or TERMINAL_INTERACTION_DISTANCE_BUFFER)
+    return (rootPart.Position - promptPart.Position).Magnitude <= maxDistance
+end
+
+function RunSessionService:_isPlayerNearMazePrompt(player)
+    return self:_isPlayerNearTerminalPrompt(
+        player,
+        self.World and self.World.MazePortal,
+        MAZE_ENTRY_DISTANCE_BUFFER
+    )
+end
+
+function RunSessionService:_enterMaze(player)
+    runWithCampSessionLock(self, function()
+        if SessionConfig.PlaceIds.Maze == 0 then
+            self:_setStatus(
+                'Set SessionConfig.PlaceIds.Maze or SessionPlaceIdMaze before using the maze gate.'
+            )
+            return
+        end
+
+        if self.CampSession.MazeStatus == CampMazeSessionContract.MazeStatus.Completed then
+            self:_setStatus('The maze session is already complete for this mission.')
+            return
+        end
+
+        local result = self.RunToMazeTransition:enter({
+            Player = player,
+            CampSession = self.CampSession,
+            GateOpen = self.GateOpen,
+            SessionConfig = self.SessionData,
+            PlayerInventory = self.InventoryService:getSummary(player),
+            EnteringPlayer = {
+                UserId = player.UserId,
+                Name = player.DisplayName,
+            },
+            EntryReason = 'maze_gate',
+        })
+        if not result.Ok then
+            self.CampSession = result.CurrentSession or self.CampSession
+            self.MazeEntryMode = MazeEntryAvailability.Mode.Blocked
+            self.MazeEntryReasonCode = result.ReasonCode or result.FailureCode
+            self.MazeEntryReason = result.Reason
+            self:_setStatus(
+                string.format('%s could not enter the maze: %s', player.DisplayName, result.Reason)
+            )
+            return
+        end
+
+        self.MazeEntryMode = MazeEntryAvailability.Mode.Teleport
+        self.MazeEntryReasonCode = result.ReasonCode
+        self.MazeEntryReason = result.Reason
+        self.CampSession = result.NextSession
+        self:_setStatus(string.format('%s is entering the shared maze run.', player.DisplayName))
+    end)
+end
+
+function RunSessionService:_requestMazeEntry(player, requireDistanceCheck)
+    if not self.IsLaunched or not self.World then
+        return
+    end
+
+    if requireDistanceCheck and not self:_isPlayerNearMazePrompt(player) then
+        return
+    end
+
+    local availability = self:_evaluateMazeEntry(player)
+    if availability.Mode == MazeEntryAvailability.Mode.Teleport then
+        self:_enterMaze(player)
+        return
+    end
+
+    self:_setStatus(
+        string.format(
+            '%s could not enter the maze: %s (code=%s, gameId=%d, placeId=%d, mazePlaceId=%d)',
+            player.DisplayName,
+            availability.Reason,
+            availability.ReasonCode or 'Unknown',
+            game.GameId,
+            game.PlaceId,
+            SessionConfig.PlaceIds.Maze
+        )
+    )
+end
+
+function RunSessionService:_compileMonsterForRun(authorProfile)
+    local MonsterRuntimeProfile = Gameplay.Monsters.MonsterRuntimeProfile
+
+    local tuning = authorProfile.Tuning
+    local presentation = authorProfile.Executable.Presentation
+    local behaviors = {}
+
+    for _, intent in ipairs(authorProfile.Executable.BehaviorIntents or {}) do
+        if intent.Enabled ~= false then
+            behaviors[intent.Id] = true
+        end
+    end
+
+    local runtimeProfile = {
+        Id = authorProfile.Id,
+        Name = authorProfile.Name,
+        Presentation = table.freeze({
+            ModelAssetId = presentation.ModelAssetId,
+            RigType = presentation.RigType,
+            AnimationMode = presentation.AnimationMode,
+            ChaseLoopSoundAssetId = presentation.ChaseLoopSoundAssetId,
+        }),
+        AttackCooldownSeconds = tuning.AttackCooldownSeconds or 1,
+        AttackDamagePips = tuning.AttackDamagePips or 1,
+        AttackRange = tuning.AttackRange or 4,
+        Speed = tuning.Speed,
+        SightRange = tuning.SightRange,
+        PatrolSpeedMultiplier = tuning.PatrolSpeedMultiplier,
+        SpawnOffset = tuning.SpawnOffset or Vector3.new(0, 4, 0),
+        CombatHitPoints = tuning.CombatHitPoints or 1,
+        Behaviors = table.freeze(behaviors),
+        Effects = table.freeze({}),
+    }
+    runtimeProfile.Components =
+        Gameplay.Monsters.MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)
+    runtimeProfile = table.freeze(runtimeProfile)
+
+    local valid, reason = MonsterRuntimeProfile.validate(runtimeProfile)
+    if not valid then
+        error(string.format('Run monster profile invalid: %s', tostring(reason)), 0)
+    end
+
+    return runtimeProfile
+end
+
+function RunSessionService:_createMonsterService()
+    local monsterProfile = self:_compileMonsterForRun(Gameplay.Config.Monsters[1])
+    local canTraverseFn = RunWorldScanner.buildCanTraverseFn(self.World)
+    local randomSource = Random.new(self.SessionData.Seed > 0 and self.SessionData.Seed or 42)
+
+    return MonsterService.new(
+        monsterProfile,
+        function()
+            return self.CampSession.DangerActive == true
+        end,
+        function(player)
+            return self:_isPlayerTargetableInField(player)
+        end,
+        canTraverseFn,
+        {
+            RandomSeed = self.SessionData.Seed,
+            RandomSource = randomSource,
+            OnAttackHit = function(player, damagePips, hitContext)
+                self:_applyPlayerDamage(player, damagePips)
+                if hitContext and hitContext.Effects then
+                    for _, effect in ipairs(hitContext.Effects) do
+                        self.PlayerStateService:applyEffect(
+                            player,
+                            effect.Id,
+                            effect.DurationSeconds
+                        )
+                    end
+                end
+            end,
+        }
+    )
+end
+
+function RunSessionService:_applyPlayerDamage(player, damagePips)
+    if not self:_isPlayerTargetableInField(player) then
+        return
+    end
+
+    local damageKind = DAMAGE_KIND_BY_PIPS[damagePips]
+    if damageKind == nil then
+        return
+    end
+
+    local success, result = self.PlayerService:applyDamage(player, damageKind)
+    if not success then
+        warn(
+            ('[RunSessionService] applyDamage failed for %s: %s'):format(
+                player.DisplayName,
+                tostring(result)
+            )
+        )
+        return
+    end
+
+    local summary = self.PlayerService:getSummary(player)
+    if summary and summary.Health and summary.Health.IsDead then
+        self:_setStatus(
+            string.format(
+                '%s died in the run field and will respawn at the ship next round.',
+                player.DisplayName
+            )
+        )
+        self:_toast(player, 'You are out for this round.', 'Error')
+        self:_maybeEndRoundForAllDeaths()
+    end
+end
+
+function RunSessionService:_beginExpedition()
+    if not self.MonsterService then
+        return
+    end
+
+    local allPositions = RunWorldScanner.scanSpawnPoints()
+    if #allPositions == 0 then
+        warn('[RunSessionService] No SpawnPoint_* found in RunStaticWorld - skipping monster spawn')
+        return
+    end
+
+    local shipPosition = nil
+    local shipCollision = self.World and self.World.Collision and self.World.Collision.Ship
+    if shipCollision and shipCollision:IsA('PVInstance') then
+        shipPosition = shipCollision:GetPivot().Position
+    end
+
+    local shipModel = self.World and self.World.ShipModel
+    if not shipPosition and shipModel and shipModel:IsA('PVInstance') then
+        shipPosition = shipModel:GetPivot().Position
+    end
+
+    if not shipPosition then
+        warn(
+            '[RunSessionService] Ship position not found (no collision shell or model) - skipping monster spawn'
+        )
+        return
+    end
+
+    local eligible = RunMonsterSpawnPolicy.collectEligiblePatrolPoints(allPositions, shipPosition)
+    if #eligible == 0 then
+        warn(
+            '[RunSessionService] No eligible patrol points after exclusion - skipping monster spawn'
+        )
+        return
+    end
+
+    local initialIndex = RunMonsterSpawnPolicy.selectInitialPatrolIndex(eligible)
+    self.MonsterService:spawn(eligible, initialIndex)
+end
+
+function RunSessionService:_canProcessMazeEntryRequest(player)
+    local now = os.clock()
+    local previous = self.LastMazeEntryRequestAtByUserId[player.UserId]
+    if previous and now - previous < MAZE_ENTRY_REQUEST_COOLDOWN_SECONDS then
+        return false
+    end
+
+    self.LastMazeEntryRequestAtByUserId[player.UserId] = now
+    return true
+end
+
+function RunSessionService:_launchRun(_player)
+    if self.IsLaunched then
+        return
+    end
+
+    self:_ensureHost()
+    self.GateOpen = self.CampSession.GateOpen == true
+    self:_syncCampSession()
+    self:_subscribeToRoundSignals()
+    self:_rebuildWorld()
+
+    self.IsLaunched = true
+    Players.CharacterAutoLoads = true
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        player:LoadCharacter()
+    end
+
+    self:_startSnapshotLoop()
+    if self.CampSession.RoundStarted == true then
+        self:_setStatus('The shared round is already live. Regroup or push deeper as needed.')
+    else
+        self:_setStatus('The ship is safe. The host can open the door when the crew is ready.')
+    end
+end
+
+function RunSessionService:_getPlayerUpdateContext(player)
+    local character = player.Character
+    local humanoid = character and character:FindFirstChildOfClass('Humanoid')
+    local rootPart = humanoid and humanoid.RootPart
+    local currentPosition = rootPart and rootPart.Position or Vector3.zero
+
+    return {
+        CurrentPosition = currentPosition,
+        InputState = {},
+    }
+end
+
+function RunSessionService:_startSnapshotLoop()
+    if self.SnapshotThread then
+        return
+    end
+
+    self.SnapshotThread = task.spawn(function()
+        local previousTick = os.clock()
+
+        while true do
+            task.wait(SNAPSHOT_INTERVAL_SECONDS)
+
+            if self.IsLaunched then
+                local currentTick = os.clock()
+                local dt = currentTick - previousTick
+                previousTick = currentTick
+
+                for _, player in ipairs(Players:GetPlayers()) do
+                    local context = self:_getPlayerUpdateContext(player)
+                    self.PlayerService:update(player, dt, context)
+                    self:_syncPlayerMovement(player)
+                    self:_updateOceanPerPlayer(player, dt)
+                end
+
+                if
+                    self:_isRoundStarted()
+                    and not self.RoundClosureInProgress
+                    and (self:_getRoundTimeRemainingSeconds() or 0) <= 0
+                then
+                    self:_completeRound(ROUND_SETTLEMENT_REASON.Timeout, nil, true)
+                end
+
+                self:_maybeEndRoundForAllDeaths()
+                self:_broadcastSnapshot()
+            else
+                previousTick = os.clock()
+            end
+        end
+    end)
+end
+
+function RunSessionService:_setPlayerSprinting(player, isSprinting)
+    if not self.IsLaunched then
+        return
+    end
+
+    local playerState = self.PlayerService:getSummary(player)
+    local success, result
+    if isSprinting then
+        success, result = self.ControlStateService:requestSprintStart(player, playerState)
+    else
+        success, result = self.ControlStateService:requestSprintStop(player)
+    end
+
+    if not success then
+        if result == 'StaminaDepleted' then
+            self:_setStatus(string.format('%s is too exhausted to sprint.', player.DisplayName))
+        elseif result == 'Dead' then
+            self:_setStatus(string.format('%s cannot sprint while dead.', player.DisplayName))
+        end
+        self:_syncPlayerMovement(player)
+        return
+    end
+
+    self:_syncPlayerMovement(player)
+end
+
+function RunSessionService:_handlePlayerTeleportData(player)
+    local teleportData = self:_readTeleportData(player)
+    if not teleportData then
+        return
+    end
+
+    local _, accepted = self:_applyIncomingCampSession(teleportData)
+    if not accepted then
+        return
+    end
+
+    self:_applySessionConfig(teleportData.SessionConfig)
+    self:_hydratePlayerInventory(player, teleportData)
+
+    local summary = CampMazeSessionContract.findReturnSummary(teleportData, player.UserId)
+    if summary then
+        self.PendingSpawnByUserId[player.UserId] = self:_getReturnSpawnTargetForSummary(summary)
+        self.Status = self:_getReturnStatusText(player.DisplayName, summary, teleportData)
+        return
+    end
+
+    self.CampSession = CampMazeSessionContract.prunePlayer(self.CampSession, player.UserId, {
+        PreserveMazeEntry = CampMazeSessionContract.isPlayerInMaze(self.CampSession, player.UserId),
+    })
+    self.GateOpen = self.CampSession.GateOpen
+    self.Status = string.format('%s joined the ship session.', player.DisplayName)
+end
+
+function RunSessionService:_ensureAuthoritativeSessionSeed()
+    local seed, issuedNewSeed = SessionSeedPolicy.ensureAuthoritativeSeed({
+        CurrentSeed = self.SessionData.Seed,
+        DefaultSeed = SessionConfig.DefaultSeed,
+        HasAuthoritativeSeed = self.HasAuthoritativeSessionSeed,
+        RandomSource = self.SessionSeedRandom or Random.new(),
+    })
+
+    self.SessionData.Seed = seed
+    if issuedNewSeed then
+        self.HasAuthoritativeSessionSeed = true
+    end
+end
+
+function RunSessionService:_emptyInventorySummary()
+    return {
+        Capacity = self.SessionData.InventoryCapacity,
+        Weight = 0,
+        Count = 0,
+        BackpackCount = 0,
+        HeldCount = 0,
+        Value = 0,
+        BackpackItems = {},
+        HeldItem = nil,
+    }
+end
+
+function RunSessionService:_inventorySummaryFor(player)
+    if not self.IsLaunched then
+        return self:_emptyInventorySummary()
+    end
+
+    return self.InventoryService:getSummary(player)
+end
+
+function RunSessionService:_getLegacyHeldItemShim(player, legacyToolName)
+    if type(legacyToolName) ~= 'string' then
+        return nil
+    end
+
+    local expectedCategory = LEGACY_TOOL_CATEGORY[legacyToolName]
+    if not expectedCategory then
+        return nil
+    end
+
+    local held = self:_inventorySummaryFor(player).HeldItem
+    if not held or held.ToolCategory ~= expectedCategory then
+        return nil
+    end
+
+    return {
+        Name = held.Name,
+        Type = 'Tool',
+        Description = held.Description or '',
+        IsEquipped = true,
+        IsActive = false,
+        IconAssetId = held.IconAssetId or '',
+        Color = held.Color,
+    }
 end
 
 function RunSessionService:start()

--- a/places/run/src/ServerScriptService/Run/RunSnapshotBuilder.luau
+++ b/places/run/src/ServerScriptService/Run/RunSnapshotBuilder.luau
@@ -5,7 +5,7 @@ function RunSnapshotBuilder.buildForPlayer(service, player, mazeEntryAvailabilit
     local playerStateSummary = if playerSummary and playerSummary.PlayerState ~= nil
         then playerSummary.PlayerState
         else service.PlayerStateService:getSummary(player)
-    local bookSnapshot = service:_getBookSnapshot()
+    local missionSnapshot = service:_getMissionSnapshot()
     local mazeEntry = mazeEntryAvailability or service:_evaluateMazeEntry(player)
 
     return {
@@ -19,7 +19,7 @@ function RunSnapshotBuilder.buildForPlayer(service, player, mazeEntryAvailabilit
         IsHost = service.CampSession.HostUserId == player.UserId,
         RoundStarted = service.CampSession.RoundStarted == true,
         DangerActive = service.CampSession.DangerActive == true,
-        RoundTimeRemainingSeconds = bookSnapshot.RoundTimeRemainingSeconds,
+        RoundTimeRemainingSeconds = missionSnapshot.RoundTimeRemainingSeconds,
         SettlementReason = service.CampSession.SettlementReason,
         Objective = service:_getObjectiveFor(player),
         SessionId = service.CampSession.SessionId,
@@ -31,10 +31,20 @@ function RunSnapshotBuilder.buildForPlayer(service, player, mazeEntryAvailabilit
         MazeEntryReason = mazeEntry.Reason,
         MazeEntryReasonCode = mazeEntry.ReasonCode,
         CanEnterMaze = mazeEntry.Mode == 'Teleport',
-        TeamPages = bookSnapshot.TeamPages,
-        BookGoalAmount = bookSnapshot.BookGoalAmount,
-        BookGoalProgress = bookSnapshot.BookGoalProgress,
-        BookGoalReached = bookSnapshot.BookGoalReached,
+        CurrentRound = missionSnapshot.CurrentRound,
+        MaxRounds = missionSnapshot.MaxRounds,
+        BankedItemCount = missionSnapshot.BankedItemCount,
+        TargetItemCount = missionSnapshot.TargetItemCount,
+        RoundOutcome = missionSnapshot.RoundOutcome,
+        SessionOutcome = missionSnapshot.SessionOutcome,
+        TeamPages = missionSnapshot.BankedItemCount,
+        BookGoalAmount = missionSnapshot.TargetItemCount,
+        BookGoalProgress = missionSnapshot.TargetItemCount > 0 and math.clamp(
+            missionSnapshot.BankedItemCount / missionSnapshot.TargetItemCount,
+            0,
+            1
+        ) or 0,
+        BookGoalReached = missionSnapshot.BankedItemCount >= missionSnapshot.TargetItemCount,
         Inventory = service.InventoryService:getSummary(player),
         Movement = service:_getMovementSummaryFor(player),
         ControlState = service.ControlStateService:getSummary(player),

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -20,9 +20,9 @@ local heldItemController = Shared.Client.HeldItemController.new(localPlayer)
 local Theme = UI.Hud.Theme
 
 local TEMPLE_LABEL = 'Temple'
-local PAGE_LABEL = 'Pages'
-local SAND_BOOK_LABEL = 'Book of Sand'
-local SAND_BOOK_PROGRESS_LABEL = 'Book of Sand Progress'
+local PAGE_LABEL = 'Banked Loot'
+local SAND_BOOK_LABEL = 'Mission'
+local SAND_BOOK_PROGRESS_LABEL = 'Mission Progress'
 
 local disconnectFirstPersonLock
 local ensureFirstPersonLock
@@ -654,10 +654,10 @@ task.spawn(connectTODRemote)
 
 local shopPanel = createModalPanel('ShopPanel', UDim2.fromOffset(460, 520))
 local shopTitle = makeTextLabel(shopPanel, UDim2.new(1, 0, 0, 32), Theme.Text, 26, true)
-shopTitle.Text = 'Temple Shop'
+shopTitle.Text = 'Ship Locker'
 
 local shopPageLabel = makeTextLabel(shopPanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
-shopPageLabel.Text = 'Team Pages: 0'
+shopPageLabel.Text = 'Banked Loot: 0'
 
 local shopInventoryLabel =
     makeTextLabel(shopPanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
@@ -676,10 +676,10 @@ local shopCloseButton = makeButton(shopPanel, 'Close', 44, Theme.Warning)
 
 local sellPanel = createModalPanel('SellPanel', UDim2.fromOffset(460, 480))
 local sellTitle = makeTextLabel(sellPanel, UDim2.new(1, 0, 0, 32), Theme.Text, 26, true)
-sellTitle.Text = 'Salvage Exchange'
+sellTitle.Text = 'Recovery Log'
 
 local sellPageLabel = makeTextLabel(sellPanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
-sellPageLabel.Text = 'Team Pages: 0'
+sellPageLabel.Text = 'Banked Loot: 0'
 
 local sellItemsFrame = Instance.new('Frame')
 sellItemsFrame.Size = UDim2.new(1, 0, 1, -160)
@@ -694,11 +694,11 @@ local sellCloseButton = makeButton(sellPanel, 'Close', 44, Theme.Warning)
 
 local objectivePanel = createModalPanel('ObjectivePanel', UDim2.fromOffset(440, 360))
 local objectiveTitle = makeTextLabel(objectivePanel, UDim2.new(1, 0, 0, 32), Theme.Text, 26, true)
-objectiveTitle.Text = 'Book of Sand Board'
+objectiveTitle.Text = 'Mission Board'
 
 local objectiveGoalLabel =
     makeTextLabel(objectivePanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
-objectiveGoalLabel.Text = 'Goal: 0 Pages'
+objectiveGoalLabel.Text = 'Target: 0 item(s)'
 
 local objectiveProgressLabel =
     makeTextLabel(objectivePanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
@@ -744,24 +744,24 @@ end
 
 local function updateObjectiveUi()
     local clampedProgress = math.clamp(goalProgress, 0, 1)
-    objectiveGoalLabel.Text = string.format('Goal: %d %s', goalAmount, PAGE_LABEL)
+    objectiveGoalLabel.Text = string.format('Target: %d item(s)', goalAmount)
     objectiveProgressLabel.Text =
         string.format('%s: %d%%', SAND_BOOK_PROGRESS_LABEL, math.floor(clampedProgress * 100 + 0.5))
     progressBarFill.Size = UDim2.fromScale(clampedProgress, 1)
 end
 
 local function updatePageLabels()
-    shopPageLabel.Text = string.format('Team %s: %d', PAGE_LABEL, teamPages)
-    sellPageLabel.Text = string.format('Team %s: %d', PAGE_LABEL, teamPages)
+    shopPageLabel.Text = string.format('%s: %d', PAGE_LABEL, teamPages)
+    sellPageLabel.Text = string.format('%s: %d', PAGE_LABEL, teamPages)
     updateObjectiveUi()
 
     if inventorySummary then
         shopInventoryLabel.Text = string.format(
-            'Inventory: %d total | %d/%d KG | %d value',
+            'Inventory: %d total | %d loot | %d clue | %d tool',
             inventorySummary.Count or 0,
-            inventorySummary.Weight or 0,
-            inventorySummary.Capacity or 0,
-            inventorySummary.Value or 0
+            inventorySummary.LootCount or 0,
+            inventorySummary.ClueCount or 0,
+            inventorySummary.ToolCount or 0
         )
     else
         shopInventoryLabel.Text = 'Inventory: --'
@@ -791,7 +791,7 @@ local function showToast(message, tone)
 end
 
 local function showGoalBanner()
-    goalBanner.Text = string.format('Goal reached! Team %s: %d', PAGE_LABEL, teamPages)
+    goalBanner.Text = string.format('Quota reached! %s: %d', PAGE_LABEL, teamPages)
     goalBanner.Visible = true
 
     task.delay(3, function()
@@ -1215,13 +1215,13 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
     heldItemController:applyInventory(inventory)
     updatePageLabels()
     inventoryLabel.Text = string.format(
-        'Inventory: %d total | %d backpack | %d held | %d/%d KG | %d value',
+        'Inventory: %d total | %d loot | %d clue | %d tool | %d/%d slots',
         inventory.Count or 0,
-        inventory.BackpackCount or 0,
-        inventory.HeldCount or 0,
-        inventory.Weight or 0,
-        inventory.Capacity or 0,
-        inventory.Value or 0
+        inventory.LootCount or 0,
+        inventory.ClueCount or 0,
+        inventory.ToolCount or 0,
+        inventory.Count or 0,
+        inventory.Capacity or 0
     )
 
     local heldItem = inventory.HeldItem
@@ -1233,10 +1233,9 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
 
     local inventoryDetailLines = {
         heldItem and string.format(
-            'Held: %s | %d KG | %d value%s',
+            'Held: %s | %s%s',
             heldItem.Name,
-            heldItem.Weight,
-            heldItem.Value,
+            heldItem.ItemCategory or 'Loot',
             heldItem.Light and ' | Glow active' or ''
         ) or 'Held: Empty hands',
         'Backpack:',
@@ -1249,11 +1248,10 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
             table.insert(
                 inventoryDetailLines,
                 string.format(
-                    '- [%d] %s | %d KG | %d value',
+                    '- [%d] %s | %s',
                     itemIndex,
                     itemEntry.Name,
-                    itemEntry.Weight,
-                    itemEntry.Value
+                    itemEntry.ItemCategory or 'Loot'
                 )
             )
         end
@@ -1314,9 +1312,9 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
             table.insert(
                 mazeLines,
                 string.format(
-                    '- %s: %d value (%s)',
+                    '- %s: %d loot item(s) (%s)',
                     entry.Name,
-                    entry.Value or 0,
+                    entry.LootItemCount or entry.MissionCount or 0,
                     entry.ReturnReason or 'unknown'
                 )
             )

--- a/tests/src/Shared/CampMazeSessionContract.spec.luau
+++ b/tests/src/Shared/CampMazeSessionContract.spec.luau
@@ -11,111 +11,153 @@ return function()
         SignalScope = 'run:test-scope',
     })
 
+    assert(campSession.CurrentRound == 1, 'New sessions should start on round 1')
+    assert(campSession.MaxRounds == 5, 'New sessions should default to a 5-round mission')
     assert(
-        campSession.MazeStatus == contract.MazeStatus.Idle,
-        'New camp sessions should start idle'
+        campSession.TargetItemCount == 12,
+        'New sessions should default to the mission target item count'
     )
+    assert(campSession.BankedItemCount == 0, 'New sessions should start with zero banked items')
     assert(
         campSession.SessionPhase == contract.SessionPhase.RunPrep,
-        'New camp sessions should start in RunPrep'
-    )
-    assert(
-        campSession.SignalScope == 'run:test-scope',
-        'Signal scope should normalize through camp sessions'
-    )
-    assert(
-        campSession.RoundStarted == false,
-        'New camp sessions should start before the round opens'
-    )
-    assert(
-        campSession.DangerActive == false,
-        'New camp sessions should start in the safe camp state'
+        'New sessions should start in RunPrep'
     )
 
     local assignedHost = contract.assignHost(campSession, 42)
-    assert(assignedHost.HostUserId == 42, 'Host assignment should persist on the camp session')
+    assert(assignedHost.HostUserId == 42, 'Host assignment should persist on the session')
 
     local roundLive = contract.markRoundStarted(assignedHost, {
         HostUserId = 42,
         RoundStartTime = 10,
-        RoundEndTime = 190,
+        RoundEndTime = 910,
         DangerActive = true,
     })
-    assert(roundLive.GateOpen == true, 'Round start should open the gate')
+    assert(roundLive.GateOpen == true, 'Round start should open the ship gate')
     assert(roundLive.RoundStarted == true, 'Round start should mark the round live')
-    assert(roundLive.DangerActive == true, 'Round start should enable danger')
     assert(
-        roundLive.RoundStartTime == 10 and roundLive.RoundEndTime == 190,
-        'Round timing should be recorded'
+        roundLive.SessionPhase == contract.SessionPhase.RunField,
+        'Live round should resolve to RunField'
     )
 
-    local settledFromBook = contract.markSettlementTriggered(roundLive, {
-        SettlementReason = 'book_settlement',
+    local midSettlement = contract.markSettlementTriggered(roundLive, {
+        SettlementReason = 'timeout',
         TriggeredByUserId = 42,
         TriggeredByName = 'Scout',
+        RoundOutcome = 'timeout',
     })
-    assert(settledFromBook.GateOpen == false, 'Settlement should close the gate')
-    assert(settledFromBook.RoundStarted == false, 'Settlement should end the live round flag')
-    assert(settledFromBook.DangerActive == false, 'Settlement should disable danger')
+    assert(midSettlement.GateOpen == false, 'Settlement should close the gate')
+    assert(midSettlement.RoundOutcome == 'timeout', 'Settlement should preserve the round outcome')
     assert(
-        settledFromBook.SettlementReason == 'book_settlement',
-        'Settlement should record the triggering reason'
-    )
-    assert(
-        settledFromBook.SettlementTriggeredByUserId == 42
-            and settledFromBook.SettlementTriggeredByName == 'Scout',
-        'Settlement should record the triggering player'
+        midSettlement.SessionPhase == contract.SessionPhase.RunIntermission,
+        'Non-final settlement should move into RunIntermission'
     )
 
-    local resetRound = contract.resetForNextRound(settledFromBook)
-    assert(
-        resetRound.RoundStarted == false and resetRound.DangerActive == false,
-        'Reset should return to the safe camp state'
-    )
-    assert(resetRound.SettlementReason == nil, 'Reset should clear settlement tracking')
+    local afterBank = contract.recordBankedItems(midSettlement, 3)
+    assert(afterBank.BankedItemCount == 3, 'Banked items should accumulate on the shared session')
 
-    local entered = contract.markPlayerEntered(campSession, {
+    local persistentWorld = contract.setPersistentWorldState(afterBank, {
+        CollectedLootRoomIds = { 'Room_A', 'Room_B' },
+        DropNodes = {
+            {
+                DropNodeId = 'drop-1',
+                Label = 'Scout Pack',
+                Position = Vector3.new(1, 2, 3),
+                Entries = {
+                    {
+                        InstanceId = 7,
+                        Id = 'clue-threat-1',
+                        Name = 'Warning Note',
+                        ItemCategory = 'Clue',
+                        MissionCount = 0,
+                        ReadableTitle = 'Warning Note',
+                        ReadableText = 'Do not trust the first footsteps you hear.',
+                    },
+                },
+            },
+        },
+    })
+    assert(
+        persistentWorld.PersistentWorldState.DropNodes[1].Position.X == 1,
+        'Persistent world drop positions should normalize to serializable coordinates'
+    )
+    assert(
+        persistentWorld.PersistentWorldState.DropNodes[1].Entries[1].ReadableTitle == 'Warning Note',
+        'Persistent world state should preserve dropped clue entries'
+    )
+
+    local resetRound = contract.resetForNextRound(persistentWorld)
+    assert(resetRound.CurrentRound == 2, 'Reset should advance to the next mission round')
+    assert(resetRound.BankedItemCount == 3, 'Reset should preserve banked mission progress')
+    assert(
+        resetRound.PersistentWorldState.CollectedLootRoomIds[2] == 'Room_B',
+        'Reset should preserve persistent world state'
+    )
+    assert(
+        resetRound.SessionPhase == contract.SessionPhase.RunPrep,
+        'Reset should return to RunPrep when the mission continues'
+    )
+
+    local entered = contract.markPlayerEntered(resetRound, {
         UserId = 42,
         Name = 'Scout',
     })
     entered.MazeAccessCode = 'maze-access-code'
-
     assert(
         entered.MazeStatus == contract.MazeStatus.Active,
         'Entering the maze should activate the maze status'
     )
-    assert(#entered.PlayersInMaze == 1, 'Entering should track the player inside the maze')
     assert(
         entered.SessionPhase == contract.SessionPhase.MazeActive,
-        'Entering the maze should move the shared session into MazeActive'
+        'Entering the maze should move the session into MazeActive'
     )
 
-    local lobbyToRun = contract.buildLobbyToRunTeleportData({
-        SessionId = 'camp-session-1',
-        CampAccessCode = 'camp-access-code',
-        SessionConfig = {
-            Seed = 12345,
+    local roundTripInventory = {
+        Capacity = 5,
+        Weight = 0,
+        Count = 2,
+        BackpackCount = 1,
+        HeldCount = 1,
+        Value = 0,
+        LootCount = 1,
+        ClueCount = 1,
+        ToolCount = 0,
+        MissionCount = 1,
+        BackpackItems = {
+            {
+                InstanceId = 1,
+                Id = 'clue-threat-1',
+                Name = 'Warning Note',
+                ItemCategory = 'Clue',
+                MissionCount = 0,
+                ReadableTitle = 'Warning Note',
+                ReadableText = 'Do not trust the first footsteps you hear.',
+                ClueId = 'threat-1',
+                ThreatHintId = 'monster-echo',
+                SourceMarkerId = 'ClueMarker_Warning',
+            },
         },
-    })
-    assert(
-        lobbyToRun.Entry.Kind == 'LobbyLaunch',
-        'Lobby -> run teleport payload should mark the handoff entry kind'
-    )
-    assert(
-        lobbyToRun.CampSession.SessionPhase == contract.SessionPhase.RunPrep,
-        'Lobby -> run payload should preserve direct-entry run prep phase'
-    )
-    assert(
-        lobbyToRun.CampSession.RoundStarted == false
-            and lobbyToRun.CampSession.DangerActive == false,
-        'Lobby -> run payload should start with a safe camp round state'
-    )
+        HeldItem = {
+            InstanceId = 2,
+            Id = 'glow-orb',
+            Name = 'Glow Orb',
+            ItemCategory = 'Loot',
+            MissionCount = 1,
+            Weight = 1,
+            Value = 24,
+            Color = Color3.fromRGB(142, 236, 255),
+            Light = {
+                Brightness = 2.5,
+                Range = 18,
+                Color = Color3.fromRGB(170, 240, 255),
+            },
+        },
+    }
 
     local campToMaze = contract.buildRunToMazeTeleportData({
         SessionConfig = {
             Seed = 12345,
-            Quota = 120,
-            RunDurationSeconds = 180,
+            Quota = 12,
+            RunDurationSeconds = 900,
             InventoryCapacity = 5,
         },
         CampSession = entered,
@@ -124,28 +166,7 @@ return function()
             Name = 'Scout',
         },
         EntryReason = 'maze_gate',
-        PlayerInventory = {
-            Capacity = 5,
-            Weight = 1,
-            Count = 1,
-            BackpackCount = 0,
-            HeldCount = 1,
-            Value = 24,
-            BackpackItems = {},
-            HeldItem = {
-                InstanceId = 4,
-                Id = 'glow-orb',
-                Name = 'Glow Orb',
-                Weight = 1,
-                Value = 24,
-                Color = Color3.fromRGB(142, 236, 255),
-                Light = {
-                    Brightness = 2.5,
-                    Range = 18,
-                    Color = Color3.fromRGB(170, 240, 255),
-                },
-            },
-        },
+        PlayerInventory = roundTripInventory,
         PendingUgcMonsterPayload = {
             OwnerUserId = 42,
             MonsterId = 'ugc-42-100',
@@ -165,7 +186,6 @@ return function()
                 SightRange = 36,
                 PatrolSpeedMultiplier = 0.45,
                 SpawnOffset = Vector3.new(0, 4, 0),
-                CombatHitPoints = 2,
                 Behaviors = {
                     SenseNearestTarget = true,
                     Chase = true,
@@ -180,314 +200,99 @@ return function()
         },
     })
 
-    assert(
-        campToMaze.MazeSession.MazeAccessCode == 'maze-access-code',
-        'Maze access code should flow into the maze teleport payload'
-    )
-    assert(
-        campToMaze.CampSession.SessionId == 'camp-session-1',
-        'Camp session id should survive camp -> maze teleport shaping'
-    )
-    assert(
-        campToMaze.CampSession.SessionPhase == contract.SessionPhase.MazeActive,
-        'Camp -> maze payload should carry the MazeActive phase for shared re-entry'
-    )
     local enteringInventory = contract.findPlayerInventory(campToMaze, 42)
     assert(
         enteringInventory ~= nil,
         'Run -> maze payload should carry the entering player inventory'
     )
+    assert(enteringInventory.ClueCount == 1, 'Teleport inventory should preserve clue counts')
     assert(
-        enteringInventory.HeldItem.Id == 'glow-orb',
-        'Run -> maze inventory payload should preserve the held glow orb'
+        enteringInventory.HeldItem.MissionCount == 1,
+        'Teleport inventory should preserve loot mission count'
     )
+    assert(
+        enteringInventory.BackpackItems[1].ReadableText
+            == 'Do not trust the first footsteps you hear.',
+        'Teleport inventory should preserve readable clue text'
+    )
+
     local pendingUgcPayload = contract.findPendingUgcMonsterPayload(campToMaze)
     assert(
         pendingUgcPayload ~= nil and pendingUgcPayload.OwnerUserId == 42,
-        'Run -> maze payload should preserve pending UGC spawn payloads'
+        'Run -> maze payload should preserve pending UGC monster payloads'
     )
     assert(
-        pendingUgcPayload.RuntimeProfile ~= nil
-            and pendingUgcPayload.RuntimeProfile.Presentation.ModelAssetId
-                == monsterAssetIds.DefaultModelAssetId,
-        'Pending UGC payload should preserve runtime monster presentation data'
-    )
-
-    local toolHoldTeleport = contract.buildRunToMazeTeleportData({
-        SessionConfig = {
-            Seed = 12345,
-            Quota = 120,
-            RunDurationSeconds = 180,
-            InventoryCapacity = 8,
-        },
-        CampSession = entered,
-        EnteringPlayer = {
-            UserId = 42,
-            Name = 'Scout',
-        },
-        EntryReason = 'maze_gate',
-        PlayerInventory = {
-            Capacity = 8,
-            Weight = 1,
-            Count = 1,
-            BackpackCount = 0,
-            HeldCount = 1,
-            Value = 0,
-            BackpackItems = {},
-            HeldItem = {
-                InstanceId = 10,
-                Id = 'tool-potion',
-                Name = 'Potion',
-                Weight = 1,
-                Value = 0,
-                Color = Color3.fromRGB(236, 72, 153),
-                ToolCategory = 'Potion',
-                StateModel = 'Charges',
-                InitialState = 3,
-                CurrentState = 3,
-                ConsumePerUse = 1,
-                CooldownSeconds = 1,
-                IconAssetId = '',
-                ToolTemplateName = 'ToolPotion',
-                Description = 'Contract potion row',
-                HealHealthPips = 2,
-                SwingRange = 4,
-                SwingArcDegrees = 50,
-                KnockbackStrength = 9,
-                MeleeDamage = 2,
-            },
-        },
-        PendingUgcMonsterPayload = nil,
-    })
-    local toolHoldInventory = contract.findPlayerInventory(toolHoldTeleport, 42)
-    assert(
-        toolHoldInventory.HeldItem.ToolCategory == 'Potion',
-        'Run -> maze inventory clone should preserve ToolCategory for tools'
-    )
-    assert(
-        toolHoldInventory.HeldItem.ToolTemplateName == 'ToolPotion',
-        'Run -> maze inventory clone should preserve ToolTemplateName for presentation'
-    )
-    assert(
-        toolHoldInventory.HeldItem.HealHealthPips == 2,
-        'Run -> maze inventory clone should preserve HealHealthPips for potion tools'
-    )
-    assert(
-        toolHoldInventory.HeldItem.MeleeDamage == 2,
-        'Run -> maze inventory clone should preserve MeleeDamage for tool entries'
+        pendingUgcPayload.RuntimeProfile.Presentation.ModelAssetId
+            == monsterAssetIds.DefaultModelAssetId,
+        'Pending UGC payload should preserve monster presentation data'
     )
 
     local earlyReturn = contract.buildReturnSummary({
         UserId = 42,
         Name = 'Scout',
-        ReturnReason = 'early_return',
-        Value = 18,
-        ItemCount = 1,
-        Weight = 2,
+        ReturnReason = 'extracted',
+        LootItemCount = 2,
+        ClueCount = 1,
+        ToolCount = 0,
+        MissionCount = 2,
+        ItemCount = 3,
+        WasExtracted = true,
     })
     local resumed = contract.applyReturn(entered, earlyReturn, false)
-
+    assert(#resumed.PlayersInMaze == 0, 'Returned players should leave the maze roster')
     assert(
-        #resumed.PlayersInMaze == 0,
-        'Returned players should be removed from the in-maze roster'
+        resumed.ReturnedPlayerSummaries[1].LootItemCount == 2,
+        'Return summaries should preserve loot counts'
     )
     assert(
-        resumed.MazeStatus == contract.MazeStatus.Active,
-        'Maze stays active when it was opened but not completed'
-    )
-    assert(
-        resumed.SessionPhase == contract.SessionPhase.Debrief,
-        'Returned players should move the shared session into Debrief while no crew remains in maze'
-    )
-    assert(
-        resumed.ReturnedPlayerSummaries[1].Value == 18,
-        'Return summaries should preserve collected value'
-    )
-    assert(
-        resumed.ReturnedPlayerSummaries[1].CountedInSettlement == true,
-        'Return summaries should count inventory by default'
-    )
-    assert(
-        contract.hasReturnedSummary(resumed, 42) == true,
-        'Returned players should remain discoverable through the summary helper'
+        resumed.SessionPhase == contract.SessionPhase.RunIntermission,
+        'Returned summaries should move the mission into RunIntermission while rounds remain'
     )
 
-    local reentered = contract.markPlayerEntered(resumed, {
-        UserId = 42,
-        Name = 'Scout',
+    local finalRound = contract.newCampSession({
+        SessionId = 'camp-session-final',
+        CampAccessCode = 'camp-access-final',
+        CurrentRound = 5,
+        MaxRounds = 5,
+        BankedItemCount = 11,
+        TargetItemCount = 12,
     })
-    assert(
-        contract.hasReturnedSummary(reentered, 42) == false,
-        "Re-entering the maze should clear that player's stale return summary"
-    )
-    assert(
-        contract.isPlayerInMaze(reentered, 42) == true,
-        'Re-entering the maze should put the player back into the active maze roster'
-    )
-
-    local preservedMazeEntry = contract.prunePlayer(entered, 42, {
-        PreserveMazeEntry = true,
+    local finalSettlement = contract.markSettlementTriggered(finalRound, {
+        SettlementReason = 'timeout',
+        RoundOutcome = 'timeout',
     })
+    local finalOutcome = contract.markSessionOutcome(finalSettlement, 'failure')
     assert(
-        contract.isPlayerInMaze(preservedMazeEntry, 42) == true,
-        'Camp-side disconnect cleanup should preserve active maze entries'
+        finalOutcome.SessionPhase == contract.SessionPhase.FinalDebrief,
+        'Final-round outcome should move into FinalDebrief'
+    )
+    assert(
+        finalOutcome.SessionOutcome == 'failure',
+        'Session outcome should persist on final debrief'
     )
 
-    local prunedReturn = contract.prunePlayer(resumed, 42)
-    assert(
-        contract.hasReturnedSummary(prunedReturn, 42) == false,
-        'Disconnect cleanup should clear stale returned summaries by default'
-    )
-
-    local preservedReturn = contract.prunePlayer(resumed, 42, {
-        PreserveReturnSummary = true,
-    })
-    assert(
-        contract.hasReturnedSummary(preservedReturn, 42) == true,
-        'Maze-side cleanup should be able to keep a recorded return summary'
-    )
-
-    local settled = contract.buildReturnSummary({
-        UserId = 7,
-        Name = 'Lead',
-        ReturnReason = 'settled',
-        Value = 42,
-        ItemCount = 2,
-        Weight = 4,
-        WasExtracted = true,
-        WasSettled = true,
-    })
-    assert(
-        settled.CountedInSettlement == true,
-        'Settled return summaries should count inventory unless explicitly disabled'
-    )
-    local completed = contract.applyReturn(
-        contract.markPlayerEntered(resumed, {
-            UserId = 7,
-            Name = 'Lead',
-        }),
-        settled,
-        true
-    )
-
-    assert(
-        completed.MazeStatus == contract.MazeStatus.Completed,
-        'Completed maze sessions should lock into completed status'
-    )
-    assert(
-        #completed.PlayersInMaze == 0,
-        'Completed maze sessions should not retain active maze players'
-    )
-    assert(
-        completed.SessionPhase == contract.SessionPhase.Debrief,
-        'Completed maze sessions should stay in Debrief until the camp session closes'
-    )
-
-    local mazeToCamp = contract.buildMazeToRunTeleportData({
+    local mazeToRun = contract.buildMazeToRunTeleportData({
         SessionConfig = {
             Seed = 12345,
-            Quota = 120,
-            RunDurationSeconds = 180,
-            InventoryCapacity = 5,
         },
-        CampSession = completed,
-        Summaries = completed.ReturnedPlayerSummaries,
+        CampSession = finalOutcome,
+        Summaries = {
+            earlyReturn,
+        },
         MazeCompleted = true,
         PlayerInventories = {
             {
                 UserId = 42,
-                Inventory = {
-                    Capacity = 5,
-                    Weight = 1,
-                    Count = 1,
-                    BackpackCount = 0,
-                    HeldCount = 1,
-                    Value = 24,
-                    BackpackItems = {},
-                    HeldItem = {
-                        InstanceId = 4,
-                        Id = 'glow-orb',
-                        Name = 'Glow Orb',
-                        Weight = 1,
-                        Value = 24,
-                        Color = Color3.fromRGB(142, 236, 255),
-                        Light = {
-                            Brightness = 2.5,
-                            Range = 18,
-                            Color = Color3.fromRGB(170, 240, 255),
-                        },
-                    },
-                },
+                Inventory = roundTripInventory,
             },
         },
     })
-
-    local returnedScout = contract.findReturnSummary(mazeToCamp, 42)
-    local returnedLead = contract.findReturnSummary(mazeToCamp, 7)
-
     assert(
-        returnedScout.ReturnReason == 'early_return',
-        'findReturnSummary should locate the matching player summary'
+        mazeToRun.MazeReturn.MazeCompleted == true,
+        'Maze -> run payload should preserve completion state'
     )
     assert(
-        returnedLead.WasSettled == true,
-        'Maze return payload should preserve settlement summaries'
-    )
-    local returnedInventory = contract.findPlayerInventory(mazeToCamp, 42)
-    assert(
-        returnedInventory ~= nil,
-        'Maze -> run payload should carry the returning player inventory'
-    )
-    assert(
-        returnedInventory.HeldItem.Light ~= nil,
-        'Maze -> run payload should preserve held item light metadata'
-    )
-
-    local closed = contract.closeCampSession(completed)
-    assert(
-        closed.SessionPhase == contract.SessionPhase.SessionClosed,
-        'Closed sessions should expose a terminal SessionClosed phase'
-    )
-    assert(
-        closed.SessionClosed == true,
-        'Closing the session should preserve an explicit terminal marker'
-    )
-
-    local reconciledPlaceholder, placeholderAccepted = contract.reconcileIncomingCampSession(
-        contract.newCampSession({}),
-        contract.newCampSession({
-            SessionId = 'camp-session-2',
-            CampAccessCode = 'camp-access-code-2',
-            MazeAccessCode = 'maze-access-code-2',
-        })
-    )
-    assert(
-        placeholderAccepted == true and reconciledPlaceholder.SessionId == 'camp-session-2',
-        'Placeholder camp sessions should accept the first real incoming session'
-    )
-
-    local reconciledSameSession, sameSessionAccepted = contract.reconcileIncomingCampSession(
-        entered,
-        contract.newCampSession({
-            SessionId = 'camp-session-1',
-            CampAccessCode = 'camp-access-code',
-            MazeAccessCode = 'maze-access-code',
-        })
-    )
-    assert(
-        sameSessionAccepted == true and reconciledSameSession.CampAccessCode == 'camp-access-code',
-        'Matching incoming session payloads should be accepted'
-    )
-
-    local rejectedSession, mismatchedAccepted = contract.reconcileIncomingCampSession(
-        entered,
-        contract.newCampSession({
-            SessionId = 'camp-session-other',
-            CampAccessCode = 'camp-access-code-other',
-        })
-    )
-    assert(
-        mismatchedAccepted == false and rejectedSession.SessionId == entered.SessionId,
-        'Mismatched incoming sessions should not overwrite the current authority'
+        contract.findReturnSummary(mazeToRun, 42).MissionCount == 2,
+        'Maze -> run payload should preserve mission counts inside return summaries'
     )
 end

--- a/tests/src/Shared/Inventory.spec.luau
+++ b/tests/src/Shared/Inventory.spec.luau
@@ -4,400 +4,192 @@ return function()
     local sharedPackage = ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared')
     local shared = require(sharedPackage)
     local contract = shared.Session.CampMazeSessionContract
-    local items = gameplay.Config.Items
-    local inventory = gameplay.Inventory.new(7)
-    local inventoryService =
-        require(sharedPackage:WaitForChild('Runtime'):WaitForChild('InventoryService')).new(7)
-    local fakePlayer = {
-        UserId = 101,
+    local InventoryService =
+        require(sharedPackage:WaitForChild('Runtime'):WaitForChild('InventoryService'))
+
+    local inventory = gameplay.Inventory.new(2)
+    local lootItem = {
+        Id = 'signal-core',
+        Name = 'Signal Core',
+        Weight = 99,
+        Value = 18,
+        ItemCategory = 'Loot',
+        MissionCount = 1,
     }
-    local overweightItem = {
-        Id = 'overweight-canister',
-        Name = 'Overweight Canister',
-        Weight = 5,
-        Value = 99,
-        Color = Color3.fromRGB(255, 140, 140),
+    local clueItem = {
+        Id = 'clue-threat-1',
+        Name = 'Warning Note',
+        ItemCategory = 'Clue',
+        MissionCount = 0,
+        ReadableTitle = 'Warning Note',
+        ReadableText = 'Do not trust the first footsteps you hear.',
+        ClueId = 'threat-1',
+        ThreatHintId = 'monster-echo',
+        SourceMarkerId = 'ClueMarker_Warning',
     }
     local toolItem = {
         Id = 'tool-crowbar',
         Name = 'Crowbar',
-        Weight = 3,
-        Value = 0,
-        Color = Color3.fromRGB(200, 200, 200),
-        Description = 'Spec crowbar',
-        IconAssetId = '',
-        ToolTemplateName = 'ToolCrowbar',
+        ItemCategory = 'Tool',
+        MissionCount = 0,
         ToolCategory = 'Crowbar',
         StateModel = 'Durability',
         InitialState = 10,
         ConsumePerUse = 0,
         CooldownSeconds = 0.5,
         KnockbackStrength = 15,
+        ToolTemplateName = 'ToolCrowbar',
     }
 
-    local success, firstEntry = inventory:add(items[2])
-    assert(success == true, 'Inventory should accept a low-weight item')
-    assert(inventory.Weight == items[2].Weight, 'Inventory weight should increase after add')
-    assert(firstEntry.InstanceId == 1, 'Inventory should issue a stable item instance id')
-    assert(inventory:getSummary().BackpackCount == 1, 'Picked-up items should enter the backpack')
+    local firstOk, firstEntry = inventory:add(lootItem)
+    assert(firstOk == true, 'Inventory should accept the first item')
+    assert(firstEntry.InstanceId == 1, 'Inventory should issue a stable instance id')
 
-    local secondSuccess, secondEntry = inventory:add(items[1])
-    assert(secondSuccess == true, 'Inventory should accept a second item within capacity')
+    local secondOk, secondEntry = inventory:add(clueItem)
+    assert(secondOk == true, 'Inventory should accept a second item while capacity remains')
     assert(secondEntry.InstanceId == 2, 'Second pickup should increment the instance id')
 
-    local equipSuccess, equippedEntry = inventory:equip(firstEntry.InstanceId)
-    assert(equipSuccess == true, 'Inventory should equip a valid backpack item')
-    assert(
-        equippedEntry.InstanceId == firstEntry.InstanceId,
-        'Equipping should move the requested item into the held slot'
-    )
+    local fullOk, fullReason = inventory:add(toolItem)
+    assert(fullOk == false, 'Inventory capacity should now be slot-based, not weight-based')
+    assert(fullReason == 'InventoryFull', 'Full slot inventory should expose InventoryFull')
 
-    local inventorySummary = inventory:getSummary()
-    assert(inventorySummary.HeldItem ~= nil, 'Inventory summary should surface the held item')
-    assert(
-        inventorySummary.HeldItem.InstanceId == firstEntry.InstanceId,
-        'Held item summary should match the equipped item'
-    )
-    assert(
-        inventorySummary.BackpackCount == 1 and inventorySummary.HeldCount == 1,
-        'Summary should distinguish backpack and held counts'
-    )
+    local summary = inventory:getSummary()
+    assert(summary.LootCount == 1, 'Summary should count loot items')
+    assert(summary.ClueCount == 1, 'Summary should count clue items')
+    assert(summary.MissionCount == 1, 'Only loot should count toward mission progress')
+    assert(summary.Value == 0, 'Inventory summary value should stay compatibility-only')
+    assert(summary.Weight == 0, 'Inventory summary weight should stay compatibility-only')
 
-    local swapSuccess, swappedEntry = inventory:equip(secondEntry.InstanceId)
-    assert(swapSuccess == true, 'Equipping another item should swap it into the held slot')
+    local extractedEntries, extractedMissionCount = inventory:extractMissionCargo()
+    assert(extractedMissionCount == 1, 'extractMissionCargo should count only loot mission entries')
     assert(
-        swappedEntry.InstanceId == secondEntry.InstanceId,
-        'Second equip should hold the newly requested item'
-    )
-
-    local swappedSummary = inventory:getSummary()
-    assert(
-        swappedSummary.HeldItem.InstanceId == secondEntry.InstanceId,
-        'Swap equip should replace the held item'
+        #extractedEntries == 1 and extractedEntries[1].Id == 'signal-core',
+        'extractMissionCargo should remove the loot item from inventory'
     )
     assert(
-        swappedSummary.BackpackItems[1].InstanceId == firstEntry.InstanceId,
-        'Previously held item should return to the backpack after a swap'
+        inventory:getSummary().ClueCount == 1,
+        'Clue items should remain after banking loot cargo'
     )
 
-    local unequipSuccess, unequippedEntry = inventory:unequip()
-    assert(unequipSuccess == true, 'Unequip should move the held item back into the backpack')
-    assert(
-        unequippedEntry.InstanceId == secondEntry.InstanceId,
-        'Unequip should return the previously held item'
-    )
-    assert(
-        inventory:getSummary().HeldItem == nil,
-        'Unequip should clear the held slot in the summary'
-    )
+    local dropInventory = gameplay.Inventory.new(3)
+    dropInventory:add(lootItem)
+    dropInventory:add(clueItem)
+    local _, dropTool = dropInventory:add(toolItem)
+    assert(dropInventory:equip(dropTool.InstanceId) == true, 'Inventory should equip tool items')
+    local droppedEntries = dropInventory:dropAllItems()
+    assert(#droppedEntries == 3, 'dropAllItems should return every carried item')
+    assert(dropInventory:getSummary().Count == 0, 'dropAllItems should empty the inventory')
 
-    local missingItemSuccess, missingItemReason = inventory:equip(999)
-    assert(missingItemSuccess == false, 'Inventory should reject unknown item instance ids')
-    assert(missingItemReason == 'ItemNotFound', 'Unknown items should expose ItemNotFound')
-
-    local missingHeldSuccess, missingHeldReason = inventory:unequip()
-    assert(missingHeldSuccess == false, 'Inventory should reject unequip without a held item')
-    assert(missingHeldReason == 'NothingHeld', 'Unequip should expose NothingHeld when empty')
-
-    local thirdSuccess = inventory:add(overweightItem)
-    assert(thirdSuccess == false, 'Inventory should reject items that exceed remaining capacity')
-
-    local depositedValue = inventory:getTotalValue()
-    assert(
-        depositedValue == items[2].Value + items[1].Value,
-        'Inventory value should include backpack contents after equip swaps'
-    )
-
-    inventory:clear()
-    assert(inventory.Weight == 0, 'Inventory clear should reset weight')
-    assert(
-        inventory:getSummary().BackpackCount == 0 and inventory:getSummary().HeldCount == 0,
-        'Inventory clear should reset backpack and held state'
-    )
-
+    local inventoryService = InventoryService.new(4)
+    local fakePlayer = { UserId = 101 }
     inventoryService:addPlayer(fakePlayer)
-    local servicePickupSuccess, serviceEntry = inventoryService:pickup(fakePlayer, items[4])
-    assert(servicePickupSuccess == true, 'Runtime inventory should pick up items for the player')
-    local tokenPickupSuccess, tokenEntry = inventoryService:pickup(fakePlayer, items[1])
-    assert(tokenPickupSuccess == true, 'Runtime inventory should pick up the starter UGC token')
+
+    local serviceLootOk = inventoryService:pickup(fakePlayer, lootItem)
+    local serviceClueOk = inventoryService:pickup(fakePlayer, clueItem)
+    local serviceToolOk, serviceTool = inventoryService:pickup(fakePlayer, toolItem)
     assert(
-        inventoryService:countByItemId(fakePlayer, items[1].Id) == 1,
-        'Runtime inventory should count items by item id'
-    )
-    local consumedToken, consumedEntry = inventoryService:consumeByItemId(fakePlayer, items[1].Id)
-    assert(consumedToken == true, 'Runtime inventory should consume an item by id')
-    assert(
-        consumedEntry.InstanceId == tokenEntry.InstanceId,
-        'Consumed item should match the picked-up token instance id'
+        serviceLootOk == true and serviceClueOk == true and serviceToolOk == true,
+        'Runtime inventory should accept loot, clue, and tool items'
     )
     assert(
-        inventoryService:countByItemId(fakePlayer, items[1].Id) == 0,
-        'Consumed items should no longer be counted in inventory summaries'
+        inventoryService:equip(fakePlayer, serviceTool.InstanceId) == true,
+        'Runtime inventory should equip a held tool'
     )
 
-    local serviceEquipSuccess = inventoryService:equip(fakePlayer, serviceEntry.InstanceId)
-    assert(serviceEquipSuccess == true, 'Runtime inventory should equip a held item')
+    local consumeOk, consumedTool = inventoryService:consumeHeldItemState(fakePlayer, 100)
+    assert(consumeOk == true, 'Runtime inventory should use held tools')
+    assert(consumedTool.CurrentState == 10, 'Zero-consume tools should preserve durability state')
 
-    local serviceSummary = inventoryService:getSummary(fakePlayer)
+    local cooldownOk, cooldownReason = inventoryService:consumeHeldItemState(fakePlayer, 100.2)
     assert(
-        serviceSummary.HeldItem.InstanceId == serviceEntry.InstanceId,
-        'Runtime inventory summary should expose the held item'
-    )
-    assert(
-        serviceSummary.HeldItem.Light ~= nil,
-        'Runtime inventory should preserve held item effect data'
-    )
-    local toolPlayer = {
-        UserId = 202,
-    }
-    inventoryService:addPlayer(toolPlayer)
-    local pickupToolSuccess, pickedToolEntry = inventoryService:pickup(toolPlayer, toolItem)
-    assert(pickupToolSuccess == true, 'Runtime inventory should pick up tool items')
-    local equipToolSuccess = inventoryService:equip(toolPlayer, pickedToolEntry.InstanceId)
-    assert(equipToolSuccess == true, 'Runtime inventory should equip tool items')
-
-    local consumeToolSuccess, consumedHeldTool = inventoryService:consumeHeldItemState(toolPlayer)
-    assert(consumeToolSuccess == true, 'Runtime inventory should consume held tool state')
-    assert(
-        consumedHeldTool.CurrentState == 10,
-        'Crowbar with ConsumePerUse 0 should not decrement current state'
+        cooldownOk == false and cooldownReason == 'Cooldown',
+        'Cooldown tools should reject early reuse'
     )
 
-    local toolSummary = inventoryService:getSummary(toolPlayer)
+    local bankedMissionCount = inventoryService:deposit(fakePlayer)
+    assert(bankedMissionCount == 1, 'deposit should bank only mission-count loot items')
+    local postDepositSummary = inventoryService:getSummary(fakePlayer)
+    assert(postDepositSummary.ClueCount == 1, 'deposit should preserve clue items')
+    assert(postDepositSummary.ToolCount == 1, 'deposit should preserve non-loot tools')
+
+    local droppedAfterDeposit = inventoryService:dropAllItems(fakePlayer)
     assert(
-        toolSummary.HeldItem.CurrentState == 10,
-        'Tool state should persist unchanged when ConsumePerUse is 0'
-    )
-    assert(
-        toolSummary.HeldItem.KnockbackStrength == toolItem.KnockbackStrength,
-        'Runtime inventory should preserve extended item fields through summaries'
-    )
-    assert(
-        toolSummary.HeldItem.ToolTemplateName == 'ToolCrowbar',
-        'Tool presentation template name should round-trip through summaries'
+        #droppedAfterDeposit == 2,
+        'dropAllItems should return the remaining clue and tool after loot banking'
     )
 
-    local toolRoundTrip = gameplay.Inventory.new(7)
-    assert(
-        toolRoundTrip:loadSummary(toolSummary) == true,
-        'Tool summaries should hydrate inventory'
-    )
-    assert(
-        toolRoundTrip:getSummary().HeldItem.ToolTemplateName == 'ToolCrowbar',
-        'Hydrated inventory should preserve ToolTemplateName'
-    )
-
-    local potionPlayer = {
-        UserId = 204,
-    }
-    inventoryService:addPlayer(potionPlayer)
-    local potionDef = {
-        Id = 'tool-potion',
-        Name = 'Potion',
-        Weight = 1,
+    local restorablePlayer = { UserId = 202 }
+    inventoryService:addPlayer(restorablePlayer)
+    local loadOk = inventoryService:loadSummary(restorablePlayer, {
+        Capacity = 4,
+        Weight = 0,
+        Count = 2,
+        BackpackCount = 1,
+        HeldCount = 1,
         Value = 0,
-        Color = Color3.fromRGB(236, 72, 153),
-        ToolCategory = 'Potion',
-        StateModel = 'Charges',
-        InitialState = 2,
-        CurrentState = 2,
-        ConsumePerUse = 1,
-        CooldownSeconds = 0,
-        HealHealthPips = 2,
-    }
-    local pickupPotionSuccess, potionEntry = inventoryService:pickup(potionPlayer, potionDef)
-    assert(pickupPotionSuccess == true, 'Runtime inventory should pick up potion tool defs')
-    local equipPotionSuccess = inventoryService:equip(potionPlayer, potionEntry.InstanceId)
-    assert(equipPotionSuccess == true, 'Runtime inventory should equip potion tools')
-    local potionSummary = inventoryService:getSummary(potionPlayer)
+        LootCount = 1,
+        ClueCount = 1,
+        ToolCount = 0,
+        MissionCount = 1,
+        BackpackItems = { clueItem },
+        HeldItem = {
+            InstanceId = 9,
+            Id = 'glow-orb',
+            Name = 'Glow Orb',
+            ItemCategory = 'Loot',
+            MissionCount = 1,
+            Weight = 1,
+            Value = 24,
+            Light = {
+                Brightness = 2.5,
+                Range = 18,
+                Color = Color3.fromRGB(170, 240, 255),
+            },
+        },
+    })
+    assert(loadOk == true, 'Runtime inventory should hydrate modern summaries')
     assert(
-        potionSummary.HeldItem.HealHealthPips == 2,
-        'HealHealthPips should round-trip on held potion summaries'
+        inventoryService:getSummary(restorablePlayer).HeldItem.Light ~= nil,
+        'Hydrated inventories should preserve light metadata'
     )
 
-    local durableUser = {
-        UserId = 205,
-    }
-    inventoryService:addPlayer(durableUser)
-    local durableDef = {
-        Id = 'spec-durable',
-        Name = 'Durable',
-        Weight = 1,
-        Value = 0,
-        Color = Color3.fromRGB(90, 90, 90),
-        ToolCategory = 'Pry',
-        StateModel = 'Durability',
-        InitialState = 5,
-        ConsumePerUse = 1,
-        CooldownSeconds = 0,
-    }
-    local durablePickupOk, durableEntry = inventoryService:pickup(durableUser, durableDef)
-    assert(durablePickupOk == true, 'Runtime inventory should pick up durable consumable defs')
-    assert(
-        inventoryService:equip(durableUser, durableEntry.InstanceId) == true,
-        'Runtime inventory should equip durable consumable tools'
-    )
-    local durableConsumeOk, durableHeld = inventoryService:consumeHeldItemState(durableUser, 200)
-    assert(durableConsumeOk == true, 'consumeHeldItemState should succeed for held durable tools')
-    assert(
-        durableHeld.CurrentState == 4,
-        'Held durable tool CurrentState should decrement by ConsumePerUse'
-    )
-
-    local durableSummary = inventoryService:getSummary(durableUser)
-    local campForRoundTrip = contract.newCampSession({
+    local campSession = contract.newCampSession({
         SessionId = 'inv-contract-rt',
         CampAccessCode = 'inv-contract-rt',
     })
-    local enteredRoundTrip = contract.markPlayerEntered(campForRoundTrip, {
-        UserId = durableUser.UserId,
+    local entered = contract.markPlayerEntered(campSession, {
+        UserId = restorablePlayer.UserId,
         Name = 'RoundTrip',
     })
-    enteredRoundTrip.MazeAccessCode = 'inv-contract-rt-maze'
+    entered.MazeAccessCode = 'inv-contract-rt-maze'
+
     local roundTripTeleport = contract.buildRunToMazeTeleportData({
         SessionConfig = {
             Seed = 42,
             Quota = 10,
             RunDurationSeconds = 120,
-            InventoryCapacity = 7,
+            InventoryCapacity = 4,
         },
-        CampSession = enteredRoundTrip,
+        CampSession = entered,
         EnteringPlayer = {
-            UserId = durableUser.UserId,
+            UserId = restorablePlayer.UserId,
             Name = 'RoundTrip',
         },
         EntryReason = 'maze_gate',
-        PlayerInventory = durableSummary,
+        PlayerInventory = inventoryService:getSummary(restorablePlayer),
         PendingUgcMonsterPayload = nil,
     })
-    local clonedSummary = contract.findPlayerInventory(roundTripTeleport, durableUser.UserId)
+    local clonedSummary = contract.findPlayerInventory(roundTripTeleport, restorablePlayer.UserId)
     assert(
         clonedSummary ~= nil and clonedSummary.HeldItem ~= nil,
-        'Contract teleport shaping should carry the durable inventory summary'
+        'Contract teleport shaping should preserve player inventories'
     )
     assert(
-        clonedSummary.HeldItem.CurrentState == 4,
-        'Contract clone should preserve CurrentState across maze teleport shaping'
-    )
-    local inventoryAfterContract = gameplay.Inventory.new(7)
-    assert(
-        inventoryAfterContract:loadSummary(clonedSummary) == true,
-        'Inventory should hydrate summaries produced by contract cloning'
+        clonedSummary.BackpackItems[1].ReadableTitle == 'Warning Note',
+        'Contract teleport shaping should preserve clue metadata'
     )
     assert(
-        inventoryAfterContract:getSummary().HeldItem.CurrentState == 4,
-        'Hydrated inventory should preserve contract-cloned CurrentState'
+        clonedSummary.MissionCount == 1,
+        'Contract teleport shaping should preserve mission counts'
     )
-
-    local cooldownToolPlayer = {
-        UserId = 203,
-    }
-    inventoryService:addPlayer(cooldownToolPlayer)
-    local pickupCooldownToolSuccess, cooldownToolEntry =
-        inventoryService:pickup(cooldownToolPlayer, toolItem)
-    assert(pickupCooldownToolSuccess == true, 'Runtime inventory should pick up cooldown tools')
-    local equipCooldownToolSuccess =
-        inventoryService:equip(cooldownToolPlayer, cooldownToolEntry.InstanceId)
-    assert(equipCooldownToolSuccess == true, 'Runtime inventory should equip cooldown tools')
-
-    local consumeAt100Success = inventoryService:consumeHeldItemState(cooldownToolPlayer, 100)
-    assert(consumeAt100Success == true, 'Tool should be usable before entering cooldown')
-
-    local consumeDuringCooldownSuccess, cooldownReason, remainingSeconds =
-        inventoryService:consumeHeldItemState(cooldownToolPlayer, 100.2)
-    assert(
-        consumeDuringCooldownSuccess == false and cooldownReason == 'Cooldown',
-        'Tool should reject use attempts during cooldown window'
-    )
-    assert(
-        remainingSeconds > 0 and remainingSeconds <= 0.3,
-        'Cooldown rejection should report remaining cooldown seconds'
-    )
-
-    local restoredInventory = gameplay.Inventory.new(7)
-    local restored = restoredInventory:loadSummary(serviceSummary)
-    assert(
-        restored == true,
-        'Inventory should restore a carried summary from teleport payload data'
-    )
-    assert(
-        restoredInventory:getSummary().HeldItem.InstanceId == serviceEntry.InstanceId,
-        'Restored inventory should preserve the held item'
-    )
-    assert(
-        restoredInventory:getSummary().HeldItem.Light ~= nil,
-        'Restored inventory should preserve held item light metadata'
-    )
-
-    local restoredToolInventory = gameplay.Inventory.new(7)
-    local restoredToolSummaryOk = restoredToolInventory:loadSummary(toolSummary)
-    assert(
-        restoredToolSummaryOk == true,
-        'Inventory should restore tool summaries with extended item fields intact'
-    )
-    assert(
-        restoredToolInventory:getSummary().HeldItem.KnockbackStrength == toolItem.KnockbackStrength,
-        'Inventory loadSummary should preserve extended item fields copied by the OOP surface'
-    )
-
-    local sellInventory = gameplay.Inventory.new(10)
-    local sellBackpackSuccess, sellBackpackEntry = sellInventory:add(items[2])
-    assert(sellBackpackSuccess == true, 'Sell test inventory should accept a backpack item')
-    local soldBackpackSuccess, soldBackpackItem, soldBackpackValue = sellInventory:sell(items[2].Id)
-    assert(soldBackpackSuccess == true, 'Inventory should sell matching backpack items by item id')
-    assert(
-        soldBackpackItem.InstanceId == sellBackpackEntry.InstanceId
-            and soldBackpackValue == items[2].Value,
-        'Selling from the backpack should return the sold item entry and its value'
-    )
-    assert(
-        sellInventory:getSummary().Count == 0,
-        'Selling the only backpack item should remove it from the inventory summary'
-    )
-
-    local heldSellSuccess, heldSellEntry = sellInventory:add(toolItem)
-    assert(heldSellSuccess == true, 'Sell test inventory should accept a held-item candidate')
-    local heldEquipSuccess = sellInventory:equip(heldSellEntry.InstanceId)
-    assert(heldEquipSuccess == true, 'Sell test inventory should equip the held-item candidate')
-    local soldHeldSuccess, soldHeldItem, soldHeldValue = sellInventory:sell(toolItem.Id)
-    assert(soldHeldSuccess == true, 'Inventory should sell a matching held item by item id')
-    assert(
-        soldHeldItem.InstanceId == heldSellEntry.InstanceId and soldHeldValue == toolItem.Value,
-        'Selling a held item should return the held entry and its value'
-    )
-    assert(
-        sellInventory:getSummary().HeldItem == nil,
-        'Selling the held item should clear the held slot'
-    )
-
-    local serviceSellPlayer = {
-        UserId = 204,
-    }
-    inventoryService:addPlayer(serviceSellPlayer)
-    local serviceSellPickupSuccess = inventoryService:pickup(serviceSellPlayer, items[2])
-    assert(
-        serviceSellPickupSuccess == true,
-        'Runtime inventory should pick up items before selling'
-    )
-    local serviceSoldSuccess, serviceSoldItem, serviceSoldValue =
-        inventoryService:sell(serviceSellPlayer, items[2].Id)
-    assert(serviceSoldSuccess == true, 'InventoryService should expose the restored sell facade')
-    assert(
-        serviceSoldItem.Id == items[2].Id and serviceSoldValue == items[2].Value,
-        'InventoryService sell should return the sold item and its value'
-    )
-    assert(
-        inventoryService:getSummary(serviceSellPlayer).Count == 0,
-        'InventoryService sell should remove the sold item from the player inventory'
-    )
-
-    local serviceDepositValue = inventoryService:deposit(fakePlayer)
-    assert(
-        serviceDepositValue == items[4].Value,
-        'Depositing should include the currently held item value'
-    )
-
-    local clearedServiceSummary = inventoryService:getSummary(fakePlayer)
-    assert(clearedServiceSummary.Count == 0, 'Deposit should clear the inventory count')
-    assert(clearedServiceSummary.HeldItem == nil, 'Deposit should clear the held slot')
 end

--- a/tests/src/Shared/ItemEntryFields.spec.luau
+++ b/tests/src/Shared/ItemEntryFields.spec.luau
@@ -32,6 +32,13 @@ return function()
         KnockbackStrength = 8,
         MeleeDamage = 2,
         HealHealthPips = 3,
+        ItemCategory = 'Clue',
+        MissionCount = 0,
+        ReadableTitle = 'Threat Note',
+        ReadableText = 'The first noise is bait.',
+        ClueId = 'threat-note',
+        ThreatHintId = 'echo-monster',
+        SourceMarkerId = 'ClueMarker_ThreatNote',
     }
 
     local copy = ItemFields.copyItemEntry(fixture)
@@ -62,11 +69,15 @@ return function()
 
     local summary = {
         Capacity = 8,
-        Weight = fixture.Weight,
+        Weight = 0,
         Count = 1,
         BackpackCount = 0,
         HeldCount = 1,
-        Value = fixture.Value,
+        Value = 0,
+        LootCount = 0,
+        ClueCount = 1,
+        ToolCount = 0,
+        MissionCount = 0,
         BackpackItems = {},
         HeldItem = fixture,
     }
@@ -100,5 +111,10 @@ return function()
     assert(
         ItemFields.copyItemEntry(fixture).HealHealthPips == viaContract.HeldItem.HealHealthPips,
         'Contract clone should match ItemFields for HealHealthPips'
+    )
+    assert(
+        viaContract.HeldItem.ReadableTitle == 'Threat Note'
+            and viaContract.HeldItem.ThreatHintId == 'echo-monster',
+        'Contract clone should preserve clue-readable metadata'
     )
 end

--- a/tests/src/Shared/MazeRunTracker.spec.luau
+++ b/tests/src/Shared/MazeRunTracker.spec.luau
@@ -3,18 +3,6 @@ return function()
     local shared = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared'))
     local gameplay = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Gameplay'))
     local tracker = gameplay.Session.MazeRunTracker.new()
-    local incompleteTracker = gameplay.Session.MazeRunTracker.new()
-
-    local completedBeforeExpedition, completedBeforeExpeditionReason =
-        incompleteTracker:completeExpedition()
-    assert(
-        completedBeforeExpedition == false,
-        'Direct completion should fail before the expedition starts'
-    )
-    assert(
-        completedBeforeExpeditionReason == 'InvalidState',
-        'Direct completion should expose InvalidState before expedition'
-    )
 
     assert(tracker:addPlayer({ UserId = 10, Name = 'Alpha' }) == true, 'First player should join')
     assert(tracker:addPlayer({ UserId = 20, Name = 'Bravo' }) == true, 'Second player should join')
@@ -30,10 +18,13 @@ return function()
     local earlyReturnRecorded, earlyReturnReason = tracker:recordReturn({
         UserId = 10,
         Name = 'Alpha',
-        ReturnReason = 'early_return',
-        Value = 18,
-        ItemCount = 1,
-        Weight = 2,
+        ReturnReason = 'extracted',
+        LootItemCount = 1,
+        ClueCount = 1,
+        ToolCount = 0,
+        MissionCount = 1,
+        ItemCount = 2,
+        WasExtracted = true,
     })
     assert(earlyReturnRecorded == true, earlyReturnReason or 'Early return should be recorded')
     assert(
@@ -43,60 +34,6 @@ return function()
     assert(
         tracker:getState() == shared.Enums.RunState.Expedition,
         'Early return should not force settlement'
-    )
-
-    local completedWithActivePlayers, completedWithActivePlayersReason =
-        tracker:completeExpedition()
-    assert(
-        completedWithActivePlayers == false,
-        'Direct completion should fail while active players remain'
-    )
-    assert(
-        completedWithActivePlayersReason == 'ActivePlayersRemaining',
-        'Direct completion should explain that active players still remain'
-    )
-
-    local directCompletionTracker = gameplay.Session.MazeRunTracker.new()
-    assert(
-        directCompletionTracker:addPlayer({ UserId = 30, Name = 'Charlie' }) == true,
-        'Direct completion tracker should accept a player'
-    )
-    assert(
-        directCompletionTracker:beginExpedition() == true,
-        'Direct completion tracker should enter expedition'
-    )
-
-    local directReturnRecorded, directReturnReason = directCompletionTracker:recordReturn({
-        UserId = 30,
-        Name = 'Charlie',
-        ReturnReason = 'extracted',
-        Value = 21,
-        ItemCount = 1,
-        Weight = 3,
-        WasExtracted = true,
-    })
-    assert(
-        directReturnRecorded == true,
-        directReturnReason or 'Final player return should be recorded for direct completion'
-    )
-    assert(
-        directCompletionTracker:getActiveCount() == 0,
-        'Direct completion tracker should have no active players left'
-    )
-
-    local expeditionCompleted, expeditionCompletedReason =
-        directCompletionTracker:completeExpedition()
-    assert(
-        expeditionCompleted == true,
-        expeditionCompletedReason or 'Direct expedition completion should succeed'
-    )
-    assert(
-        directCompletionTracker.IsCompleted == true,
-        'Direct completion should mark the tracker complete'
-    )
-    assert(
-        directCompletionTracker:getState() == shared.Enums.RunState.Settlement,
-        'Direct completion should end in settlement'
     )
 
     local extractionStarted, extractionReason = tracker:beginExtraction()
@@ -114,9 +51,11 @@ return function()
             UserId = 20,
             Name = 'Bravo',
             ReturnReason = 'settled',
-            Value = 42,
-            ItemCount = 2,
-            Weight = 4,
+            LootItemCount = 2,
+            ClueCount = 0,
+            ToolCount = 1,
+            MissionCount = 2,
+            ItemCount = 3,
             WasExtracted = true,
             WasSettled = true,
         },
@@ -133,8 +72,12 @@ return function()
 
     local summaries = tracker:getReturnedSummaries()
     assert(#summaries == 2, 'Both player summaries should be retained')
-    assert(summaries[1].ReturnReason == 'early_return', 'Early return should be preserved')
-    assert(summaries[2].WasSettled == true, 'Settlement summary should keep settled flag')
+    assert(summaries[1].ClueCount == 1, 'Tracker should preserve clue counts on returned summaries')
+    assert(summaries[2].ToolCount == 1, 'Tracker should preserve tool counts on returned summaries')
+    assert(
+        summaries[2].MissionCount == 2,
+        'Tracker should preserve mission counts on returned summaries'
+    )
 
     local canRejoin, rejoinReason = tracker:addPlayer({ UserId = 30, Name = 'Charlie' })
     assert(canRejoin == false, 'Completed trackers should reject new active players')

--- a/tests/src/Shared/SessionPhase.spec.luau
+++ b/tests/src/Shared/SessionPhase.spec.luau
@@ -3,49 +3,47 @@ return function()
     local shared = require(ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared'))
     local SessionPhase = shared.Session.SessionPhase
 
-    assert(SessionPhase.resolveFromCampSession({
-        GateOpen = false,
-        MazeStatus = 'idle',
-    }) == SessionPhase.RunPrep, 'Closed temple sessions should resolve to RunPrep')
-
     assert(
-        SessionPhase.resolveFromCampSession({
-            GateOpen = true,
-            MazeStatus = 'idle',
-        }) == SessionPhase.RunField,
-        'Open temple sessions without an active maze should resolve to RunField'
-    )
-    assert(
-        SessionPhase.resolveFromCampSession({
-            RoundStarted = true,
-            DangerActive = true,
-            MazeStatus = 'idle',
-        }) == SessionPhase.RunField,
-        'A live shared round should resolve to RunField even without relying on GateOpen'
+        SessionPhase.resolveFromCampSession({}) == SessionPhase.RunPrep,
+        'Default session should resolve to RunPrep'
     )
 
     assert(SessionPhase.resolveFromCampSession({
         GateOpen = true,
+        CurrentRound = 1,
+        MaxRounds = 5,
+    }) == SessionPhase.RunField, 'Open ship state should resolve to RunField')
+
+    assert(SessionPhase.resolveFromCampSession({
         MazeStatus = 'active',
         PlayersInMaze = {
             { UserId = 1, Name = 'Scout' },
         },
-    }) == SessionPhase.MazeActive, 'Active maze sessions should resolve to MazeActive')
+        CurrentRound = 1,
+        MaxRounds = 5,
+    }) == SessionPhase.MazeActive, 'Active maze state should resolve to MazeActive')
 
-    assert(SessionPhase.resolveFromCampSession({
-        GateOpen = true,
-        MazeStatus = 'completed',
-        ReturnedPlayerSummaries = {
-            { UserId = 1, ReturnReason = 'settled' },
-        },
-    }) == SessionPhase.Debrief, 'Completed or returned sessions should resolve to Debrief')
     assert(
         SessionPhase.resolveFromCampSession({
-            SettlementReason = 'book_settlement',
-            MazeStatus = 'idle',
-        }) == SessionPhase.Debrief,
-        'Explicit settlement should resolve to Debrief even before returned summaries arrive'
+            SettlementReason = 'timeout',
+            RoundOutcome = 'timeout',
+            CurrentRound = 2,
+            MaxRounds = 5,
+        }) == SessionPhase.RunIntermission,
+        'Mid-mission settlement should resolve to RunIntermission'
     )
+
+    assert(SessionPhase.resolveFromCampSession({
+        SessionOutcome = 'failure',
+        CurrentRound = 5,
+        MaxRounds = 5,
+    }) == SessionPhase.FinalDebrief, 'Resolved mission outcomes should resolve to FinalDebrief')
+
+    assert(SessionPhase.resolveFromCampSession({
+        SettlementReason = 'timeout',
+        CurrentRound = 5,
+        MaxRounds = 5,
+    }) == SessionPhase.FinalDebrief, 'Final-round settlement should resolve to FinalDebrief')
 
     assert(
         SessionPhase.resolveFromCampSession({


### PR DESCRIPTION
## what changed in player-facing terms

- Players now loop through a fixed 5-round Run -> Maze -> Run mission on the same authored maze instead of a one-shot expedition.
- Mission success is now based on how many loot items the team safely banks back at Run, not on pages, item value, or carry weight.
- Run now supports clue pickup as inventory items, so wilderness discoveries can be carried, dropped, recovered, and reused across later rounds.
- Maze progress is persistent within the session: banked loot stays banked, collected world loot does not respawn, and dropped inventory can be recovered in later rounds.
- Run and Maze client snapshots/UI now reflect round state, banked progress, and the new clue-vs-loot semantics.

## what changed in shared contract/runtime terms

- `CampMazeSessionContract`, `SessionPhase`, `MazeRunTracker`, and `SessionConfig` now stabilize the round-based mission-loop surface: `CurrentRound`, `MaxRounds`, `BankedItemCount`, `TargetItemCount`, `RoundOutcome`, and `SessionOutcome`.
- Inventory/runtime logic now distinguishes `Loot`, `Clue`, and `Tool`, with mission success driven by loot item count only.
- Shared inventory/session summaries now preserve clue/tool breakdowns and mission counts while keeping persistent maze world state for collected authored loot and dropped item recovery.
- `RunSessionService` and `MazeSessionService` now consume the round-based contract and persist the authored maze state across round transitions.
- `RunClueMarker` plus run-side interaction plumbing now support authored clue pickups that stay player-owned unless physically dropped and recovered by someone else.

## validation completed

- `stylua --check .`
- `selene .`
- `rojo build places/run/default.project.json -o /tmp/run-checkpoint.rbxlx`
- `rojo build places/maze/default.project.json -o /tmp/maze-checkpoint.rbxlx`
- `rojo build tests/default.project.json -o /tmp/roblox_experience-checkpoint-tests.rbxlx`
- Deterministic shared specs were updated in `tests/src/Shared/CampMazeSessionContract.spec.luau`, `tests/src/Shared/Inventory.spec.luau`, `tests/src/Shared/ItemEntryFields.spec.luau`, `tests/src/Shared/MazeRunTracker.spec.luau`, and `tests/src/Shared/SessionPhase.spec.luau` to match the new mission-loop contract.
- `run-in-roblox --place /tmp/roblox_experience-checkpoint-tests.rbxlx --script tests/run-in-roblox.lua` returned successfully in the checkpoint worktree.

## validation blocked by environment

- None in the latest checkpoint run. Earlier local attempts had hit a Studio-online timeout, but that blocker did not reproduce in this branch validation pass.

## known intentional compatibility leftovers

- `TeamPages`, `BookGoalAmount`, `BookGoalProgress`, and `BookGoalReached` still exist as transitional migration shims for older consumers.
- Some runtime/UI wording and service branching still reflect the previous single-expedition model and are intentionally not fully retired in this checkpoint architecture drop.
- Old `Book of Sand` / `Pages` / value-weight semantics are no longer the target design and should not drive future gameplay or UI work.

## linked follow-up issues

- #291 `cleanup: retire legacy run/maze mission compatibility after checkpoint`
- #292 `design: run wilderness clue layer and maze authored threat echo follow-up`
