### PR TITLE
feat(maze): assemble static worlds from chunks and overlays

### DIFF
--- a/places/maze/assets/Chunks/MazeChunk_maze_v1.rbxmx
+++ b/places/maze/assets/Chunks/MazeChunk_maze_v1.rbxmx
@@ -1,0 +1,357 @@
+<?xml version="1.0" encoding="utf-8"?>
+<roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
+  <Meta name="ExplicitAutoJoints">true</Meta>
+  <External>null</External>
+  <External>nil</External>
+  <Item class="Model" referent="RBXMazeChunkRoot">
+    <Properties>
+      <string name="Name">MazeChunk_maze_v1</string>
+    </Properties>
+    <Item class="Model" referent="RBXMazeChunkTerrain">
+      <Properties>
+        <string name="Name">terrain</string>
+      </Properties>
+      <Item class="Part" referent="RBXMazeChunkTerrainFloor">
+        <Properties>
+          <string name="Name">Ground</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">true</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <Vector3 name="Size">
+            <X>160</X>
+            <Y>8</Y>
+            <Z>160</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>0</X>
+            <Y>-4</Y>
+            <Z>0</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+          <Color3 name="Color">
+            <R>0.29411765933036804</R>
+            <G>0.3176470696926117</G>
+            <B>0.2823529541492462</B>
+          </Color3>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="RBXMazeChunkTerrainShelf">
+        <Properties>
+          <string name="Name">NorthShelf</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">true</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <Vector3 name="Size">
+            <X>68</X>
+            <Y>4</Y>
+            <Z>40</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>-40</X>
+            <Y>2</Y>
+            <Z>-40</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+          <Color3 name="Color">
+            <R>0.3607843220233917</R>
+            <G>0.3490196168422699</G>
+            <B>0.32156863808631897</B>
+          </Color3>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="RBXMazeChunkTerrainSouthShelf">
+        <Properties>
+          <string name="Name">SouthShelf</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">true</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <Vector3 name="Size">
+            <X>54</X>
+            <Y>4</Y>
+            <Z>32</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>48</X>
+            <Y>2</Y>
+            <Z>40</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+          <Color3 name="Color">
+            <R>0.3607843220233917</R>
+            <G>0.3490196168422699</G>
+            <B>0.32156863808631897</B>
+          </Color3>
+        </Properties>
+      </Item>
+    </Item>
+    <Item class="Model" referent="RBXMazeChunkWalls">
+      <Properties>
+        <string name="Name">walls</string>
+      </Properties>
+      <Item class="Part" referent="RBXMazeChunkWallNorth">
+        <Properties>
+          <string name="Name">NorthWall</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">true</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <Vector3 name="Size">
+            <X>156</X>
+            <Y>20</Y>
+            <Z>6</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>0</X>
+            <Y>10</Y>
+            <Z>-77</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+          <Color3 name="Color">
+            <R>0.1568627506494522</R>
+            <G>0.16470588743686676</G>
+            <B>0.18039216101169586</B>
+          </Color3>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="RBXMazeChunkWallSouth">
+        <Properties>
+          <string name="Name">SouthWall</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">true</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <Vector3 name="Size">
+            <X>156</X>
+            <Y>20</Y>
+            <Z>6</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>0</X>
+            <Y>10</Y>
+            <Z>77</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+          <Color3 name="Color">
+            <R>0.1568627506494522</R>
+            <G>0.16470588743686676</G>
+            <B>0.18039216101169586</B>
+          </Color3>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="RBXMazeChunkWallWest">
+        <Properties>
+          <string name="Name">WestWall</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">true</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <Vector3 name="Size">
+            <X>6</X>
+            <Y>20</Y>
+            <Z>156</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>-77</X>
+            <Y>10</Y>
+            <Z>0</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+          <Color3 name="Color">
+            <R>0.1568627506494522</R>
+            <G>0.16470588743686676</G>
+            <B>0.18039216101169586</B>
+          </Color3>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="RBXMazeChunkWallEast">
+        <Properties>
+          <string name="Name">EastWall</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">true</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <Vector3 name="Size">
+            <X>6</X>
+            <Y>20</Y>
+            <Z>156</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>77</X>
+            <Y>10</Y>
+            <Z>0</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+          <Color3 name="Color">
+            <R>0.1568627506494522</R>
+            <G>0.16470588743686676</G>
+            <B>0.18039216101169586</B>
+          </Color3>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="RBXMazeChunkWallCenter">
+        <Properties>
+          <string name="Name">CentralSpine</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">true</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <Vector3 name="Size">
+            <X>18</X>
+            <Y>16</Y>
+            <Z>92</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>8</X>
+            <Y>8</Y>
+            <Z>6</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+          <Color3 name="Color">
+            <R>0.1882352977991104</R>
+            <G>0.19607843458652496</G>
+            <B>0.21176470816135406</B>
+          </Color3>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="RBXMazeChunkWallBranch">
+        <Properties>
+          <string name="Name">SouthBranch</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">true</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <Vector3 name="Size">
+            <X>74</X>
+            <Y>16</Y>
+            <Z>14</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>32</X>
+            <Y>8</Y>
+            <Z>28</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+          <Color3 name="Color">
+            <R>0.1882352977991104</R>
+            <G>0.19607843458652496</G>
+            <B>0.21176470816135406</B>
+          </Color3>
+        </Properties>
+      </Item>
+    </Item>
+    <Item class="Model" referent="RBXMazeChunkWater">
+      <Properties>
+        <string name="Name">water</string>
+      </Properties>
+      <Item class="Part" referent="RBXMazeChunkWaterPool">
+        <Properties>
+          <string name="Name">CentralPool</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">false</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <float name="Transparency">0.35</float>
+          <Vector3 name="Size">
+            <X>42</X>
+            <Y>2</Y>
+            <Z>24</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>28</X>
+            <Y>1</Y>
+            <Z>48</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+          <Color3 name="Color">
+            <R>0.125490203499794</R>
+            <G>0.4117647111415863</G>
+            <B>0.7607843279838562</B>
+          </Color3>
+        </Properties>
+      </Item>
+    </Item>
+  </Item>
+</roblox>

--- a/places/maze/assets/Overlays/MazeStaticWorldOverlay_Default.rbxmx
+++ b/places/maze/assets/Overlays/MazeStaticWorldOverlay_Default.rbxmx
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="utf-8"?>
+<roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
+  <Meta name="ExplicitAutoJoints">true</Meta>
+  <External>null</External>
+  <External>nil</External>
+  <Item class="Folder" referent="RBXMazeOverlayRoot">
+    <Properties>
+      <string name="Name">MazeStaticWorldOverlay_Default</string>
+    </Properties>
+    <Item class="Part" referent="RBXMazeOverlaySpawnMarker">
+      <Properties>
+        <string name="Name">SpawnMarker</string>
+        <bool name="Anchored">true</bool>
+        <bool name="CanCollide">false</bool>
+        <bool name="CanTouch">false</bool>
+        <bool name="CanQuery">true</bool>
+        <float name="Transparency">1</float>
+        <Vector3 name="Size">
+          <X>4</X>
+          <Y>1</Y>
+          <Z>4</Z>
+        </Vector3>
+        <CoordinateFrame name="CFrame">
+          <X>-52</X>
+          <Y>4</Y>
+          <Z>-48</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+      </Properties>
+    </Item>
+    <Item class="Part" referent="RBXMazeOverlayReturnHoldPad">
+      <Properties>
+        <string name="Name">ReturnHoldPad</string>
+        <bool name="Anchored">true</bool>
+        <bool name="CanCollide">false</bool>
+        <bool name="CanTouch">false</bool>
+        <bool name="CanQuery">true</bool>
+        <float name="Transparency">1</float>
+        <Vector3 name="Size">
+          <X>8</X>
+          <Y>1</Y>
+          <Z>8</Z>
+        </Vector3>
+        <CoordinateFrame name="CFrame">
+          <X>-56</X>
+          <Y>0.5</Y>
+          <Z>-56</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+      </Properties>
+      <Item class="ProximityPrompt" referent="RBXMazeOverlayReturnPrompt">
+        <Properties>
+          <string name="Name">Prompt</string>
+        </Properties>
+      </Item>
+    </Item>
+    <Item class="Model" referent="RBXMazeOverlayRoomCamp">
+      <Properties>
+        <string name="Name">Room_Camp</string>
+      </Properties>
+      <Item class="Part" referent="RBXMazeOverlayRoomCampShell">
+        <Properties>
+          <string name="Name">Shell</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">false</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <float name="Transparency">1</float>
+          <Vector3 name="Size">
+            <X>28</X>
+            <Y>12</Y>
+            <Z>28</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>-44</X>
+            <Y>6</Y>
+            <Z>-36</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+        </Properties>
+      </Item>
+    </Item>
+    <Item class="Model" referent="RBXMazeOverlayRoomLoot">
+      <Properties>
+        <string name="Name">Room_Loot</string>
+      </Properties>
+      <Item class="Part" referent="RBXMazeOverlayRoomLootShell">
+        <Properties>
+          <string name="Name">Shell</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">false</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <float name="Transparency">1</float>
+          <Vector3 name="Size">
+            <X>34</X>
+            <Y>12</Y>
+            <Z>34</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>6</X>
+            <Y>6</Y>
+            <Z>-2</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="RBXMazeOverlayRoomLootSpawnPoint">
+        <Properties>
+          <string name="Name">SpawnPoint_1</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">false</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <float name="Transparency">1</float>
+          <Vector3 name="Size">
+            <X>2</X>
+            <Y>1</Y>
+            <Z>2</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>0</X>
+            <Y>2</Y>
+            <Z>-2</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="RBXMazeOverlayRoomLootSocket">
+        <Properties>
+          <string name="Name">LootSocket_1</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">false</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <float name="Transparency">1</float>
+          <Vector3 name="Size">
+            <X>2</X>
+            <Y>1</Y>
+            <Z>2</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>12</X>
+            <Y>2</Y>
+            <Z>-4</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="RBXMazeOverlayRoomLootPromptPart">
+        <Properties>
+          <string name="Name">LootPrompt</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">false</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <float name="Transparency">1</float>
+          <Vector3 name="Size">
+            <X>2</X>
+            <Y>1</Y>
+            <Z>2</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>12</X>
+            <Y>2</Y>
+            <Z>-4</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+        </Properties>
+        <Item class="ProximityPrompt" referent="RBXMazeOverlayRoomLootPrompt">
+          <Properties>
+            <string name="Name">Prompt</string>
+          </Properties>
+        </Item>
+      </Item>
+      <Item class="Part" referent="RBXMazeOverlayRoomDoorway">
+        <Properties>
+          <string name="Name">Doorway_East</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">true</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <float name="Transparency">1</float>
+          <Vector3 name="Size">
+            <X>6</X>
+            <Y>8</Y>
+            <Z>2</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>22</X>
+            <Y>4</Y>
+            <Z>-2</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+        </Properties>
+        <Item class="ProximityPrompt" referent="RBXMazeOverlayRoomDoorwayPrompt">
+          <Properties>
+            <string name="Name">Prompt</string>
+          </Properties>
+        </Item>
+      </Item>
+    </Item>
+    <Item class="Model" referent="RBXMazeOverlayRoomExtraction">
+      <Properties>
+        <string name="Name">Room_Extraction</string>
+      </Properties>
+      <Item class="Part" referent="RBXMazeOverlayRoomExtractionShell">
+        <Properties>
+          <string name="Name">Shell</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">false</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <float name="Transparency">1</float>
+          <Vector3 name="Size">
+            <X>28</X>
+            <Y>12</Y>
+            <Z>28</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>54</X>
+            <Y>6</Y>
+            <Z>42</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="RBXMazeOverlayExtractionMarker">
+        <Properties>
+          <string name="Name">ExtractionMarker</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">false</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <float name="Transparency">1</float>
+          <Vector3 name="Size">
+            <X>6</X>
+            <Y>1</Y>
+            <Z>6</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>54</X>
+            <Y>2</Y>
+            <Z>42</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+        </Properties>
+        <Item class="ProximityPrompt" referent="RBXMazeOverlayExtractionPrompt">
+          <Properties>
+            <string name="Name">Prompt</string>
+          </Properties>
+        </Item>
+      </Item>
+    </Item>
+  </Item>
+</roblox>

--- a/places/maze/default.project.json
+++ b/places/maze/default.project.json
@@ -29,110 +29,26 @@
           "ToolPotion": {
             "$path": "../../assets/ToolTemplates/ToolPotion.rbxmx"
           }
+        },
+        "Maze": {
+          "$className": "Folder",
+          "Chunks": {
+            "$className": "Folder",
+            "MazeChunk_maze_v1": {
+              "$path": "assets/Chunks/MazeChunk_maze_v1.rbxmx"
+            }
+          },
+          "Overlays": {
+            "$className": "Folder",
+            "MazeStaticWorldOverlay_Default": {
+              "$path": "assets/Overlays/MazeStaticWorldOverlay_Default.rbxmx"
+            }
+          }
         }
       }
     },
     "Workspace": {
-      "$className": "Workspace",
-      "MazeStaticWorld": {
-        "$className": "Folder",
-        "SpawnMarker": {
-          "$className": "Part",
-          "$properties": {
-            "Anchored": true
-          }
-        },
-        "ReturnHoldPad": {
-          "$className": "Part",
-          "$properties": {
-            "Anchored": true
-          },
-          "Prompt": {
-            "$className": "ProximityPrompt"
-          }
-        },
-        "Room_Camp": {
-          "$className": "Model",
-          "$attributes": {
-            "RoomType": "OpenHub",
-            "IsCamp": true,
-            "DifficultyTier": 0
-          },
-          "Shell": {
-            "$className": "Part",
-            "$properties": {
-              "Anchored": true
-            }
-          }
-        },
-        "Room_Loot": {
-          "$className": "Model",
-          "$attributes": {
-            "RoomType": "DeadEnd",
-            "HasMonsterSpawner": true,
-            "DifficultyTier": 2,
-            "MonsterBudget": 2
-          },
-          "Shell": {
-            "$className": "Part",
-            "$properties": {
-              "Anchored": true
-            }
-          },
-          "SpawnPoint_1": {
-            "$className": "Part",
-            "$properties": {
-              "Anchored": true
-            }
-          },
-          "LootSocket_1": {
-            "$className": "Part",
-            "$properties": {
-              "Anchored": true
-            }
-          },
-          "LootPrompt": {
-            "$className": "Part",
-            "$properties": {
-              "Anchored": true
-            },
-            "Prompt": {
-              "$className": "ProximityPrompt"
-            }
-          },
-          "Doorway_East": {
-            "$className": "Part",
-            "$properties": {
-              "Anchored": true
-            },
-            "Prompt": {
-              "$className": "ProximityPrompt"
-            }
-          }
-        },
-        "Room_Extraction": {
-          "$className": "Model",
-          "$attributes": {
-            "RoomType": "Straight",
-            "IsExtraction": true
-          },
-          "Shell": {
-            "$className": "Part",
-            "$properties": {
-              "Anchored": true
-            }
-          },
-          "ExtractionMarker": {
-            "$className": "Part",
-            "$properties": {
-              "Anchored": true
-            },
-            "Prompt": {
-              "$className": "ProximityPrompt"
-            }
-          }
-        }
-      }
+      "$className": "Workspace"
     },
     "ServerScriptService": {
       "$className": "ServerScriptService",

--- a/places/maze/src/ServerScriptService/Maze/MazeChunkManifest.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeChunkManifest.luau
@@ -1,0 +1,9 @@
+local MazeChunkManifest = table.freeze({
+    table.freeze({
+        ChunkId = 'maze.3dm',
+        AssetName = 'MazeChunk_maze_v1',
+        Enabled = true,
+    }),
+})
+
+return MazeChunkManifest

--- a/places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau
@@ -37,7 +37,10 @@ end
 local function requirePrompt(part, contextLabel)
     local prompt = part:FindFirstChildOfClass('ProximityPrompt')
     if prompt == nil then
-        error(string.format('%s part "%s" is missing a ProximityPrompt.', contextLabel, part.Name), 0)
+        error(
+            string.format('%s part "%s" is missing a ProximityPrompt.', contextLabel, part.Name),
+            0
+        )
     end
 
     return prompt
@@ -172,6 +175,8 @@ local function cloneOverlayAsset(overlayAsset, root)
         end
     end
 
+    -- MazeWorldScanner only binds gameplay nodes that are direct room children,
+    -- so the overlay authoring contract keeps these prompt parts at that level.
     requirePrompt(
         requireBasePart(lootRoom, 'LootPrompt', 'Maze static world overlay'),
         'Maze static world overlay'

--- a/places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau
@@ -1,0 +1,220 @@
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local Workspace = game:GetService('Workspace')
+
+local MazeChunkManifest = require(script.Parent.MazeChunkManifest)
+local MazeStaticWorldContract = require(script.Parent.MazeStaticWorldContract)
+local MazeStaticWorldOverlayManifest = require(script.Parent.MazeStaticWorldOverlayManifest)
+
+local MazeStaticWorldAssembler = {}
+
+local function requireFolder(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not child:IsA('Folder') then
+        error(string.format('%s is missing required Folder "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function requireAsset(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not (child:IsA('Folder') or child:IsA('Model')) then
+        error(string.format('%s is missing required asset "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function requireBasePart(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not child:IsA('BasePart') then
+        error(string.format('%s is missing required part "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function requirePrompt(part, contextLabel)
+    local prompt = part:FindFirstChildOfClass('ProximityPrompt')
+    if prompt == nil then
+        error(string.format('%s part "%s" is missing a ProximityPrompt.', contextLabel, part.Name), 0)
+    end
+
+    return prompt
+end
+
+local function getMazeAssets()
+    local assetsRoot = requireFolder(
+        ReplicatedStorage,
+        MazeStaticWorldContract.AssetsRootName,
+        'ReplicatedStorage'
+    )
+    local mazeAssets = requireFolder(
+        assetsRoot,
+        MazeStaticWorldContract.MazeAssetsFolderName,
+        'ReplicatedStorage.Assets'
+    )
+    local chunkAssets = requireFolder(
+        mazeAssets,
+        MazeStaticWorldContract.ChunksFolderName,
+        'ReplicatedStorage.Assets.Maze'
+    )
+    local overlayAssets = requireFolder(
+        mazeAssets,
+        MazeStaticWorldContract.OverlaysFolderName,
+        'ReplicatedStorage.Assets.Maze'
+    )
+
+    return chunkAssets, overlayAssets
+end
+
+local function createRoot()
+    local existing = Workspace:FindFirstChild(MazeStaticWorldContract.RootName)
+    if existing ~= nil then
+        existing:Destroy()
+    end
+
+    local root = Instance.new('Folder')
+    root.Name = MazeStaticWorldContract.RootName
+    root.Parent = Workspace
+    root:SetAttribute('BuildFingerprint', MazeStaticWorldContract.BuildFingerprint)
+
+    local sceneryRoot = Instance.new('Folder')
+    sceneryRoot.Name = MazeStaticWorldContract.SceneryFolderName
+    sceneryRoot.Parent = root
+
+    return root, sceneryRoot
+end
+
+local function stabilizeChunkGeometry(chunkModel)
+    for _, descendant in ipairs(chunkModel:GetDescendants()) do
+        if descendant:IsA('BasePart') then
+            descendant.Anchored = true
+            descendant.CanTouch = false
+            descendant.CanQuery = true
+            descendant:SetAttribute('IsScenery', true)
+        end
+    end
+end
+
+local function cloneChunkAsset(chunkAsset, chunkDefinition, sceneryRoot)
+    if not chunkAsset:IsA('Model') then
+        error(
+            string.format(
+                'Maze chunk asset "%s" must be authored as a Model.',
+                chunkDefinition.AssetName
+            ),
+            0
+        )
+    end
+
+    local clone = chunkAsset:Clone()
+    clone.Name = chunkDefinition.ChunkId
+    clone.Parent = sceneryRoot
+    stabilizeChunkGeometry(clone)
+    if chunkDefinition.Transform ~= nil then
+        clone:PivotTo(chunkDefinition.Transform)
+    end
+end
+
+local function applyRoomAttributes(room, definition)
+    for attributeName, attributeValue in pairs(definition) do
+        room:SetAttribute(attributeName, attributeValue)
+    end
+end
+
+local function cloneOverlayAsset(overlayAsset, root)
+    for _, child in ipairs(overlayAsset:GetChildren()) do
+        local clone = child:Clone()
+        clone.Parent = root
+    end
+
+    for _, partName in ipairs(MazeStaticWorldOverlayManifest.RootParts) do
+        requireBasePart(root, partName, 'Maze static world overlay')
+    end
+
+    requirePrompt(
+        requireBasePart(root, 'ReturnHoldPad', 'Maze static world overlay'),
+        'Maze static world overlay'
+    )
+
+    for roomName, definition in pairs(MazeStaticWorldOverlayManifest.Rooms) do
+        local room = root:FindFirstChild(roomName)
+        if room == nil or not room:IsA('Model') then
+            error(
+                string.format(
+                    'Maze static world overlay is missing required room model "%s".',
+                    roomName
+                ),
+                0
+            )
+        end
+
+        applyRoomAttributes(room, definition)
+    end
+
+    local lootRoom = root:FindFirstChild('Room_Loot')
+    local extractionRoom = root:FindFirstChild('Room_Extraction')
+    if lootRoom == nil or extractionRoom == nil then
+        error('Maze static world overlay must define Room_Loot and Room_Extraction.', 0)
+    end
+
+    for _, nodeName in ipairs(MazeStaticWorldOverlayManifest.RequiredInteractionNodes) do
+        local node = root:FindFirstChild(nodeName, true)
+        if node == nil then
+            error(
+                string.format(
+                    'Maze static world overlay is missing required interaction node "%s".',
+                    nodeName
+                ),
+                0
+            )
+        end
+    end
+
+    requirePrompt(
+        requireBasePart(lootRoom, 'LootPrompt', 'Maze static world overlay'),
+        'Maze static world overlay'
+    )
+    requirePrompt(
+        requireBasePart(lootRoom, 'Doorway_East', 'Maze static world overlay'),
+        'Maze static world overlay'
+    )
+    requirePrompt(
+        requireBasePart(extractionRoom, 'ExtractionMarker', 'Maze static world overlay'),
+        'Maze static world overlay'
+    )
+end
+
+function MazeStaticWorldAssembler.assemble()
+    local chunkAssets, overlayAssets = getMazeAssets()
+    local root, sceneryRoot = createRoot()
+
+    local overlayAsset = requireAsset(
+        overlayAssets,
+        MazeStaticWorldContract.OverlayAssetName,
+        'ReplicatedStorage.Assets.Maze.Overlays'
+    )
+    cloneOverlayAsset(overlayAsset, root)
+
+    local enabledChunkCount = 0
+    for _, chunkDefinition in ipairs(MazeChunkManifest) do
+        if chunkDefinition.Enabled ~= false then
+            local chunkAsset = requireAsset(
+                chunkAssets,
+                chunkDefinition.AssetName,
+                'ReplicatedStorage.Assets.Maze.Chunks'
+            )
+            cloneChunkAsset(chunkAsset, chunkDefinition, sceneryRoot)
+            enabledChunkCount += 1
+        end
+    end
+
+    if enabledChunkCount == 0 then
+        error('Maze chunk manifest must enable at least one geometry chunk.', 0)
+    end
+
+    return root
+end
+
+return MazeStaticWorldAssembler

--- a/places/maze/src/ServerScriptService/Maze/MazeStaticWorldContract.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeStaticWorldContract.luau
@@ -1,0 +1,12 @@
+local MazeStaticWorldContract = table.freeze({
+    RootName = 'MazeStaticWorld',
+    AssetsRootName = 'Assets',
+    MazeAssetsFolderName = 'Maze',
+    ChunksFolderName = 'Chunks',
+    OverlaysFolderName = 'Overlays',
+    SceneryFolderName = 'Scenery',
+    OverlayAssetName = 'MazeStaticWorldOverlay_Default',
+    BuildFingerprint = 'maze-static-chunk-v1',
+})
+
+return MazeStaticWorldContract

--- a/places/maze/src/ServerScriptService/Maze/MazeStaticWorldOverlayManifest.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeStaticWorldOverlayManifest.luau
@@ -1,0 +1,51 @@
+local function freezeRoomDefinition(definition)
+    return table.freeze({
+        RoomType = definition.RoomType,
+        IsCamp = definition.IsCamp or false,
+        IsExtraction = definition.IsExtraction or false,
+        DifficultyTier = definition.DifficultyTier or 1,
+        MonsterBudget = definition.MonsterBudget or 0,
+        LootBudget = definition.LootBudget or 0,
+        RoomTemplateId = definition.RoomTemplateId or definition.RoomType,
+        RoomCategory = definition.RoomCategory or definition.RoomType,
+    })
+end
+
+local MazeStaticWorldOverlayManifest = table.freeze({
+    RootParts = table.freeze({
+        'SpawnMarker',
+        'ReturnHoldPad',
+    }),
+    Rooms = table.freeze({
+        Room_Camp = freezeRoomDefinition({
+            RoomType = 'OpenHub',
+            IsCamp = true,
+            DifficultyTier = 0,
+            RoomTemplateId = 'CampHub',
+            RoomCategory = 'CampHub',
+        }),
+        Room_Loot = freezeRoomDefinition({
+            RoomType = 'DeadEnd',
+            DifficultyTier = 2,
+            MonsterBudget = 2,
+            LootBudget = 1,
+            RoomTemplateId = 'SearchCluster',
+            RoomCategory = 'SearchCluster',
+        }),
+        Room_Extraction = freezeRoomDefinition({
+            RoomType = 'Straight',
+            IsExtraction = true,
+            DifficultyTier = 1,
+            RoomTemplateId = 'ExtractionLane',
+            RoomCategory = 'ExtractionLane',
+        }),
+    }),
+    RequiredInteractionNodes = table.freeze({
+        'LootPrompt',
+        'LootSocket_1',
+        'Doorway_East',
+        'ExtractionMarker',
+    }),
+})
+
+return MazeStaticWorldOverlayManifest

--- a/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
@@ -1,5 +1,3 @@
-local Workspace = game:GetService('Workspace')
-
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
@@ -7,25 +5,11 @@ local Shared = require(Packages:WaitForChild('Shared'))
 
 local MazeScene = require(script.Parent.MazeScene)
 local MazeStaticWorldAssembler = require(script.Parent.MazeStaticWorldAssembler)
-local MazeStaticWorldContract = require(script.Parent.MazeStaticWorldContract)
 
 local MazeWorldBuilder = {}
 
 function MazeWorldBuilder.build()
     local staticWorldRoot = MazeStaticWorldAssembler.assemble()
-    if staticWorldRoot == nil then
-        staticWorldRoot = Workspace:FindFirstChild(MazeStaticWorldContract.RootName)
-    end
-
-    if staticWorldRoot == nil then
-        error(
-            string.format(
-                'Workspace is missing required authored root "%s".',
-                MazeStaticWorldContract.RootName
-            ),
-            0
-        )
-    end
 
     if not (staticWorldRoot:IsA('Folder') or staticWorldRoot:IsA('Model')) then
         error('MazeStaticWorld must be a Folder or Model.', 0)

--- a/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
@@ -6,14 +6,25 @@ local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Shared = require(Packages:WaitForChild('Shared'))
 
 local MazeScene = require(script.Parent.MazeScene)
+local MazeStaticWorldAssembler = require(script.Parent.MazeStaticWorldAssembler)
+local MazeStaticWorldContract = require(script.Parent.MazeStaticWorldContract)
 
 local MazeWorldBuilder = {}
-local STATIC_WORLD_ROOT_NAME = 'MazeStaticWorld'
 
 function MazeWorldBuilder.build()
-    local staticWorldRoot = Workspace:FindFirstChild(STATIC_WORLD_ROOT_NAME)
+    local staticWorldRoot = MazeStaticWorldAssembler.assemble()
     if staticWorldRoot == nil then
-        error('Workspace is missing required authored root "MazeStaticWorld".', 0)
+        staticWorldRoot = Workspace:FindFirstChild(MazeStaticWorldContract.RootName)
+    end
+
+    if staticWorldRoot == nil then
+        error(
+            string.format(
+                'Workspace is missing required authored root "%s".',
+                MazeStaticWorldContract.RootName
+            ),
+            0
+        )
     end
 
     if not (staticWorldRoot:IsA('Folder') or staticWorldRoot:IsA('Model')) then

--- a/tests/default.project.json
+++ b/tests/default.project.json
@@ -29,6 +29,21 @@
           "ToolPotion": {
             "$path": "../assets/ToolTemplates/ToolPotion.rbxmx"
           }
+        },
+        "Maze": {
+          "$className": "Folder",
+          "Chunks": {
+            "$className": "Folder",
+            "MazeChunk_maze_v1": {
+              "$path": "../places/maze/assets/Chunks/MazeChunk_maze_v1.rbxmx"
+            }
+          },
+          "Overlays": {
+            "$className": "Folder",
+            "MazeStaticWorldOverlay_Default": {
+              "$path": "../places/maze/assets/Overlays/MazeStaticWorldOverlay_Default.rbxmx"
+            }
+          }
         }
       },
       "PlaceModules": {

--- a/tests/src/Shared/MazeStaticWorldAssembler.spec.luau
+++ b/tests/src/Shared/MazeStaticWorldAssembler.spec.luau
@@ -1,0 +1,99 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local Workspace = game:GetService('Workspace')
+
+    local packages = ReplicatedStorage:WaitForChild('Packages')
+    local shared = require(packages:WaitForChild('Shared'))
+    local mazeModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
+    local MazeStaticWorldAssembler = require(mazeModules:WaitForChild('MazeStaticWorldAssembler'))
+    local MazeStaticWorldContract = require(mazeModules:WaitForChild('MazeStaticWorldContract'))
+    local MazeWorldBuilder = require(mazeModules:WaitForChild('MazeWorldBuilder'))
+
+    local root = MazeStaticWorldAssembler.assemble()
+    assert(root.Name == MazeStaticWorldContract.RootName, 'Assembler should create MazeStaticWorld root')
+
+    local sceneryRoot = root:FindFirstChild(MazeStaticWorldContract.SceneryFolderName)
+    assert(
+        sceneryRoot ~= nil and sceneryRoot:IsA('Folder'),
+        'Assembler should place geometry chunks under MazeStaticWorld/Scenery'
+    )
+
+    local chunkModel = sceneryRoot:FindFirstChild('maze.3dm')
+    assert(
+        chunkModel ~= nil and chunkModel:IsA('Model'),
+        'Assembler should clone the enabled manifest chunk into the scenery root'
+    )
+
+    local geometryGroups = {
+        terrain = false,
+        walls = false,
+        water = false,
+    }
+    for groupName in pairs(geometryGroups) do
+        local group = chunkModel:FindFirstChild(groupName)
+        geometryGroups[groupName] = group ~= nil and group:IsA('Model')
+    end
+    assert(
+        geometryGroups.terrain and geometryGroups.walls and geometryGroups.water,
+        'First maze chunk should preserve terrain/walls/water geometry groupings'
+    )
+
+    local scanResult = shared.Runtime.MazeWorldScanner.Scan(root)
+    local roomIds = shared.Runtime.MazeWorldScanner.GetRoomIds(scanResult)
+    assert(#roomIds == 3, 'Assembler should expose the overlay rooms without treating scenery as rooms')
+    assert(
+        table.find(roomIds, 'maze.3dm') == nil,
+        'Geometry chunk containers under Scenery must be ignored by the runtime scanner'
+    )
+
+    local world = shared.Runtime.MazeWorldScanner.BuildStaticWorld(root)
+    assert(world.LootNodes.Room_Loot ~= nil, 'Assembled world should still expose overlay-authored loot nodes')
+    assert(
+        world.Doorways['Room_Loot:Doorway_East'] ~= nil,
+        'Assembled world should still expose overlay-authored doorway nodes'
+    )
+    assert(
+        next(world.ExtractionNodes) ~= nil,
+        'Assembled world should still expose overlay-authored extraction nodes'
+    )
+
+    local scene = MazeWorldBuilder.build()
+    assert(scene.Root.Name == MazeStaticWorldContract.RootName, 'World builder should assemble before scanning')
+    assert(
+        scene:getLootNode('Room_Loot') ~= nil,
+        'World builder should produce a MazeScene from the assembled static world'
+    )
+
+    local overlayAsset = ReplicatedStorage.Assets.Maze.Overlays:FindFirstChild(
+        MazeStaticWorldContract.OverlayAssetName
+    )
+    assert(overlayAsset ~= nil, 'Tests should mount the maze overlay asset in ReplicatedStorage.Assets.Maze')
+
+    local savedSpawnMarker = overlayAsset:FindFirstChild('SpawnMarker')
+    local spawnMarkerClone = savedSpawnMarker and savedSpawnMarker:Clone()
+    if savedSpawnMarker ~= nil then
+        savedSpawnMarker:Destroy()
+    end
+
+    local brokenOk, brokenErr = pcall(function()
+        MazeStaticWorldAssembler.assemble()
+    end)
+
+    if spawnMarkerClone ~= nil then
+        spawnMarkerClone.Parent = overlayAsset
+    end
+
+    assert(
+        brokenOk == false,
+        'Assembler should fail loudly when the overlay asset is missing a required authored marker'
+    )
+    assert(
+        string.find(tostring(brokenErr), 'SpawnMarker', 1, true) ~= nil,
+        'Missing overlay marker failures should mention the missing authored node'
+    )
+
+    local finalRoot = Workspace:FindFirstChild(MazeStaticWorldContract.RootName)
+    if finalRoot ~= nil then
+        finalRoot:Destroy()
+    end
+end

--- a/tests/src/Shared/MazeStaticWorldAssembler.spec.luau
+++ b/tests/src/Shared/MazeStaticWorldAssembler.spec.luau
@@ -10,7 +10,10 @@ return function()
     local MazeWorldBuilder = require(mazeModules:WaitForChild('MazeWorldBuilder'))
 
     local root = MazeStaticWorldAssembler.assemble()
-    assert(root.Name == MazeStaticWorldContract.RootName, 'Assembler should create MazeStaticWorld root')
+    assert(
+        root.Name == MazeStaticWorldContract.RootName,
+        'Assembler should create MazeStaticWorld root'
+    )
 
     local sceneryRoot = root:FindFirstChild(MazeStaticWorldContract.SceneryFolderName)
     assert(
@@ -40,14 +43,20 @@ return function()
 
     local scanResult = shared.Runtime.MazeWorldScanner.Scan(root)
     local roomIds = shared.Runtime.MazeWorldScanner.GetRoomIds(scanResult)
-    assert(#roomIds == 3, 'Assembler should expose the overlay rooms without treating scenery as rooms')
+    assert(
+        #roomIds == 3,
+        'Assembler should expose the overlay rooms without treating scenery as rooms'
+    )
     assert(
         table.find(roomIds, 'maze.3dm') == nil,
         'Geometry chunk containers under Scenery must be ignored by the runtime scanner'
     )
 
     local world = shared.Runtime.MazeWorldScanner.BuildStaticWorld(root)
-    assert(world.LootNodes.Room_Loot ~= nil, 'Assembled world should still expose overlay-authored loot nodes')
+    assert(
+        world.LootNodes.Room_Loot ~= nil,
+        'Assembled world should still expose overlay-authored loot nodes'
+    )
     assert(
         world.Doorways['Room_Loot:Doorway_East'] ~= nil,
         'Assembled world should still expose overlay-authored doorway nodes'
@@ -58,7 +67,10 @@ return function()
     )
 
     local scene = MazeWorldBuilder.build()
-    assert(scene.Root.Name == MazeStaticWorldContract.RootName, 'World builder should assemble before scanning')
+    assert(
+        scene.Root.Name == MazeStaticWorldContract.RootName,
+        'World builder should assemble before scanning'
+    )
     assert(
         scene:getLootNode('Room_Loot') ~= nil,
         'World builder should produce a MazeScene from the assembled static world'
@@ -67,7 +79,10 @@ return function()
     local overlayAsset = ReplicatedStorage.Assets.Maze.Overlays:FindFirstChild(
         MazeStaticWorldContract.OverlayAssetName
     )
-    assert(overlayAsset ~= nil, 'Tests should mount the maze overlay asset in ReplicatedStorage.Assets.Maze')
+    assert(
+        overlayAsset ~= nil,
+        'Tests should mount the maze overlay asset in ReplicatedStorage.Assets.Maze'
+    )
 
     local savedSpawnMarker = overlayAsset:FindFirstChild('SpawnMarker')
     local spawnMarkerClone = savedSpawnMarker and savedSpawnMarker:Clone()


### PR DESCRIPTION
## Summary
- replace the inline maze static world placeholder with a chunk + overlay asset flow
- add a place-local maze static world assembler, chunk manifest, and overlay manifest
- wire the maze place and tests project to mount maze chunk/overlay assets from the repo
- add deterministic coverage for assembled maze static worlds and scanner compatibility

## Validation
- ojo build places/maze/default.project.json -o .\\tmp\\maze.rbxlx`n- ojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx`n- stylua --check . could not run in this environment because stylua is not installed on PATH
- selene . could not run in this environment because selene is not installed on PATH