### PR TITLE
feat(maze): move monster spawn points under MonsterSpawns

### DIFF
--- a/packages/shared/src/Runtime/MazeWorldScanner.luau
+++ b/packages/shared/src/Runtime/MazeWorldScanner.luau
@@ -175,6 +175,10 @@ local function collectSpawnPoints(roomInstance)
     return collectNamedPoints(monsterSpawns, 'SpawnPoint', 'Unknown')
 end
 
+local function requiresMonsterPatrolAnchors(room, affordance)
+    return room.MonsterBudget > 0 or affordance.HasMonsterSpawner
+end
+
 local function collectLootSockets(roomInstance)
     return collectNamedPoints(roomInstance, 'LootSocket', 'Unknown')
 end
@@ -495,7 +499,17 @@ function MazeWorldScanner.BuildStaticWorld(scanRoot)
             end
         end
 
-        if room.MonsterBudget > 0 or affordance.HasMonsterSpawner then
+        if requiresMonsterPatrolAnchors(room, affordance) and #affordance.PatrolAnchors == 0 then
+            error(
+                string.format(
+                    'Maze room "%s" requires authored MonsterSpawns/SpawnPoint_* patrol anchors.',
+                    roomId
+                ),
+                0
+            )
+        end
+
+        if requiresMonsterPatrolAnchors(room, affordance) then
             for _, patrolAnchor in ipairs(affordance.PatrolAnchors) do
                 table.insert(patrolPoints, patrolAnchor.Position)
             end

--- a/packages/shared/src/Runtime/MazeWorldScanner.luau
+++ b/packages/shared/src/Runtime/MazeWorldScanner.luau
@@ -8,8 +8,8 @@
     - Supported room metadata lives on Attributes such as `IsCamp`, `IsExtraction`,
       `DifficultyTier`, `MonsterBudget`, `LootBudget`, `DetectionRadius`,
       `RoomTemplateId`, and `RoomCategory`.
-    - Supported authored child parts include `SpawnPoint_*`, `LootSocket_*`,
-      `LootPrompt`, `Doorway_*`, and `ExtractionMarker`.
+    - Supported authored room nodes include `MonsterSpawns/SpawnPoint_*`,
+      `LootSocket_*`, `LootPrompt`, `Doorway_*`, and `ExtractionMarker`.
 ]]
 
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -35,6 +35,7 @@ local SCAN_CONFIG = {
     HasMonsterSpawnerTag = 'HasMonsterSpawner',
     HasLootSocketTag = 'HasLootSocket',
     DoorwayTagPrefix = 'Doorway/',
+    MonsterSpawnsFolderName = 'MonsterSpawns',
     SceneryFolderName = 'Scenery',
     SceneryAttribute = 'IsScenery',
 }
@@ -156,8 +157,22 @@ local function collectNamedPoints(roomInstance, pattern, defaultDirection)
     return entries
 end
 
+local function findNamedChildFolder(parent, folderName)
+    local child = parent:FindFirstChild(folderName)
+    if child and child:IsA('Folder') then
+        return child
+    end
+
+    return nil
+end
+
 local function collectSpawnPoints(roomInstance)
-    return collectNamedPoints(roomInstance, 'SpawnPoint', 'Unknown')
+    local monsterSpawns = findNamedChildFolder(roomInstance, SCAN_CONFIG.MonsterSpawnsFolderName)
+    if monsterSpawns == nil then
+        return {}
+    end
+
+    return collectNamedPoints(monsterSpawns, 'SpawnPoint', 'Unknown')
 end
 
 local function collectLootSockets(roomInstance)

--- a/places/maze/FEATURES.md
+++ b/places/maze/FEATURES.md
@@ -73,7 +73,7 @@
 |------|------|------|-------------|
 | monster-runtime | active | MonsterService.luau | 共享runtime，maze已接入 |
 | monster-spawn-policy | active | MazeFormalWorldComposer.luau内 | 程序生成时计算初始巡逻索引 |
-| monster-spawn-points | active | MazeWorldScanner.luau | 扫描SpawnPoint_* BasePart作为巡逻点 |
+| monster-spawn-points | active | MazeWorldScanner.luau | 扫描 `MonsterSpawns/SpawnPoint_*` BasePart 作为巡逻点 |
 | monster-behavior-catalog | active | MonsterBehaviorCatalog.luau | 行为开关：SenseNearestTarget/Chase/Patrol |
 
 ## 7. UI / HUD
@@ -105,7 +105,8 @@ MazeStaticWorld/
 ├── LootSocket_*                            # 战利品生成位置
 ├── LootPrompt                              # 战利品拾取提示（ProximityPrompt）
 ├── ExtractionMarker                         # 撤离确认点（ProximityPrompt）
-├── SpawnPoint_*                            # 怪物巡逻点
+├── MonsterSpawns
+│   └── SpawnPoint_*                        # 怪物巡逻点
 └── Scenery                                 # 装饰物Folder（扫描时跳过）
 ```
 

--- a/places/maze/SPEC.md
+++ b/places/maze/SPEC.md
@@ -50,7 +50,7 @@
 
 ### 怪物刷新点
 - **不在 DCC 里做**
-- Roblox 端手动摆放 `SpawnPoint_*` BasePart（与 run 相同）
+- Roblox 端手动创建 `MonsterSpawns` Folder，再在其中摆放 `SpawnPoint_*` BasePart
 
 ### 战利品节点
 - **沿用 `LootSocket_*` BasePart**，Roblox 端手动摆放
@@ -92,7 +92,7 @@ local TODProfile = {
 ## 4. 怪物系统（保留不变）
 
 - 完整保留 `MonsterService` + `EnemyRuntime` + `EnemyStateMachine`
-- 刷新点：Roblox 端手动摆放 `SpawnPoint_*`
+- 刷新点：Roblox 端手动摆放 `MonsterSpawns/SpawnPoint_*`
 - 行为（Patrol/Chase/Attack/Sense）：不变
 
 ---

--- a/places/maze/STATIC_WORLD.md
+++ b/places/maze/STATIC_WORLD.md
@@ -13,7 +13,7 @@ Authored room contract:
 
 - Each room is a `Model` tagged `RoomType/<TypeId>`.
 - Supported room metadata lives on Attributes such as `IsCamp`, `IsExtraction`, `DifficultyTier`, `MonsterBudget`, `LootBudget`, `DetectionRadius`, `RoomTemplateId`, and `RoomCategory`.
-- Supported authored child parts include `SpawnPoint_*`, `LootSocket_*`, `LootPrompt`, `Doorway_*`, and `ExtractionMarker`.
+- Supported authored room nodes include `MonsterSpawns/SpawnPoint_*`, `LootSocket_*`, `LootPrompt`, `Doorway_*`, and `ExtractionMarker`.
 - A formal authored maze must contain at least one room, one loot interaction, one doorway, and one extraction marker.
 
 Runtime behavior:

--- a/places/maze/assets/Overlays/MazeStaticWorldOverlay_Default.rbxmx
+++ b/places/maze/assets/Overlays/MazeStaticWorldOverlay_Default.rbxmx
@@ -137,34 +137,39 @@
           </CoordinateFrame>
         </Properties>
       </Item>
-      <Item class="Part" referent="RBXMazeOverlayRoomLootSpawnPoint">
+      <Item class="Folder" referent="RBXMazeOverlayRoomLootMonsterSpawns">
         <Properties>
-          <string name="Name">SpawnPoint_1</string>
-          <bool name="Anchored">true</bool>
-          <bool name="CanCollide">false</bool>
-          <bool name="CanTouch">false</bool>
-          <bool name="CanQuery">true</bool>
-          <float name="Transparency">1</float>
-          <Vector3 name="Size">
-            <X>2</X>
-            <Y>1</Y>
-            <Z>2</Z>
-          </Vector3>
-          <CoordinateFrame name="CFrame">
-            <X>0</X>
-            <Y>2</Y>
-            <Z>-2</Z>
-            <R00>1</R00>
-            <R01>0</R01>
-            <R02>0</R02>
-            <R10>0</R10>
-            <R11>1</R11>
-            <R12>0</R12>
-            <R20>0</R20>
-            <R21>0</R21>
-            <R22>1</R22>
-          </CoordinateFrame>
+          <string name="Name">MonsterSpawns</string>
         </Properties>
+        <Item class="Part" referent="RBXMazeOverlayRoomLootSpawnPoint">
+          <Properties>
+            <string name="Name">SpawnPoint_1</string>
+            <bool name="Anchored">true</bool>
+            <bool name="CanCollide">false</bool>
+            <bool name="CanTouch">false</bool>
+            <bool name="CanQuery">true</bool>
+            <float name="Transparency">1</float>
+            <Vector3 name="Size">
+              <X>2</X>
+              <Y>1</Y>
+              <Z>2</Z>
+            </Vector3>
+            <CoordinateFrame name="CFrame">
+              <X>0</X>
+              <Y>2</Y>
+              <Z>-2</Z>
+              <R00>1</R00>
+              <R01>0</R01>
+              <R02>0</R02>
+              <R10>0</R10>
+              <R11>1</R11>
+              <R12>0</R12>
+              <R20>0</R20>
+              <R21>0</R21>
+              <R22>1</R22>
+            </CoordinateFrame>
+          </Properties>
+        </Item>
       </Item>
       <Item class="Part" referent="RBXMazeOverlayRoomLootSocket">
         <Properties>

--- a/places/maze/harness/maze.rbxlx
+++ b/places/maze/harness/maze.rbxlx
@@ -8988,8 +8988,8 @@ return MazeModuleAssetContract
     - Supported room metadata lives on Attributes such as `IsCamp`, `IsExtraction`,
       `DifficultyTier`, `MonsterBudget`, `LootBudget`, `DetectionRadius`,
       `RoomTemplateId`, and `RoomCategory`.
-    - Supported authored child parts include `SpawnPoint_*`, `LootSocket_*`,
-      `LootPrompt`, `Doorway_*`, and `ExtractionMarker`.
+    - Supported authored room nodes include `MonsterSpawns/SpawnPoint_*`,
+      `LootSocket_*`, `Doorway_*`, `LootPrompt`, and `ExtractionMarker`.
 ]]
 
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -9012,6 +9012,7 @@ local SCAN_CONFIG = {
     HasMonsterSpawnerTag = 'HasMonsterSpawner',
     HasLootSocketTag = 'HasLootSocket',
     DoorwayTagPrefix = 'Doorway/',
+    MonsterSpawnsFolderName = 'MonsterSpawns',
     SceneryFolderName = 'Scenery',
     SceneryAttribute = 'IsScenery',
 }
@@ -9133,8 +9134,22 @@ local function collectNamedPoints(roomInstance, pattern, defaultDirection)
     return entries
 end
 
+local function findNamedChildFolder(parent, folderName)
+    local child = parent:FindFirstChild(folderName)
+    if child and child:IsA('Folder') then
+        return child
+    end
+
+    return nil
+end
+
 local function collectSpawnPoints(roomInstance)
-    return collectNamedPoints(roomInstance, 'SpawnPoint', 'Unknown')
+    local monsterSpawns = findNamedChildFolder(roomInstance, SCAN_CONFIG.MonsterSpawnsFolderName)
+    if monsterSpawns == nil then
+        return {}
+    end
+
+    return collectNamedPoints(monsterSpawns, 'SpawnPoint', 'Unknown')
 end
 
 local function collectLootSockets(roomInstance)
@@ -14798,11 +14813,16 @@ end)
             <bool name="Anchored">true</bool>
           </Properties>
         </Item>
-        <Item class="Part" referent="134">
+        <Item class="Folder" referent="136">
           <Properties>
-            <string name="Name">SpawnPoint_1</string>
-            <bool name="Anchored">true</bool>
+            <string name="Name">MonsterSpawns</string>
           </Properties>
+          <Item class="Part" referent="134">
+            <Properties>
+              <string name="Name">SpawnPoint_1</string>
+              <bool name="Anchored">true</bool>
+            </Properties>
+          </Item>
         </Item>
       </Item>
       <Item class="Part" referent="135">

--- a/tests/src/Shared/MazeScene.spec.luau
+++ b/tests/src/Shared/MazeScene.spec.luau
@@ -52,11 +52,15 @@ return function()
     })
     lootRoom:AddTag('HasMonsterSpawner')
 
+    local monsterSpawns = Instance.new('Folder')
+    monsterSpawns.Name = 'MonsterSpawns'
+    monsterSpawns.Parent = lootRoom
+
     local patrolPoint = Instance.new('Part')
     patrolPoint.Name = 'SpawnPoint_1'
     patrolPoint.Anchored = true
     patrolPoint.Position = Vector3.new(24, 2, 24)
-    patrolPoint.Parent = lootRoom
+    patrolPoint.Parent = monsterSpawns
 
     local lootSocket = Instance.new('Part')
     lootSocket.Name = 'LootSocket_1'

--- a/tests/src/Shared/MazeStaticWorld.spec.luau
+++ b/tests/src/Shared/MazeStaticWorld.spec.luau
@@ -160,4 +160,82 @@ return function()
     assert(doorwayPart.CanCollide == false, 'Toggling authored doors should release collision')
 
     root:Destroy()
+
+    local invalidRoot = Instance.new('Folder')
+    invalidRoot.Name = 'MazeStaticWorld'
+    invalidRoot.Parent = Workspace
+
+    local invalidSpawnMarker = Instance.new('Part')
+    invalidSpawnMarker.Name = 'SpawnMarker'
+    invalidSpawnMarker.Anchored = true
+    invalidSpawnMarker.Parent = invalidRoot
+
+    local invalidReturnHoldPad = Instance.new('Part')
+    invalidReturnHoldPad.Name = 'ReturnHoldPad'
+    invalidReturnHoldPad.Anchored = true
+    invalidReturnHoldPad.Parent = invalidRoot
+
+    Instance.new('ProximityPrompt').Parent = invalidReturnHoldPad
+
+    local invalidMonsterRoom =
+        createRoom('Room_InvalidMonster', 'DeadEnd', Vector3.new(24, 6, 24), {
+            MonsterBudget = 2,
+            DifficultyTier = 2,
+        })
+    invalidMonsterRoom.Parent = invalidRoot
+    invalidMonsterRoom:AddTag('HasMonsterSpawner')
+
+    local directSpawnPoint = Instance.new('Part')
+    directSpawnPoint.Name = 'SpawnPoint_1'
+    directSpawnPoint.Anchored = true
+    directSpawnPoint.Position = Vector3.new(24, 2, 24)
+    directSpawnPoint.Parent = invalidMonsterRoom
+
+    local invalidLootSocket = Instance.new('Part')
+    invalidLootSocket.Name = 'LootSocket_1'
+    invalidLootSocket.Anchored = true
+    invalidLootSocket.Position = Vector3.new(26, 2, 24)
+    invalidLootSocket.Parent = invalidMonsterRoom
+
+    local invalidLootPromptPart = Instance.new('Part')
+    invalidLootPromptPart.Name = 'LootPrompt'
+    invalidLootPromptPart.Anchored = true
+    invalidLootPromptPart.Position = Vector3.new(26, 2, 24)
+    invalidLootPromptPart.Parent = invalidMonsterRoom
+
+    Instance.new('ProximityPrompt').Parent = invalidLootPromptPart
+
+    local invalidExtractionRoom =
+        createRoom('Room_InvalidExtraction', 'Straight', Vector3.new(48, 6, 24), {
+            IsExtraction = true,
+            DifficultyTier = 1,
+        })
+    invalidExtractionRoom.Parent = invalidRoot
+
+    local invalidExtractionMarker = Instance.new('Part')
+    invalidExtractionMarker.Name = 'ExtractionMarker'
+    invalidExtractionMarker.Anchored = true
+    invalidExtractionMarker.Position = Vector3.new(48, 2, 24)
+    invalidExtractionMarker.Parent = invalidExtractionRoom
+
+    Instance.new('ProximityPrompt').Parent = invalidExtractionMarker
+
+    local invalidOk, invalidErr = pcall(function()
+        scanner.BuildStaticWorld(invalidRoot)
+    end)
+
+    assert(
+        invalidOk == false,
+        'Static maze world build should fail loudly when monster rooms miss MonsterSpawns'
+    )
+    assert(
+        string.find(tostring(invalidErr), 'MonsterSpawns/SpawnPoint_*', 1, true) ~= nil,
+        'Missing monster patrol anchors should mention the MonsterSpawns contract'
+    )
+    assert(
+        string.find(tostring(invalidErr), 'Room_InvalidMonster', 1, true) ~= nil,
+        'Missing monster patrol anchors should identify the authored room'
+    )
+
+    invalidRoot:Destroy()
 end

--- a/tests/src/Shared/MazeStaticWorld.spec.luau
+++ b/tests/src/Shared/MazeStaticWorld.spec.luau
@@ -58,11 +58,15 @@ return function()
     })
     lootRoom:AddTag('HasMonsterSpawner')
 
+    local monsterSpawns = Instance.new('Folder')
+    monsterSpawns.Name = 'MonsterSpawns'
+    monsterSpawns.Parent = lootRoom
+
     local patrolPoint = Instance.new('Part')
     patrolPoint.Name = 'SpawnPoint_1'
     patrolPoint.Anchored = true
     patrolPoint.Position = Vector3.new(24, 2, 24)
-    patrolPoint.Parent = lootRoom
+    patrolPoint.Parent = monsterSpawns
 
     local lootSocket = Instance.new('Part')
     lootSocket.Name = 'LootSocket_1'

--- a/tests/src/Shared/MazeWorldScanner.spec.luau
+++ b/tests/src/Shared/MazeWorldScanner.spec.luau
@@ -28,13 +28,25 @@ return function()
             room:AddTag(tag)
         end
 
+        local monsterSpawnsFolder = nil
+
         -- 添加子级（SpawnPoint、LootSocket 等）
         for _, childData in ipairs(children or {}) do
             local child = Instance.new('Part')
             child.Name = childData.name
             child.Position = childData.position or Vector3.new(0, 0, 0)
             child:SetAttribute('Direction', childData.direction or 'Unknown')
-            child.Parent = room
+
+            if string.find(child.Name, 'SpawnPoint') then
+                if monsterSpawnsFolder == nil then
+                    monsterSpawnsFolder = Instance.new('Folder')
+                    monsterSpawnsFolder.Name = 'MonsterSpawns'
+                    monsterSpawnsFolder.Parent = room
+                end
+                child.Parent = monsterSpawnsFolder
+            else
+                child.Parent = room
+            end
         end
 
         return room
@@ -430,6 +442,37 @@ return function()
         mockRoot:Destroy()
 
         print('[PASS] MazeWorldScanner correctly collects PatrolAnchors and SpawnSockets')
+    end
+
+    -- ============================================
+    -- Test: 没有 MonsterSpawns 文件夹时不产生 PatrolAnchors
+    -- ============================================
+    do
+        local mockRoot = Instance.new('Folder')
+        mockRoot.Name = 'MockWorkspace'
+
+        local room = Instance.new('Model')
+        room.Name = 'Room_NoMonsterFolder'
+        room:AddTag('RoomType/DeadEnd')
+        room.Parent = mockRoot
+
+        local directSpawnPoint = Instance.new('Part')
+        directSpawnPoint.Name = 'SpawnPoint_1'
+        directSpawnPoint.Position = Vector3.new(0, 5, 0)
+        directSpawnPoint.Parent = room
+
+        local worldFormat = MazeWorldScanner.ToWorldFormat(MazeWorldScanner.Scan(mockRoot))
+        local affordance = worldFormat.RoomAffordances.Room_NoMonsterFolder
+
+        assert(affordance ~= nil, 'Room affordance should still exist')
+        assert(
+            #affordance.PatrolAnchors == 0,
+            'Direct child SpawnPoint_* should no longer count without MonsterSpawns'
+        )
+
+        mockRoot:Destroy()
+
+        print('[PASS] MazeWorldScanner ignores direct-child SpawnPoint_* without MonsterSpawns')
     end
 
     print('[PASS] All MazeWorldScanner spec tests passed')


### PR DESCRIPTION
## What changed
- switch the maze monster authored contract from direct `Room/SpawnPoint_*` parts to `Room/MonsterSpawns/SpawnPoint_*`
- update `MazeWorldScanner`, the maze overlay, the maze harness, and the shared specs to consume the new structure
- refresh maze docs so the authored world contract matches the runtime behavior

## Validation
- `stylua --check .`
- `selene .`
- `rojo build places/maze/default.project.json -o /tmp/maze-monster-spawns-maze.rbxlx`
- `rojo build tests/default.project.json -o /tmp/maze-monster-spawns-tests.rbxlx`
- `run-in-roblox --place /tmp/maze-monster-spawns-tests.rbxlx --script tests/run-in-roblox.lua`

## Notes
- this PR is a one-time authored world contract migration; it does not keep compatibility with the old direct-child `SpawnPoint_*` layout
- local `maze_demo` and Studio prototype changes were applied separately and are not part of this PR
