### PR TITLE
feat(monster): support custom humanoid animation assets

### DIFF
--- a/packages/gameplay/src/Monsters/MonsterAuthorProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterAuthorProfile.luau
@@ -69,29 +69,71 @@ local function validateSummaryTable(summaryTable, missingReason)
     return true
 end
 
+local function isPositiveAssetId(value)
+    return type(value) == 'number' and value > 0
+end
+
+local function validateAnimationAssetIds(animationAssetIds, missingReasonPrefix, invalidReasonPrefix)
+    if type(animationAssetIds) ~= 'table' then
+        return false, missingReasonPrefix
+    end
+
+    for _, slotName in ipairs(MonsterPresentationCatalog.RequiredCustomAnimationSlots) do
+        if animationAssetIds[slotName] == nil then
+            return false, string.format('%s%s', missingReasonPrefix, slotName)
+        end
+
+        if not isPositiveAssetId(animationAssetIds[slotName]) then
+            return false, string.format('%s%s', invalidReasonPrefix, slotName)
+        end
+    end
+
+    return true
+end
+
 local function validatePresentation(presentation)
     if type(presentation) ~= 'table' then
         return false, 'MissingPresentation'
     end
 
-    if type(presentation.ModelAssetId) ~= 'number' or presentation.ModelAssetId <= 0 then
+    if not isPositiveAssetId(presentation.ModelAssetId) then
         return false, 'InvalidModelAssetId'
     end
 
-    if not MonsterPresentationCatalog.KnownRigType[presentation.RigType] then
+    local rigType = presentation.RigType
+    if not MonsterPresentationCatalog.KnownRigType[rigType] then
         return false, 'InvalidRigType'
     end
 
-    if not MonsterPresentationCatalog.KnownAnimationMode[presentation.AnimationMode] then
+    local animationMode = presentation.AnimationMode
+    if not MonsterPresentationCatalog.KnownAnimationMode[animationMode] then
         return false, 'InvalidAnimationMode'
+    end
+
+    local usesCustomHumanoid = animationMode == MonsterPresentationCatalog.AnimationMode.CustomHumanoid
+        or rigType == MonsterPresentationCatalog.RigType.CustomHumanoid
+    if usesCustomHumanoid then
+        if rigType ~= MonsterPresentationCatalog.RigType.CustomHumanoid then
+            return false, 'CustomHumanoidRequiresCustomRigType'
+        end
+
+        if animationMode ~= MonsterPresentationCatalog.AnimationMode.CustomHumanoid then
+            return false, 'CustomHumanoidRequiresCustomAnimationMode'
+        end
+
+        local animationAssetIdsOk, animationAssetIdsReason = validateAnimationAssetIds(
+            presentation.AnimationAssetIds,
+            'MissingAnimationAssetId',
+            'InvalidAnimationAssetId'
+        )
+        if not animationAssetIdsOk then
+            return false, animationAssetIdsReason
+        end
     end
 
     if
         presentation.ChaseLoopSoundAssetId ~= nil
-        and (
-            type(presentation.ChaseLoopSoundAssetId) ~= 'number'
-            or presentation.ChaseLoopSoundAssetId <= 0
-        )
+        and not isPositiveAssetId(presentation.ChaseLoopSoundAssetId)
     then
         return false, 'InvalidChaseLoopSoundAssetId'
     end

--- a/packages/gameplay/src/Monsters/MonsterCompiler.luau
+++ b/packages/gameplay/src/Monsters/MonsterCompiler.luau
@@ -32,12 +32,18 @@ local function cloneRuntimeEffect(effectIntent)
 end
 
 local function cloneRuntimePresentation(presentation)
-    return table.freeze({
+    local runtimePresentation = {
         ModelAssetId = presentation.ModelAssetId,
         RigType = presentation.RigType,
         AnimationMode = presentation.AnimationMode,
         ChaseLoopSoundAssetId = presentation.ChaseLoopSoundAssetId,
-    })
+    }
+
+    if type(presentation.AnimationAssetIds) == 'table' then
+        runtimePresentation.AnimationAssetIds = table.freeze(table.clone(presentation.AnimationAssetIds))
+    end
+
+    return table.freeze(runtimePresentation)
 end
 
 function MonsterCompiler.compileMonsterForMaze(authorProfile)

--- a/packages/gameplay/src/Monsters/MonsterPresentationCatalog.luau
+++ b/packages/gameplay/src/Monsters/MonsterPresentationCatalog.luau
@@ -2,18 +2,36 @@ local MonsterPresentationCatalog = {}
 
 MonsterPresentationCatalog.RigType = table.freeze({
     R6 = 'R6',
+    CustomHumanoid = 'CustomHumanoid',
 })
 
 MonsterPresentationCatalog.AnimationMode = table.freeze({
     DefaultR6 = 'defaultR6',
+    CustomHumanoid = 'customHumanoid',
+})
+
+MonsterPresentationCatalog.AnimationSlot = table.freeze({
+    Idle = 'Idle',
+    Walk = 'Walk',
+    Run = 'Run',
+    Attack = 'Attack',
+})
+
+MonsterPresentationCatalog.RequiredCustomAnimationSlots = table.freeze({
+    MonsterPresentationCatalog.AnimationSlot.Idle,
+    MonsterPresentationCatalog.AnimationSlot.Walk,
+    MonsterPresentationCatalog.AnimationSlot.Run,
+    MonsterPresentationCatalog.AnimationSlot.Attack,
 })
 
 MonsterPresentationCatalog.KnownRigType = table.freeze({
     [MonsterPresentationCatalog.RigType.R6] = true,
+    [MonsterPresentationCatalog.RigType.CustomHumanoid] = true,
 })
 
 MonsterPresentationCatalog.KnownAnimationMode = table.freeze({
     [MonsterPresentationCatalog.AnimationMode.DefaultR6] = true,
+    [MonsterPresentationCatalog.AnimationMode.CustomHumanoid] = true,
 })
 
 return MonsterPresentationCatalog

--- a/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
+++ b/packages/gameplay/src/Monsters/MonsterRuntimeProfile.luau
@@ -14,6 +14,24 @@ local function isValidDamagePips(value)
     return value == 1 or value == 2
 end
 
+local function validateAnimationAssetIds(animationAssetIds, missingReasonPrefix, invalidReasonPrefix)
+    if type(animationAssetIds) ~= 'table' then
+        return false, missingReasonPrefix
+    end
+
+    for _, slotName in ipairs(MonsterPresentationCatalog.RequiredCustomAnimationSlots) do
+        if animationAssetIds[slotName] == nil then
+            return false, string.format('%s%s', missingReasonPrefix, slotName)
+        end
+
+        if type(animationAssetIds[slotName]) ~= 'number' or animationAssetIds[slotName] <= 0 then
+            return false, string.format('%s%s', invalidReasonPrefix, slotName)
+        end
+    end
+
+    return true
+end
+
 local function readComponentTable(profile, name)
     local components = profile.Components
     if components == nil then
@@ -62,6 +80,28 @@ function MonsterRuntimeProfile.validate(profile)
 
     if not MonsterPresentationCatalog.KnownAnimationMode[presentation.AnimationMode] then
         return false, 'InvalidRuntimeAnimationMode'
+    end
+
+    local usesCustomHumanoid = presentation.AnimationMode
+            == MonsterPresentationCatalog.AnimationMode.CustomHumanoid
+        or presentation.RigType == MonsterPresentationCatalog.RigType.CustomHumanoid
+    if usesCustomHumanoid then
+        if presentation.RigType ~= MonsterPresentationCatalog.RigType.CustomHumanoid then
+            return false, 'RuntimeCustomHumanoidRequiresCustomRigType'
+        end
+
+        if presentation.AnimationMode ~= MonsterPresentationCatalog.AnimationMode.CustomHumanoid then
+            return false, 'RuntimeCustomHumanoidRequiresCustomAnimationMode'
+        end
+
+        local animationAssetIdsOk, animationAssetIdsReason = validateAnimationAssetIds(
+            presentation.AnimationAssetIds,
+            'MissingRuntimeAnimationAssetId',
+            'InvalidRuntimeAnimationAssetId'
+        )
+        if not animationAssetIdsOk then
+            return false, animationAssetIdsReason
+        end
     end
 
     if

--- a/packages/shared/src/Runtime/MonsterService.luau
+++ b/packages/shared/src/Runtime/MonsterService.luau
@@ -11,6 +11,7 @@ local MonsterBehaviorCatalog = Gameplay.Monsters.MonsterBehaviorCatalog
 local MonsterComponentConfig = Gameplay.Monsters.MonsterComponentConfig
 local MonsterLogic = Gameplay.Monsters.MonsterLogic
 local Enemy = Gameplay.Monsters.Enemy
+local MonsterPresentationCatalog = Gameplay.Monsters.MonsterPresentationCatalog
 local MonsterRuntimeProfile = Gameplay.Monsters.MonsterRuntimeProfile
 local PlayerMonsterMelee = Gameplay.Combat.PlayerMonsterMelee
 local EnemyRuntime = require(script.Parent.MonsterRuntime.EnemyRuntime)
@@ -363,11 +364,46 @@ function MonsterService:_loadAnimationTracks(humanoid)
         animator.Parent = humanoid
     end
 
+    local presentation = self.Definition.Presentation
     local animationTracks = {
-        Idle = self.LoadAnimationTrack(animator, DEFAULT_R6_ANIMATIONS.Idle, 'MonsterIdle'),
-        Walk = self.LoadAnimationTrack(animator, DEFAULT_R6_ANIMATIONS.Walk, 'MonsterWalk'),
-        Run = self.LoadAnimationTrack(animator, DEFAULT_R6_ANIMATIONS.Run, 'MonsterRun'),
+        Idle = nil,
+        Walk = nil,
+        Run = nil,
     }
+    local attackTrack
+
+    if presentation.AnimationMode == MonsterPresentationCatalog.AnimationMode.CustomHumanoid then
+        local animationAssetIds = presentation.AnimationAssetIds or {}
+        animationTracks.Idle = self.LoadAnimationTrack(
+            animator,
+            animationAssetIds[MonsterPresentationCatalog.AnimationSlot.Idle],
+            'MonsterIdle'
+        )
+        animationTracks.Walk = self.LoadAnimationTrack(
+            animator,
+            animationAssetIds[MonsterPresentationCatalog.AnimationSlot.Walk],
+            'MonsterWalk'
+        )
+        animationTracks.Run = self.LoadAnimationTrack(
+            animator,
+            animationAssetIds[MonsterPresentationCatalog.AnimationSlot.Run],
+            'MonsterRun'
+        )
+        attackTrack = self.LoadAnimationTrack(
+            animator,
+            animationAssetIds[MonsterPresentationCatalog.AnimationSlot.Attack],
+            'MonsterAttack'
+        )
+    else
+        animationTracks.Idle =
+            self.LoadAnimationTrack(animator, DEFAULT_R6_ANIMATIONS.Idle, 'MonsterIdle')
+        animationTracks.Walk =
+            self.LoadAnimationTrack(animator, DEFAULT_R6_ANIMATIONS.Walk, 'MonsterWalk')
+        animationTracks.Run =
+            self.LoadAnimationTrack(animator, DEFAULT_R6_ANIMATIONS.Run, 'MonsterRun')
+        attackTrack =
+            self.LoadAnimationTrack(animator, DEFAULT_R6_ANIMATIONS.Attack, 'MonsterAttack')
+    end
 
     if animationTracks.Idle then
         animationTracks.Idle.Looped = true
@@ -384,8 +420,6 @@ function MonsterService:_loadAnimationTracks(humanoid)
         animationTracks.Run.Priority = Enum.AnimationPriority.Movement
     end
 
-    local attackTrack =
-        self.LoadAnimationTrack(animator, DEFAULT_R6_ANIMATIONS.Attack, 'MonsterAttack')
     if attackTrack then
         attackTrack.Looped = false
         attackTrack.Priority = Enum.AnimationPriority.Action
@@ -438,7 +472,10 @@ function MonsterService:_spawnModel(spawnPosition)
     preparedModel.Parent = Workspace
     preparedModel:PivotTo(CFrame.new(spawnPosition))
 
-    if presentation.AnimationMode == 'defaultR6' then
+    if
+        presentation.AnimationMode == MonsterPresentationCatalog.AnimationMode.DefaultR6
+        or presentation.AnimationMode == MonsterPresentationCatalog.AnimationMode.CustomHumanoid
+    then
         local animationOk, animationErr = pcall(function()
             self:_loadAnimationTracks(humanoid)
         end)

--- a/tests/src/Shared/MonsterAttackMarker.spec.luau
+++ b/tests/src/Shared/MonsterAttackMarker.spec.luau
@@ -1,9 +1,11 @@
 return function()
     local ReplicatedStorage = game:GetService('ReplicatedStorage')
     local packages = ReplicatedStorage:WaitForChild('Packages')
+    local gameplay = require(packages:WaitForChild('Gameplay'))
     local shared = require(packages:WaitForChild('Shared'))
 
     local MonsterService = shared.Runtime.MonsterService
+    local presentationCatalog = gameplay.Monsters.MonsterPresentationCatalog
 
     local function buildRuntimeProfile()
         return {
@@ -226,4 +228,62 @@ return function()
     noMarkerService:update(0.2)
     assert(noMarkerHits == 0, 'Animations without Hit marker support should never settle damage')
     noMarkerService:destroy()
+
+    local customTrackAssetIds = {}
+    local customRuntimeProfile = buildRuntimeProfile()
+    customRuntimeProfile.Presentation = {
+        ModelAssetId = 4446576906,
+        RigType = presentationCatalog.RigType.CustomHumanoid,
+        AnimationMode = presentationCatalog.AnimationMode.CustomHumanoid,
+        AnimationAssetIds = {
+            Idle = 7101,
+            Walk = 7102,
+            Run = 7102,
+            Attack = 7103,
+        },
+        ChaseLoopSoundAssetId = 9118823108,
+    }
+
+    local customMarkerHits = 0
+    local customService = MonsterService.new(
+        customRuntimeProfile,
+        function()
+            return true
+        end,
+        nil,
+        nil,
+        {
+            AssetLoader = function()
+                return createMonsterModel()
+            end,
+            GetPlayers = function()
+                return activePlayers
+            end,
+            LoadAnimationTrack = function(_, animationAssetId, animationName)
+                customTrackAssetIds[animationName] = animationAssetId
+                local supportsMarkers = animationName == 'MonsterAttack'
+                return createTrack(animationName, supportsMarkers)
+            end,
+            OnAttackHit = function()
+                customMarkerHits += 1
+            end,
+        }
+    )
+
+    activePlayers[1].Character.HumanoidRootPart.Position = Vector3.new(3, 4, 0)
+    customService:spawn({ Vector3.new(0, 0, 0) }, 1)
+    customService.MonsterRoot:PivotTo(CFrame.lookAt(Vector3.new(0, 4, 0), Vector3.new(5, 4, 0)))
+    customService:update(0.2)
+    assert(
+        customTrackAssetIds.MonsterAttack == 7103,
+        'Custom humanoid attack marker flow should load the configured attack animation asset'
+    )
+
+    customService.AttackAnimationTrack:FireMarker('Hit')
+    assert(
+        customMarkerHits == 1,
+        'Custom humanoid attack animations should still settle damage on the Hit marker'
+    )
+
+    customService:destroy()
 end

--- a/tests/src/Shared/MonsterCompiler.spec.luau
+++ b/tests/src/Shared/MonsterCompiler.spec.luau
@@ -220,6 +220,66 @@ return function()
         'Missing presentation payloads should expose the expected reason'
     )
 
+    local customHumanoidProfile = table.clone(scrapWisp)
+    customHumanoidProfile.Executable = table.clone(scrapWisp.Executable)
+    customHumanoidProfile.Executable.Presentation = {
+        ModelAssetId = 4446576906,
+        RigType = presentationCatalog.RigType.CustomHumanoid,
+        AnimationMode = presentationCatalog.AnimationMode.CustomHumanoid,
+        AnimationAssetIds = {
+            Idle = 8001,
+            Walk = 8002,
+            Run = 8002,
+            Attack = 8003,
+        },
+        ChaseLoopSoundAssetId = monsterAssetIds.DefaultChaseLoopSoundAssetId,
+    }
+
+    local customCompileOk, customRuntimeProfile = compiler(customHumanoidProfile)
+    assert(
+        customCompileOk == true,
+        string.format(
+            'Expected custom humanoid compiler success, got %s',
+            tostring(customRuntimeProfile)
+        )
+    )
+    assert(
+        customRuntimeProfile.Presentation.RigType == presentationCatalog.RigType.CustomHumanoid,
+        'Custom humanoid compile should preserve the configured rig type'
+    )
+    assert(
+        customRuntimeProfile.Presentation.AnimationMode
+            == presentationCatalog.AnimationMode.CustomHumanoid,
+        'Custom humanoid compile should preserve the configured animation mode'
+    )
+    assert(
+        customRuntimeProfile.Presentation.AnimationAssetIds.Idle == 8001,
+        'Custom humanoid compile should preserve animation asset ids'
+    )
+    assert(
+        customRuntimeProfile.Presentation.AnimationAssetIds.Run == 8002,
+        'Custom humanoid compile should preserve the run animation asset id'
+    )
+
+    local missingCustomAnimationProfile = table.clone(customHumanoidProfile)
+    missingCustomAnimationProfile.Executable = table.clone(customHumanoidProfile.Executable)
+    missingCustomAnimationProfile.Executable.Presentation =
+        table.clone(customHumanoidProfile.Executable.Presentation)
+    missingCustomAnimationProfile.Executable.Presentation.AnimationAssetIds =
+        table.clone(customHumanoidProfile.Executable.Presentation.AnimationAssetIds)
+    missingCustomAnimationProfile.Executable.Presentation.AnimationAssetIds.Attack = nil
+
+    local missingCustomAnimationOk, missingCustomAnimationReason =
+        authorProfileModule.validate(missingCustomAnimationProfile)
+    assert(
+        missingCustomAnimationOk == false,
+        'Missing custom animation asset ids should fail author profile validation'
+    )
+    assert(
+        missingCustomAnimationReason == 'MissingAnimationAssetIdAttack',
+        'Missing custom animation asset ids should expose a dedicated authoring reason'
+    )
+
     local unknownBehaviorProfile = table.clone(scrapWisp)
     unknownBehaviorProfile.Executable = table.clone(scrapWisp.Executable)
     unknownBehaviorProfile.Executable.BehaviorIntents = {

--- a/tests/src/Shared/MonsterRuntimeProfile.spec.luau
+++ b/tests/src/Shared/MonsterRuntimeProfile.spec.luau
@@ -75,4 +75,58 @@ return function()
         invalidDamageReason == 'InvalidRuntimeComponentAttackDamagePips',
         'Invalid attack damage pips should expose a dedicated reason'
     )
+
+    local customHumanoidProfile = {
+        Id = 'custom-humanoid-spec',
+        Name = 'Custom Humanoid Spec',
+        Presentation = {
+            ModelAssetId = 4446576906,
+            RigType = presentationCatalog.RigType.CustomHumanoid,
+            AnimationMode = presentationCatalog.AnimationMode.CustomHumanoid,
+            AnimationAssetIds = {
+                Idle = 1001,
+                Walk = 1002,
+                Run = 1002,
+                Attack = 1003,
+            },
+            ChaseLoopSoundAssetId = 9118823108,
+        },
+        Behaviors = {
+            SenseNearestTarget = true,
+            Chase = true,
+            Attack = true,
+        },
+        Effects = {},
+        Speed = 12,
+        SightRange = 36,
+        PatrolSpeedMultiplier = 0.45,
+        SpawnOffset = Vector3.new(0, 4, 0),
+        AttackRange = 4,
+        AttackCooldownSeconds = 1,
+        AttackDamagePips = 1,
+        CombatHitPoints = 2,
+    }
+
+    local validCustomHumanoid, customHumanoidReason =
+        runtimeProfileModule.validate(customHumanoidProfile)
+    assert(
+        validCustomHumanoid == true,
+        string.format(
+            'Custom humanoid runtime payload should stay valid, got %s',
+            tostring(customHumanoidReason)
+        )
+    )
+
+    local missingCustomRunProfile = table.clone(customHumanoidProfile)
+    missingCustomRunProfile.Presentation = table.clone(customHumanoidProfile.Presentation)
+    missingCustomRunProfile.Presentation.AnimationAssetIds =
+        table.clone(customHumanoidProfile.Presentation.AnimationAssetIds)
+    missingCustomRunProfile.Presentation.AnimationAssetIds.Run = nil
+
+    local missingRunOk, missingRunReason = runtimeProfileModule.validate(missingCustomRunProfile)
+    assert(missingRunOk == false, 'Missing custom run animation asset ids should fail validation')
+    assert(
+        missingRunReason == 'MissingRuntimeAnimationAssetIdRun',
+        'Missing custom run animation should expose a dedicated runtime reason'
+    )
 end

--- a/tests/src/Shared/MonsterService.spec.luau
+++ b/tests/src/Shared/MonsterService.spec.luau
@@ -208,4 +208,104 @@ return function()
     assert(#fallbackWarnings == 1, 'Fallback loads should emit a warning for diagnostics')
 
     fallbackService:destroy()
+
+    local customRuntimeProfile = {
+        Id = 'custom-humanoid-service-spec',
+        Name = 'Custom Humanoid Service Spec',
+        Presentation = {
+            ModelAssetId = 555666777,
+            RigType = gameplay.Monsters.MonsterPresentationCatalog.RigType.CustomHumanoid,
+            AnimationMode = gameplay.Monsters.MonsterPresentationCatalog.AnimationMode.CustomHumanoid,
+            AnimationAssetIds = {
+                Idle = 701,
+                Walk = 702,
+                Run = 702,
+                Attack = 703,
+            },
+        },
+        AttackRange = 4,
+        AttackCooldownSeconds = 1,
+        AttackDamagePips = 1,
+        Speed = 12,
+        SightRange = 36,
+        PatrolSpeedMultiplier = 0.45,
+        SpawnOffset = Vector3.new(0, 4, 0),
+        CombatHitPoints = 2,
+        Behaviors = {
+            SenseNearestTarget = true,
+            Chase = true,
+            Attack = true,
+        },
+        Effects = {},
+        Components = {
+            Perception = {
+                SightRange = 36,
+            },
+            Movement = {
+                Speed = 12,
+                PatrolSpeedMultiplier = 0.45,
+                SpawnOffset = Vector3.new(0, 4, 0),
+            },
+            Attack = {
+                Range = 4,
+                CooldownSeconds = 1,
+                DamagePips = 1,
+            },
+        },
+    }
+
+    local customTrackAssetIds = {}
+    local customService = monsterServiceModule.new(
+        customRuntimeProfile,
+        function()
+            return true
+        end,
+        nil,
+        nil,
+        {
+            AssetLoader = function(assetId)
+                assert(assetId == 555666777, 'Custom humanoid service should request its model asset')
+
+                local monsterModel = Instance.new('Model')
+                monsterModel.Name = 'MixamoMonster'
+
+                local rootPart = Instance.new('Part')
+                rootPart.Name = 'HumanoidRootPart'
+                rootPart.Size = Vector3.new(2, 2, 1)
+                rootPart.Parent = monsterModel
+
+                local humanoid = Instance.new('Humanoid')
+                humanoid.Parent = monsterModel
+
+                return monsterModel
+            end,
+            LoadAnimationTrack = function(_, animationAssetId, animationName)
+                customTrackAssetIds[animationName] = animationAssetId
+                return createTrack(animationName)
+            end,
+        }
+    )
+
+    customService:spawn({
+        Vector3.new(0, 0, 0),
+    }, 1)
+
+    assert(
+        customTrackAssetIds.MonsterIdle == 701,
+        'Custom humanoid service should load the configured idle animation asset'
+    )
+    assert(
+        customTrackAssetIds.MonsterWalk == 702,
+        'Custom humanoid service should load the configured walk animation asset'
+    )
+    assert(
+        customTrackAssetIds.MonsterRun == 702,
+        'Custom humanoid service should load the configured run animation asset'
+    )
+    assert(
+        customTrackAssetIds.MonsterAttack == 703,
+        'Custom humanoid service should load the configured attack animation asset'
+    )
+
+    customService:destroy()
 end


### PR DESCRIPTION
## Summary
- add custom humanoid monster presentation support alongside the existing defaultR6 path
- load Idle/Walk/Run/Attack from configured animation asset ids while keeping server-driven movement
- extend shared tests to cover validation, compiler passthrough, service loading, and attack marker handling

## Testing
- ojo build tests/default.project.json -o .\\tmp\\roblox_experience-tests.rbxlx
- not run: stylua --check . (tool not installed in this environment)
- not run: selene . (tool not installed in this environment)
- not run: un-in-roblox --place .\\tmp\\roblox_experience-tests.rbxlx --script tests/run-in-roblox.lua (tool not installed in this environment)