### PR TITLE
docs: tighten run/maze vibe guidance after mission-loop refactor

### DIFF
--- a/places/maze/NOW.md
+++ b/places/maze/NOW.md
@@ -9,8 +9,8 @@
 
 ## Open Questions
 
-- When to split the still-shared run-flavored remote surface into a clearer
-  maze-specific transport contract.
+- When to stop reusing the still run-flavored shared remote surface and define a
+  clearer maze-specific transport contract.
 
 ## Temporary Exceptions
 

--- a/places/maze/NOW.md
+++ b/places/maze/NOW.md
@@ -22,3 +22,5 @@
 - Add more authored threat-tell nodes that explicitly echo wilderness clue text.
 - Replace remaining direct-boot wording that still sounds like a one-off
   expedition instead of a multi-round mission.
+- Keep authored room/door/loot behavior in dedicated maze scene modules instead
+  of letting `MazeSessionService` become the default home for every maze rule.

--- a/places/maze/VIBE.md
+++ b/places/maze/VIBE.md
@@ -45,6 +45,32 @@
   `places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau`
 - Place project file: `places/maze/default.project.json`
 
+### File Split Rules
+
+- `MazeSessionService.luau`
+  Own expedition orchestration, player lifecycle, round closure, and the calls
+  out to inventory/monster/transition modules. Do not grow authored room/door
+  binding details inline here when a scene module can own them.
+- `MazeWorldBuilder.luau`, `MazeScene.luau`, `MazeSceneRegistry.luau`
+  Own authored world assembly and scene-object registration. If a change is
+  about how the fixed maze is scanned or bound, start here before touching the
+  session service.
+- `MazeRoom.luau`, `MazeDoor.luau`, `MazeLootNode.luau`,
+  `MazeExtractionNode.luau`, `MazeSpawnPoint.luau`, `MazeRunPortal.luau`
+  Own one authored world primitive each. Keep room/door/loot/extract behavior
+  separated at this layer instead of routing every special case through the
+  session service.
+- `MazeInteractionRegistry.luau`
+  Own the mapping between bound scene objects and interaction callbacks. If an
+  interaction changes but the session flow does not, prefer updating the
+  registry and the relevant scene wrapper.
+- `MazeToRunTransition.luau`
+  Own the maze-to-run handoff only. Keep return payload shaping and transition
+  failure behavior isolated here.
+- `MazeLightingService.luau` and `MazeBootstrapStatus.luau`
+  Own presentation/bootstrap concerns only. Avoid mixing expedition rules into
+  these modules.
+
 ### Allowed Change Graph
 
 Owner zone:
@@ -92,9 +118,9 @@ Boundary interfaces:
 
 - `stylua --check .`
 - `selene .`
-- `rojo build places/maze/default.project.json -o .\\tmp\\maze.rbxlx`
+- `rojo build places/maze/default.project.json -o ./tmp/maze.rbxlx`
 - If shared handoff behavior changed:
-  `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`
+  `rojo build tests/default.project.json -o ./tmp/roblox_experience-tests.rbxlx`
 
 ## Notes
 

--- a/places/maze/VIBE.md
+++ b/places/maze/VIBE.md
@@ -65,6 +65,8 @@ No-touch zone:
 - `places/run/**` unless the issue is explicitly about the return seam
 - shared contract files when changing teleport shape, persistent-world state, or
   return summary semantics
+- shared contract files when changing remote naming or replicated snapshot
+  meaning across both places
 
 Boundary interfaces:
 
@@ -90,12 +92,17 @@ Boundary interfaces:
 
 - `stylua --check .`
 - `selene .`
-- `rojo build places/maze/default.project.json -o .\tmp\maze.rbxlx`
+- `rojo build places/maze/default.project.json -o .\\tmp\\maze.rbxlx`
 - If shared handoff behavior changed:
-  `rojo build tests/default.project.json -o .\tmp\roblox_experience-tests.rbxlx`
+  `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`
 
 ## Notes
 
 - The live maze path is authored-world scan/bind, not procgen.
 - Loot already banked at the ship must not respawn in later rounds.
 - Death drops and unrecovered clue items are part of the persistent mission state.
+- Keep maze-specific behavior inside maze modules whenever possible.
+- `MazeStaticWorld` is the formal runtime source for expedition content.
+- If a change makes the maze client or service read more and more like a run
+  clone, the seam is probably in the wrong place and should move toward
+  `contract` first.

--- a/places/run/NOW.md
+++ b/places/run/NOW.md
@@ -8,11 +8,14 @@
   round count, and mission outcome language.
 - Preserve authored clue markers and tower sightline as the main first-round
   teaching layer.
+- Keep `RunSessionService` as an orchestrator over authored scene objects and
+  transition adapters instead of a god object.
 
 ## Open Questions
 
 - When the shared `RunAction` / `RunSnapshot` / `PrivateState` surface should be
-  renamed to reflect cross-place mission semantics instead of legacy run naming.
+  renamed or split to reflect cross-place mission semantics instead of legacy
+  run naming.
 
 ## Temporary Exceptions
 

--- a/places/run/NOW.md
+++ b/places/run/NOW.md
@@ -27,3 +27,5 @@
 - Split remaining legacy camp/store UI assumptions away from the ship mission UI.
 - Add richer authored wilderness clue content now that the clue-item pipeline is
   in place.
+- Keep pushing world-binding logic into focused run modules instead of letting
+  `RunSessionService` absorb every new authored object rule.

--- a/places/run/VIBE.md
+++ b/places/run/VIBE.md
@@ -12,6 +12,7 @@
   players interpret maze threats and information gaps.
 - After each maze round, survivors return to the ship, bank loot automatically,
   regroup, and prepare for the next round.
+- This place is the orchestration center of the current vertical slice.
 
 ### Mental Model
 
@@ -20,6 +21,8 @@
 - `run` owns ship-side mission orchestration, wilderness clue discovery,
   round resets, and the run-to-maze transition handoff.
 - `run` does not own maze-side loot persistence or maze threat behavior.
+- `run` does not own the shared handoff schema itself; contract-level shape
+  changes still belong in shared files first.
 
 ### Key State Flow
 
@@ -39,6 +42,8 @@
 - Authored world layer:
   `RunWorldBuilder.luau`, `RunScene.luau`, `RunInteractionRegistry.luau`,
   `RunClueMarker.luau`, `RunToMazeTransition.luau`
+- Supporting services still heavily used by run:
+  `InventoryService.luau`, `MonsterService.luau`, `RoleService.luau`
 - Main client:
   `places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau`
 - Place project file: `places/run/default.project.json`
@@ -61,6 +66,7 @@ Direct dependency zone:
 
 No-touch zone:
 
+- `places/lobby/**` — lobby has been removed; if re-adding a lobby layer is needed, start with `packages/shared/VIBE.md`
 - `places/maze/**` unless the issue is explicitly about the run-to-maze seam
 - shared contract files when changing handoff schema, round-loop semantics, or
   replicated snapshot meaning
@@ -89,12 +95,16 @@ Boundary interfaces:
 
 - `stylua --check .`
 - `selene .`
-- `rojo build places/run/default.project.json -o .\tmp\run.rbxlx`
+- `rojo build places/run/default.project.json -o .\\tmp\\run.rbxlx`
 - If shared handoff behavior changed:
-  `rojo build tests/default.project.json -o .\tmp\roblox_experience-tests.rbxlx`
+  `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`
 
 ## Notes
 
 - `run` now presents a multi-round mission board, not a `Book of Sand` goal loop.
 - Clues are physical personal inventory items by default; they are not auto-shared.
 - The tower/maze pull should stay visually obvious even when clue content grows.
+- `run` is the easiest place to accidentally turn into a god object. Prefer
+  extracting local modules or contract-first seams over piling unrelated duties
+  into `RunSessionService`.
+- `RunStaticWorld` is the formal runtime source for camp and wilderness content.

--- a/places/run/VIBE.md
+++ b/places/run/VIBE.md
@@ -48,6 +48,38 @@
   `places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau`
 - Place project file: `places/run/default.project.json`
 
+### File Split Rules
+
+- `RunSessionService.luau`
+  Own round/session orchestration, remote handling, player lifecycle hooks, and
+  the calls out to other modules. Do not grow authored-scene binding details or
+  cross-place payload shaping inline here if a local adapter can own them.
+- `RunWorldBuilder.luau`, `RunScene.luau`, `RunInteractionRegistry.luau`
+  Own authored world assembly plus the mapping from tagged world instances into
+  usable runtime objects. Keep scene scanning/binding here instead of pushing it
+  up into `RunSessionService`.
+- `RunClueMarker.luau`, `RunDoor.luau`, `RunPortal.luau`, `RunTerminal.luau`,
+  `RunOceanTrigger.luau`, `RunSpawnPoint.luau`
+  Own one authored object family each. If a change is about one marker, prompt,
+  or trigger type, prefer extending the specific wrapper module rather than
+  stuffing more branching into the scene or session service.
+- `RunSnapshotBuilder.luau`
+  Own client-facing payload shaping only. If the question is "what should the
+  client see," the answer belongs here; if the question is "what is true in the
+  world," the answer belongs in a service or scene module.
+- `RunToMazeTransition.luau`
+  Own the run-to-maze handoff only. Keep teleport payload shaping and transition
+  error handling here instead of spreading it across unrelated run modules.
+- `RunStaticWorldContract.luau`, `RunStaticWorldValidator.luau`,
+  `RunWorldScanner.luau`
+  Own the authored-world contract and validation seam. Changes to world tags,
+  required markers, or scanner expectations should land here instead of being
+  hidden in higher-level orchestration.
+- `RunInventoryBridge.luau`, `ItemFunctionality.luau`,
+  `RunMonsterSpawnPolicy.luau`, `RunAreaResolver.luau`
+  Own focused helper domains. If a helper starts taking on multiple unrelated
+  responsibilities, split it again before adding more callers.
+
 ### Allowed Change Graph
 
 Owner zone:
@@ -95,9 +127,9 @@ Boundary interfaces:
 
 - `stylua --check .`
 - `selene .`
-- `rojo build places/run/default.project.json -o .\\tmp\\run.rbxlx`
+- `rojo build places/run/default.project.json -o ./tmp/run.rbxlx`
 - If shared handoff behavior changed:
-  `rojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`
+  `rojo build tests/default.project.json -o ./tmp/roblox_experience-tests.rbxlx`
 
 ## Notes
 


### PR DESCRIPTION
## What changed

- Tighten the `run` and `maze` `NOW.md` / `VIBE.md` docs after the mission-loop refactor landed.
- Make the place ownership boundaries more explicit so future work does not drift back toward lobby-era or god-object assumptions.
- Clarify when `run` / `maze` work should move into shared contract changes instead of accumulating more place-local coupling.

## Why

The mission-loop checkpoint changed the actual player flow and ownership model, but a few place-local docs still underspecified the new mental model. This PR sharpens the durable guidance for follow-up work so contributors treat `run` as ship/wilderness orchestration, `maze` as authored expedition runtime, and shared contract changes as a separate seam.

## Validation

- Docs-only change
- No runtime code or tests changed
