### PR TITLE
feat(maze): preserve authored harness world

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Keep authored scene content under the matching static world root:
 - `Workspace/RunStaticWorld`
 - `Workspace/MazeStaticWorld`
 
+The Maze harness reset path also hydrates a starter
+`Workspace/MazeStaticWorld/Scenery` so the file opens with visible authored
+geometry in Studio.
+
 ### Connect Roblox Studio
 
 1. Start the desired `rojo serve` command and keep that terminal open.

--- a/places/maze/CONTENT_TEST_PLAN.md
+++ b/places/maze/CONTENT_TEST_PLAN.md
@@ -1,0 +1,166 @@
+# Maze 当前内容测试计划
+
+基于最新 `main` 的 Maze live path，目标是在**不导入外部地图资产之前**，先把当前 `/Users/qizhi_dong/Projects/roblox_experience/places/maze/harness/maze.rbxlx` 上所有可见 feature 做一轮最基础内容验收。
+
+## 0. 测试基线
+
+- 内容测试基底：`places/maze/harness/maze.rbxlx`
+- authored source：`places/maze/harness/maze.rbxlx` 里的 `Workspace/MazeStaticWorld`
+- runtime source：优先使用现有 authored `Workspace/MazeStaticWorld`，缺失时才回退到 scaffold 组装
+- 真相源以代码为准，重点覆盖：
+  - 静态世界组装
+  - authored contract
+  - HUD / 快照
+  - 交互
+  - 怪物
+  - 工具与输入
+  - 死亡掉包与恢复
+  - 返回
+  - direct-boot 行为
+- 本轮**不把跨 Place 真传送闭环**作为阻塞项；它属于后续集成测试，不阻塞当前 Maze 内容测试
+
+## 1. 测试前准备
+
+- 使用最新 `origin/main` 对应的 Maze harness 内容
+- 在 Studio 打开 `places/maze/harness/maze.rbxlx`
+- 打开后应能直接看到 `Workspace/MazeStaticWorld/Scenery` 中的可见地面/静态几何，不需要先 Play
+- 首轮先做单人 Play；若环境允许，再补 2 人最小同步 smoke
+- 注意：`places/maze/harness/maze.rbxlx` 是 authored place file，除非明确要 reset scaffold，不要从 Rojo 重新生成覆盖它
+
+## 2. 功能验收清单
+
+### A. 启动与 authored 世界装配
+
+- 单人 Play 后不出现 bootstrap fail
+- 玩家以第一人称进入 Maze
+- `MazeBootstrapStatus` 无失败提示
+- 世界中至少能确认：
+  - `SpawnMarker`
+  - `ReturnHoldPad`
+  - 1 个 loot 房
+  - 1 扇门
+  - 1 组 `MonsterSpawns/SpawnPoint_*`
+- Lighting 已应用 Maze profile，场景不是默认 Baseplate 外观
+
+### B. HUD、快照与 direct-boot 基线
+
+- 左上 HUD 可见以下内容：
+  - `Status`
+  - `Objective`
+  - `Inventory`
+  - `PlayerState`
+  - `Roster`
+  - `Returned summaries`
+- 状态文案体现 direct-boot 语义，不是空白或旧 run 文案
+- `MazeState` 驱动的区域、目标、背包、状态会随操作更新
+- `MazePrivateState` 当前为空实现，但不应报错或显示脏数据
+- 观察项：
+  - 右上手表 HUD 若未出现或不更新，记录为观察项，不判失败
+
+### C. Authored 交互面
+
+- 在当前默认 overlay 内容上逐个验证所有 prompt：
+  - `Doorway_East` 可开关，碰撞与透明度切换正常，prompt 文案在 `Open/Close` 间切换
+  - `LootPrompt` 可拾取；拾取后 prompt / 节点消失，HUD loot 数量增加
+  - `ReturnHoldPad` 可触发返回逻辑，至少能看到本地状态变化与 direct-boot fallback 文案
+- 要求：
+  - 所有交互都必须来自 authored prompt part
+  - 不依赖运行时临时生成交互件
+
+### D. 背包、工具与输入
+
+- 验证 `1-3` / `X` / `F` / `LeftShift` 输入链路
+- 通过标准：
+  - `1-3` 可装备快捷栏前 3 个槽位
+  - `X` 可卸下 held item
+  - `F` 可触发 `RequestUseTool`
+  - `LeftShift` 可触发冲刺开始 / 结束，HUD movement 状态变化正常
+- 道具表现：
+  - Flashlight：装备后有头灯 / 光源表现
+  - Crowbar：按 `F` 有本地 swing feedback，且服务端逻辑正常接收
+  - Potion：按 `F` 后不报错，反馈符合当前实现
+- 说明：
+  - 当前快捷栏就是硬编码 3 槽，本轮不额外测分页
+
+### E. 怪物主循环与近战反击
+
+- 单人内容测试必须把怪物完整跑一遍
+- 通过标准：
+  - 怪物会在 `MonsterSpawns/SpawnPoint_*` 上生成，不会静默缺失
+  - 怪物会 patrol，并能进入 chase / attack
+  - 玩家被命中后，血量与状态快照会变化
+  - 使用 crowbar 时，至少验证一次“命中有效”和一次“未命中不误伤”
+- 失败判据：
+  - 怪物完全不生成
+  - 怪物只站桩不巡逻
+  - 怪物交互后 HUD / 状态不同步
+
+### F. 死亡、尸体包与恢复
+
+- 优先用 Studio `H / J` debug damage 做稳定验证，再补一次真实怪物击杀
+- 通过标准：
+  - 玩家死亡后会生成 corpse / dropped pack，而不是吞包
+  - 玩家会被移到 return hold 区域，不能继续正常交互
+  - 场景中出现可恢复的 dropped pack prompt
+  - 恢复 dropped pack 后，物品回到背包，场景节点消失或剩余内容正确更新
+  - 已掉落 / 已捡回状态与 HUD 一致，不出现重复复制或丢失
+
+### G. 持久化与内容重建最小 smoke
+
+- 先拾取一次 loot
+- 再做一次可重建场景的 smoke（推荐重新进场或重开 Play Session）
+- 再做一次死亡掉包并恢复
+- 验收重点：
+  - 已 collected 的 authored loot 不应在同一轮验证里立即复活
+  - dropped pack 的 recover 行为前后一致
+- 说明：
+  - 真正的 5 回合跨 Place 持久化不在本轮 gate 内
+
+### H. 多人最小同步冒烟（可选）
+
+- 若 Studio 环境允许，补一轮 2 人最小同步
+- 最低覆盖：
+  - 两名玩家能加入同一 Maze session
+  - roster / returned summaries 对双方一致
+  - 一人开门 / 拿 loot，另一人能看到结果
+  - 一人先返回后，另一人仍能继续在 Maze 中活动
+- 本轮不要求：
+  - 真跨 Place teleport 成功
+  - host / camp / debrief 全链路
+
+## 3. 负向 smoke
+
+- 在**测试副本**里做一次 authored contract 破坏验证
+- 推荐二选一：
+  - 删除 `Room_Loot/MonsterSpawns`
+  - 或把 `LootPrompt` / `ReturnHoldPad` 改名
+- 通过标准：
+  - 启动会 fail loud
+  - 错误信息能指出缺失 authored node，而不是 silent fallback
+
+## 4. 退出条件
+
+只有以下项目全部通过，才允许进入“导入外部地图资产”阶段：
+
+- 启动与 authored contract 校验通过
+- 门 / loot / return 三类 prompt 全通过
+- 快捷栏 / equip / unequip / use-tool / sprint 全通过
+- 怪物生成 / patrol / chase / attack / crowbar melee 全通过
+- 死亡掉包 / dropped pack recover 全通过
+- HUD 快照与实际状态一致，无明显错字、空白、旧语义
+
+以下项目本轮可记录但不阻塞：
+
+- `TODState` 手表 HUD 未完全生效
+- `MazePrivateState` 仍为空
+- `Library Place ID` 仍未配置
+- Run ↔ Maze 真跨 Place 传送与 5 回合闭环尚未验收
+
+## 5. 测试后建议
+
+- 若本轮内容测试通过，再进入外部地图资产导入
+- 外部资产导入前，建议先补一轮文档同步，重点更新：
+  - `FEATURES.md` 中 live path 描述
+  - `MazeEntryAvailability` 状态
+  - `TODState` remote
+  - dropped pack / corpse / world-build metadata 等当前 live feature

--- a/places/maze/STATIC_WORLD.md
+++ b/places/maze/STATIC_WORLD.md
@@ -2,6 +2,15 @@
 
 `MazeStaticWorld` is the local authored content root for the `maze` place.
 
+Authoring workflow:
+
+- `places/maze/harness/maze.rbxlx` is the everyday authoring source of truth.
+- Open the harness in Studio and edit `Workspace/MazeStaticWorld` directly.
+- Keep visible floors, walls, shell meshes, imported local assets, and other
+  non-gameplay geometry under `Workspace/MazeStaticWorld/Scenery`.
+- The overlay/chunk assets in `places/maze/assets/**` are scaffold/reset inputs;
+  runtime only falls back to them when the authored root is missing.
+
 Required root authored parts:
 
 - `SpawnMarker`
@@ -23,3 +32,5 @@ Runtime behavior:
 - `MazeStaticWorld` is the only formal runtime source for the `maze` place.
 - `MazeWorldBuilder` no longer falls back to runtime formal maze generation during place boot.
 - `Run` handoff back from the maze is handled by a dedicated transition layer; scene objects only expose the authored return nodes.
+- Runtime prefers an existing authored `Workspace/MazeStaticWorld` and only
+  assembles a scaffold root when that authored root is absent.

--- a/places/maze/assets/Chunks/MazeChunk_maze_v1.rbxmx
+++ b/places/maze/assets/Chunks/MazeChunk_maze_v1.rbxmx
@@ -37,6 +37,7 @@
             <R21>0</R21>
             <R22>1</R22>
           </CoordinateFrame>
+          <Material name="Material">Enum.Material.Slate</Material>
           <Color3 name="Color">
             <R>0.29411765933036804</R>
             <G>0.3176470696926117</G>
@@ -70,6 +71,7 @@
             <R21>0</R21>
             <R22>1</R22>
           </CoordinateFrame>
+          <Material name="Material">Enum.Material.Slate</Material>
           <Color3 name="Color">
             <R>0.3607843220233917</R>
             <G>0.3490196168422699</G>
@@ -103,6 +105,7 @@
             <R21>0</R21>
             <R22>1</R22>
           </CoordinateFrame>
+          <Material name="Material">Enum.Material.Slate</Material>
           <Color3 name="Color">
             <R>0.3607843220233917</R>
             <G>0.3490196168422699</G>
@@ -122,6 +125,7 @@
           <bool name="CanCollide">true</bool>
           <bool name="CanTouch">false</bool>
           <bool name="CanQuery">true</bool>
+          <Material name="Material">Enum.Material.Concrete</Material>
           <Vector3 name="Size">
             <X>156</X>
             <Y>20</Y>
@@ -155,6 +159,7 @@
           <bool name="CanCollide">true</bool>
           <bool name="CanTouch">false</bool>
           <bool name="CanQuery">true</bool>
+          <Material name="Material">Enum.Material.Concrete</Material>
           <Vector3 name="Size">
             <X>156</X>
             <Y>20</Y>
@@ -188,6 +193,7 @@
           <bool name="CanCollide">true</bool>
           <bool name="CanTouch">false</bool>
           <bool name="CanQuery">true</bool>
+          <Material name="Material">Enum.Material.Concrete</Material>
           <Vector3 name="Size">
             <X>6</X>
             <Y>20</Y>
@@ -221,6 +227,7 @@
           <bool name="CanCollide">true</bool>
           <bool name="CanTouch">false</bool>
           <bool name="CanQuery">true</bool>
+          <Material name="Material">Enum.Material.Concrete</Material>
           <Vector3 name="Size">
             <X>6</X>
             <Y>20</Y>
@@ -254,6 +261,7 @@
           <bool name="CanCollide">true</bool>
           <bool name="CanTouch">false</bool>
           <bool name="CanQuery">true</bool>
+          <Material name="Material">Enum.Material.Concrete</Material>
           <Vector3 name="Size">
             <X>18</X>
             <Y>16</Y>
@@ -287,6 +295,7 @@
           <bool name="CanCollide">true</bool>
           <bool name="CanTouch">false</bool>
           <bool name="CanQuery">true</bool>
+          <Material name="Material">Enum.Material.Concrete</Material>
           <Vector3 name="Size">
             <X>74</X>
             <Y>16</Y>
@@ -325,6 +334,7 @@
           <bool name="CanCollide">false</bool>
           <bool name="CanTouch">false</bool>
           <bool name="CanQuery">true</bool>
+          <Material name="Material">Enum.Material.Ice</Material>
           <float name="Transparency">0.35</float>
           <Vector3 name="Size">
             <X>42</X>

--- a/places/maze/harness/README.md
+++ b/places/maze/harness/README.md
@@ -1,16 +1,23 @@
 # Maze Harness
 
-Create the initial maze harness scaffold with:
+Create or reset the Maze harness with:
 
 ```bash
-rojo build places/maze/default.project.json -o places/maze/harness/maze.rbxlx
+./scripts/build-harnesses.sh --force
 ```
 
 Open `places/maze/harness/maze.rbxlx` in Roblox Studio and publish it only to the Maze place.
 
-After the scaffold exists, treat `places/maze/harness/maze.rbxlx` as the authored place file.
+The reset scaffold hydrates `Workspace/MazeStaticWorld` from the Maze overlay
+and chunk assets so the harness opens with visible scenery in Studio.
+
+After the scaffold exists, treat `places/maze/harness/maze.rbxlx` as the
+authored place file and source of truth for Maze world layout.
 
 - Edit `Workspace/MazeStaticWorld` directly in Studio.
-- Do not rebuild the harness from Rojo unless you intentionally want to reset it back to the source scaffold.
+- Keep formal static map geometry under `Workspace/MazeStaticWorld/Scenery`.
+- Do not rebuild the harness unless you intentionally want to reset it back to
+  the source scaffold.
 - If you do need a reset, run `./scripts/build-harnesses.sh --force`.
 - Follow [STATIC_WORLD.md](../STATIC_WORLD.md) for the required authored structure.
+- Follow [CONTENT_TEST_PLAN.md](../CONTENT_TEST_PLAN.md) for the current Maze content validation checklist before importing external map assets.

--- a/places/maze/harness/maze.rbxlx
+++ b/places/maze/harness/maze.rbxlx
@@ -5,12 +5,722 @@
     </Properties>
     <Item class="Folder" referent="1">
       <Properties>
+        <string name="Name">Assets</string>
+      </Properties>
+      <Item class="Folder" referent="2">
+        <Properties>
+          <string name="Name">Maze</string>
+        </Properties>
+        <Item class="Folder" referent="3">
+          <Properties>
+            <string name="Name">Chunks</string>
+          </Properties>
+          <Item class="Model" referent="4">
+            <Properties>
+              <string name="Name">MazeChunk_maze_v1</string>
+              <bool name="NeedsPivotMigration">false</bool>
+            </Properties>
+            <Item class="Model" referent="5">
+              <Properties>
+                <string name="Name">terrain</string>
+                <bool name="NeedsPivotMigration">false</bool>
+              </Properties>
+              <Item class="Part" referent="6">
+                <Properties>
+                  <string name="Name">Ground</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>0</X>
+                    <Y>-4</Y>
+                    <Z>0</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">true</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Color3uint8 name="Color3uint8">4936008</Color3uint8>
+                  <Vector3 name="size">
+                    <X>160</X>
+                    <Y>8</Y>
+                    <Z>160</Z>
+                  </Vector3>
+                </Properties>
+              </Item>
+              <Item class="Part" referent="7">
+                <Properties>
+                  <string name="Name">NorthShelf</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>-40</X>
+                    <Y>2</Y>
+                    <Z>-40</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">true</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Color3uint8 name="Color3uint8">6052178</Color3uint8>
+                  <Vector3 name="size">
+                    <X>68</X>
+                    <Y>4</Y>
+                    <Z>40</Z>
+                  </Vector3>
+                </Properties>
+              </Item>
+              <Item class="Part" referent="8">
+                <Properties>
+                  <string name="Name">SouthShelf</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>48</X>
+                    <Y>2</Y>
+                    <Z>40</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">true</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Color3uint8 name="Color3uint8">6052178</Color3uint8>
+                  <Vector3 name="size">
+                    <X>54</X>
+                    <Y>4</Y>
+                    <Z>32</Z>
+                  </Vector3>
+                </Properties>
+              </Item>
+            </Item>
+            <Item class="Model" referent="9">
+              <Properties>
+                <string name="Name">walls</string>
+                <bool name="NeedsPivotMigration">false</bool>
+              </Properties>
+              <Item class="Part" referent="10">
+                <Properties>
+                  <string name="Name">NorthWall</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>0</X>
+                    <Y>10</Y>
+                    <Z>-77</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">true</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Color3uint8 name="Color3uint8">2632238</Color3uint8>
+                  <Vector3 name="size">
+                    <X>156</X>
+                    <Y>20</Y>
+                    <Z>6</Z>
+                  </Vector3>
+                </Properties>
+              </Item>
+              <Item class="Part" referent="11">
+                <Properties>
+                  <string name="Name">SouthWall</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>0</X>
+                    <Y>10</Y>
+                    <Z>77</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">true</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Color3uint8 name="Color3uint8">2632238</Color3uint8>
+                  <Vector3 name="size">
+                    <X>156</X>
+                    <Y>20</Y>
+                    <Z>6</Z>
+                  </Vector3>
+                </Properties>
+              </Item>
+              <Item class="Part" referent="12">
+                <Properties>
+                  <string name="Name">WestWall</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>-77</X>
+                    <Y>10</Y>
+                    <Z>0</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">true</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Color3uint8 name="Color3uint8">2632238</Color3uint8>
+                  <Vector3 name="size">
+                    <X>6</X>
+                    <Y>20</Y>
+                    <Z>156</Z>
+                  </Vector3>
+                </Properties>
+              </Item>
+              <Item class="Part" referent="13">
+                <Properties>
+                  <string name="Name">EastWall</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>77</X>
+                    <Y>10</Y>
+                    <Z>0</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">true</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Color3uint8 name="Color3uint8">2632238</Color3uint8>
+                  <Vector3 name="size">
+                    <X>6</X>
+                    <Y>20</Y>
+                    <Z>156</Z>
+                  </Vector3>
+                </Properties>
+              </Item>
+              <Item class="Part" referent="14">
+                <Properties>
+                  <string name="Name">CentralSpine</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>8</X>
+                    <Y>8</Y>
+                    <Z>6</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">true</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Color3uint8 name="Color3uint8">3158582</Color3uint8>
+                  <Vector3 name="size">
+                    <X>18</X>
+                    <Y>16</Y>
+                    <Z>92</Z>
+                  </Vector3>
+                </Properties>
+              </Item>
+              <Item class="Part" referent="15">
+                <Properties>
+                  <string name="Name">SouthBranch</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>32</X>
+                    <Y>8</Y>
+                    <Z>28</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">true</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Color3uint8 name="Color3uint8">3158582</Color3uint8>
+                  <Vector3 name="size">
+                    <X>74</X>
+                    <Y>16</Y>
+                    <Z>14</Z>
+                  </Vector3>
+                </Properties>
+              </Item>
+            </Item>
+            <Item class="Model" referent="16">
+              <Properties>
+                <string name="Name">water</string>
+                <bool name="NeedsPivotMigration">false</bool>
+              </Properties>
+              <Item class="Part" referent="17">
+                <Properties>
+                  <string name="Name">CentralPool</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>28</X>
+                    <Y>1</Y>
+                    <Z>48</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">false</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Color3uint8 name="Color3uint8">2124226</Color3uint8>
+                  <Vector3 name="size">
+                    <X>42</X>
+                    <Y>2</Y>
+                    <Z>24</Z>
+                  </Vector3>
+                  <float name="Transparency">0.35</float>
+                </Properties>
+              </Item>
+            </Item>
+          </Item>
+        </Item>
+        <Item class="Folder" referent="18">
+          <Properties>
+            <string name="Name">Overlays</string>
+          </Properties>
+          <Item class="Folder" referent="19">
+            <Properties>
+              <string name="Name">MazeStaticWorldOverlay_Default</string>
+            </Properties>
+            <Item class="Part" referent="20">
+              <Properties>
+                <string name="Name">SpawnMarker</string>
+                <bool name="Anchored">true</bool>
+                <CoordinateFrame name="CFrame">
+                  <X>-52</X>
+                  <Y>4</Y>
+                  <Z>-48</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <bool name="CanCollide">false</bool>
+                <bool name="CanQuery">true</bool>
+                <bool name="CanTouch">false</bool>
+                <Vector3 name="size">
+                  <X>4</X>
+                  <Y>1</Y>
+                  <Z>4</Z>
+                </Vector3>
+                <float name="Transparency">1</float>
+              </Properties>
+            </Item>
+            <Item class="Part" referent="21">
+              <Properties>
+                <string name="Name">ReturnHoldPad</string>
+                <bool name="Anchored">true</bool>
+                <CoordinateFrame name="CFrame">
+                  <X>-56</X>
+                  <Y>0.5</Y>
+                  <Z>-56</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <bool name="CanCollide">false</bool>
+                <bool name="CanQuery">true</bool>
+                <bool name="CanTouch">false</bool>
+                <Vector3 name="size">
+                  <X>8</X>
+                  <Y>1</Y>
+                  <Z>8</Z>
+                </Vector3>
+                <float name="Transparency">1</float>
+              </Properties>
+              <Item class="ProximityPrompt" referent="22">
+                <Properties>
+                  <string name="Name">Prompt</string>
+                </Properties>
+              </Item>
+            </Item>
+            <Item class="Model" referent="23">
+              <Properties>
+                <string name="Name">Room_Camp</string>
+                <bool name="NeedsPivotMigration">false</bool>
+              </Properties>
+              <Item class="Part" referent="24">
+                <Properties>
+                  <string name="Name">Shell</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>-44</X>
+                    <Y>6</Y>
+                    <Z>-36</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">false</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Vector3 name="size">
+                    <X>28</X>
+                    <Y>12</Y>
+                    <Z>28</Z>
+                  </Vector3>
+                  <float name="Transparency">1</float>
+                </Properties>
+              </Item>
+            </Item>
+            <Item class="Model" referent="25">
+              <Properties>
+                <string name="Name">Room_Loot</string>
+                <bool name="NeedsPivotMigration">false</bool>
+              </Properties>
+              <Item class="Part" referent="26">
+                <Properties>
+                  <string name="Name">Shell</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>6</X>
+                    <Y>6</Y>
+                    <Z>-2</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">false</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Vector3 name="size">
+                    <X>34</X>
+                    <Y>12</Y>
+                    <Z>34</Z>
+                  </Vector3>
+                  <float name="Transparency">1</float>
+                </Properties>
+              </Item>
+              <Item class="Folder" referent="27">
+                <Properties>
+                  <string name="Name">MonsterSpawns</string>
+                </Properties>
+                <Item class="Part" referent="28">
+                  <Properties>
+                    <string name="Name">SpawnPoint_1</string>
+                    <bool name="Anchored">true</bool>
+                    <CoordinateFrame name="CFrame">
+                      <X>0</X>
+                      <Y>2</Y>
+                      <Z>-2</Z>
+                      <R00>1</R00>
+                      <R01>0</R01>
+                      <R02>0</R02>
+                      <R10>0</R10>
+                      <R11>1</R11>
+                      <R12>0</R12>
+                      <R20>0</R20>
+                      <R21>0</R21>
+                      <R22>1</R22>
+                    </CoordinateFrame>
+                    <bool name="CanCollide">false</bool>
+                    <bool name="CanQuery">true</bool>
+                    <bool name="CanTouch">false</bool>
+                    <Vector3 name="size">
+                      <X>2</X>
+                      <Y>1</Y>
+                      <Z>2</Z>
+                    </Vector3>
+                    <float name="Transparency">1</float>
+                  </Properties>
+                </Item>
+              </Item>
+              <Item class="Part" referent="29">
+                <Properties>
+                  <string name="Name">LootSocket_1</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>12</X>
+                    <Y>2</Y>
+                    <Z>-4</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">false</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Vector3 name="size">
+                    <X>2</X>
+                    <Y>1</Y>
+                    <Z>2</Z>
+                  </Vector3>
+                  <float name="Transparency">1</float>
+                </Properties>
+              </Item>
+              <Item class="Part" referent="30">
+                <Properties>
+                  <string name="Name">LootPrompt</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>12</X>
+                    <Y>2</Y>
+                    <Z>-4</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">false</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Vector3 name="size">
+                    <X>2</X>
+                    <Y>1</Y>
+                    <Z>2</Z>
+                  </Vector3>
+                  <float name="Transparency">1</float>
+                </Properties>
+                <Item class="ProximityPrompt" referent="31">
+                  <Properties>
+                    <string name="Name">Prompt</string>
+                  </Properties>
+                </Item>
+              </Item>
+              <Item class="Part" referent="32">
+                <Properties>
+                  <string name="Name">Doorway_East</string>
+                  <bool name="Anchored">true</bool>
+                  <CoordinateFrame name="CFrame">
+                    <X>22</X>
+                    <Y>4</Y>
+                    <Z>-2</Z>
+                    <R00>1</R00>
+                    <R01>0</R01>
+                    <R02>0</R02>
+                    <R10>0</R10>
+                    <R11>1</R11>
+                    <R12>0</R12>
+                    <R20>0</R20>
+                    <R21>0</R21>
+                    <R22>1</R22>
+                  </CoordinateFrame>
+                  <bool name="CanCollide">true</bool>
+                  <bool name="CanQuery">true</bool>
+                  <bool name="CanTouch">false</bool>
+                  <Vector3 name="size">
+                    <X>6</X>
+                    <Y>8</Y>
+                    <Z>2</Z>
+                  </Vector3>
+                  <float name="Transparency">1</float>
+                </Properties>
+                <Item class="ProximityPrompt" referent="33">
+                  <Properties>
+                    <string name="Name">Prompt</string>
+                  </Properties>
+                </Item>
+              </Item>
+            </Item>
+          </Item>
+        </Item>
+      </Item>
+      <Item class="Folder" referent="34">
+        <Properties>
+          <string name="Name">ToolTemplates</string>
+        </Properties>
+        <Item class="Model" referent="35">
+          <Properties>
+            <string name="Name">ToolCrowbar</string>
+            <bool name="NeedsPivotMigration">false</bool>
+          </Properties>
+          <Item class="Part" referent="36">
+            <Properties>
+              <string name="Name">Handle</string>
+              <bool name="Anchored">true</bool>
+              <CoordinateFrame name="CFrame">
+                <X>0</X>
+                <Y>0</Y>
+                <Z>0</Z>
+                <R00>1</R00>
+                <R01>0</R01>
+                <R02>0</R02>
+                <R10>0</R10>
+                <R11>1</R11>
+                <R12>0</R12>
+                <R20>0</R20>
+                <R21>0</R21>
+                <R22>1</R22>
+              </CoordinateFrame>
+              <bool name="CanCollide">false</bool>
+              <Color3uint8 name="Color3uint8">13158600</Color3uint8>
+              <Vector3 name="size">
+                <X>0.15</X>
+                <Y>0.55</Y>
+                <Z>0.12</Z>
+              </Vector3>
+            </Properties>
+          </Item>
+        </Item>
+        <Item class="Model" referent="37">
+          <Properties>
+            <string name="Name">ToolFlashlight</string>
+            <bool name="NeedsPivotMigration">false</bool>
+          </Properties>
+          <Item class="Part" referent="38">
+            <Properties>
+              <string name="Name">Handle</string>
+              <bool name="Anchored">true</bool>
+              <CoordinateFrame name="CFrame">
+                <X>0</X>
+                <Y>0</Y>
+                <Z>0</Z>
+                <R00>1</R00>
+                <R01>0</R01>
+                <R02>0</R02>
+                <R10>0</R10>
+                <R11>1</R11>
+                <R12>0</R12>
+                <R20>0</R20>
+                <R21>0</R21>
+                <R22>1</R22>
+              </CoordinateFrame>
+              <bool name="CanCollide">false</bool>
+              <Color3uint8 name="Color3uint8">9741240</Color3uint8>
+              <Vector3 name="size">
+                <X>0.2</X>
+                <Y>0.35</Y>
+                <Z>0.2</Z>
+              </Vector3>
+            </Properties>
+          </Item>
+        </Item>
+        <Item class="Model" referent="39">
+          <Properties>
+            <string name="Name">ToolPotion</string>
+            <bool name="NeedsPivotMigration">false</bool>
+          </Properties>
+          <Item class="Part" referent="40">
+            <Properties>
+              <string name="Name">Handle</string>
+              <bool name="Anchored">true</bool>
+              <CoordinateFrame name="CFrame">
+                <X>0</X>
+                <Y>0</Y>
+                <Z>0</Z>
+                <R00>1</R00>
+                <R01>0</R01>
+                <R02>0</R02>
+                <R10>0</R10>
+                <R11>1</R11>
+                <R12>0</R12>
+                <R20>0</R20>
+                <R21>0</R21>
+                <R22>1</R22>
+              </CoordinateFrame>
+              <bool name="CanCollide">false</bool>
+              <Color3uint8 name="Color3uint8">15485081</Color3uint8>
+              <Vector3 name="size">
+                <X>0.25</X>
+                <Y>0.45</Y>
+                <Z>0.25</Z>
+              </Vector3>
+            </Properties>
+          </Item>
+        </Item>
+      </Item>
+    </Item>
+    <Item class="Folder" referent="41">
+      <Properties>
         <string name="Name">Packages</string>
       </Properties>
-      <Item class="ModuleScript" referent="2">
+      <Item class="ModuleScript" referent="42">
         <Properties>
           <string name="Name">Gameplay</string>
-          <string name="Source"><![CDATA[return {
+          <string name="Source">return {
+    HeldToolUseRequest = require(script.HeldToolUseRequest),
+    Combat = require(script.Combat),
     Config = require(script.Config),
     ControlState = require(script.ControlState),
     Inventory = require(script.Inventory),
@@ -21,27 +731,305 @@
     Roles = require(script.Roles),
     Session = require(script.Session),
 }
-]]></string>
+</string>
         </Properties>
-        <Item class="ModuleScript" referent="3">
+        <Item class="ModuleScript" referent="43">
+          <Properties>
+            <string name="Name">Combat</string>
+            <string name="Source">return {
+    PlayerMonsterMelee = require(script.PlayerMonsterMelee),
+}
+</string>
+          </Properties>
+          <Item class="ModuleScript" referent="44">
+            <Properties>
+              <string name="Name">PlayerMonsterMelee</string>
+              <string name="Source">-- Pure geometry for player crowbar / melee vs a monster anchor position (tests + runtime).
+
+local EPS = 1e-4
+
+local PlayerMonsterMelee = {}
+
+function PlayerMonsterMelee.horizontalUnit(vector3)
+    if typeof(vector3) ~= 'Vector3' then
+        return nil
+    end
+
+    local horizontal = Vector3.new(vector3.X, 0, vector3.Z)
+    if horizontal.Magnitude &lt;= EPS then
+        return nil
+    end
+
+    return horizontal.Unit
+end
+
+function PlayerMonsterMelee.evaluateSwing(
+    playerPosition,
+    playerLookVector,
+    monsterPosition,
+    swingRange,
+    swingArcDegrees
+)
+    if typeof(playerPosition) ~= 'Vector3' then
+        return false, 'InvalidPlayerPosition'
+    end
+    if typeof(monsterPosition) ~= 'Vector3' then
+        return false, 'InvalidMonsterPosition'
+    end
+
+    local range = swingRange
+    if type(range) ~= 'number' or range &lt;= 0 then
+        return false, 'InvalidSwingRange'
+    end
+
+    local arc = swingArcDegrees
+    if type(arc) ~= 'number' or arc &lt;= 0 then
+        return false, 'InvalidSwingArc'
+    end
+
+    local offset = monsterPosition - playerPosition
+    local distance = offset.Magnitude
+    if distance &gt; range + EPS then
+        return false, 'OutOfRange'
+    end
+
+    local facing = PlayerMonsterMelee.horizontalUnit(playerLookVector)
+    if facing == nil then
+        return false, 'InvalidFacing'
+    end
+
+    local toMonster = PlayerMonsterMelee.horizontalUnit(offset)
+    if toMonster == nil then
+        return true, 'HitGeometryOk'
+    end
+
+    local halfArcRad = math.rad(arc * 0.5)
+    local minDot = math.cos(halfArcRad)
+    local dot = facing:Dot(toMonster)
+    if dot + EPS &lt; minDot then
+        return false, 'OutOfSwingArc'
+    end
+
+    return true, 'HitGeometryOk'
+end
+
+return PlayerMonsterMelee
+</string>
+            </Properties>
+          </Item>
+        </Item>
+        <Item class="ModuleScript" referent="45">
           <Properties>
             <string name="Name">Config</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
+    ItemFields = require(script.ItemFields),
     Items = require(script.Items),
+    ItemPresentation = require(script.ItemPresentation),
     Monsters = require(script.Monsters),
+    Players = require(script.Players),
     Roles = require(script.Roles),
+    ToolItems = require(script.ToolItems),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="4">
+          <Item class="ModuleScript" referent="46">
+            <Properties>
+              <string name="Name">ItemFields</string>
+              <string name="Source">--!strict
+-- Single source for inventory item entry fields copied into summaries and teleport contracts.
+-- See issues #232 / #229: Inventory.cloneItemEntry and CampMazeSessionContract.cloneInventoryItem must stay aligned.
+
+local ItemFields = {}
+
+local function cloneLightConfig(lightConfig: any): any
+    if type(lightConfig) ~= 'table' then
+        return nil
+    end
+
+    return {
+        Brightness = lightConfig.Brightness,
+        Range = lightConfig.Range,
+        Color = lightConfig.Color,
+    }
+end
+
+local function normalizeItemCategory(itemEntry: any): string
+    if type(itemEntry.ItemCategory) == 'string' and itemEntry.ItemCategory ~= '' then
+        return itemEntry.ItemCategory
+    end
+
+    if type(itemEntry.ToolCategory) == 'string' and itemEntry.ToolCategory ~= '' then
+        return 'Tool'
+    end
+
+    return 'Loot'
+end
+
+local function normalizeMissionCount(itemEntry: any, itemCategory: string): number
+    if type(itemEntry.MissionCount) == 'number' then
+        return itemEntry.MissionCount
+    end
+
+    if itemCategory == 'Loot' then
+        return 1
+    end
+
+    return 0
+end
+
+function ItemFields.copyItemEntry(itemEntry: any): any
+    if type(itemEntry) ~= 'table' then
+        return nil
+    end
+
+    local itemCategory = normalizeItemCategory(itemEntry)
+
+    return {
+        InstanceId = itemEntry.InstanceId,
+        Id = itemEntry.Id,
+        Name = itemEntry.Name,
+        Weight = itemEntry.Weight,
+        Value = itemEntry.Value,
+        Color = itemEntry.Color,
+        Light = cloneLightConfig(itemEntry.Light),
+        Description = itemEntry.Description,
+        IconAssetId = itemEntry.IconAssetId,
+        ToolTemplateName = itemEntry.ToolTemplateName,
+        ToolCategory = itemEntry.ToolCategory,
+        StateModel = itemEntry.StateModel,
+        InitialState = itemEntry.InitialState,
+        CurrentState = itemEntry.CurrentState,
+        ConsumePerUse = itemEntry.ConsumePerUse,
+        CooldownSeconds = itemEntry.CooldownSeconds,
+        LastUsedAt = itemEntry.LastUsedAt,
+        SwingRange = itemEntry.SwingRange,
+        SwingArcDegrees = itemEntry.SwingArcDegrees,
+        KnockbackStrength = itemEntry.KnockbackStrength,
+        MeleeDamage = itemEntry.MeleeDamage,
+        HealHealthPips = itemEntry.HealHealthPips,
+        ItemCategory = itemCategory,
+        MissionCount = normalizeMissionCount(itemEntry, itemCategory),
+        ReadableTitle = itemEntry.ReadableTitle,
+        ReadableText = itemEntry.ReadableText,
+        ClueId = itemEntry.ClueId,
+        ThreatHintId = itemEntry.ThreatHintId,
+        SourceMarkerId = itemEntry.SourceMarkerId,
+    }
+end
+
+function ItemFields.normalizeItemEntryForLoad(rawItemEntry: any): any
+    if type(rawItemEntry) ~= 'table' or type(rawItemEntry.InstanceId) ~= 'number' then
+        return nil
+    end
+
+    local itemCategory = normalizeItemCategory(rawItemEntry)
+
+    return {
+        InstanceId = rawItemEntry.InstanceId,
+        Id = rawItemEntry.Id,
+        Name = rawItemEntry.Name,
+        Weight = rawItemEntry.Weight or 0,
+        Value = rawItemEntry.Value or 0,
+        Color = rawItemEntry.Color,
+        Light = cloneLightConfig(rawItemEntry.Light),
+        Description = rawItemEntry.Description,
+        IconAssetId = rawItemEntry.IconAssetId,
+        ToolTemplateName = rawItemEntry.ToolTemplateName,
+        ToolCategory = rawItemEntry.ToolCategory,
+        StateModel = rawItemEntry.StateModel,
+        InitialState = rawItemEntry.InitialState,
+        CurrentState = rawItemEntry.CurrentState,
+        ConsumePerUse = rawItemEntry.ConsumePerUse,
+        CooldownSeconds = rawItemEntry.CooldownSeconds,
+        LastUsedAt = rawItemEntry.LastUsedAt,
+        SwingRange = rawItemEntry.SwingRange,
+        SwingArcDegrees = rawItemEntry.SwingArcDegrees,
+        KnockbackStrength = rawItemEntry.KnockbackStrength,
+        MeleeDamage = rawItemEntry.MeleeDamage,
+        HealHealthPips = rawItemEntry.HealHealthPips,
+        ItemCategory = itemCategory,
+        MissionCount = normalizeMissionCount(rawItemEntry, itemCategory),
+        ReadableTitle = rawItemEntry.ReadableTitle,
+        ReadableText = rawItemEntry.ReadableText,
+        ClueId = rawItemEntry.ClueId,
+        ThreatHintId = rawItemEntry.ThreatHintId,
+        SourceMarkerId = rawItemEntry.SourceMarkerId,
+    }
+end
+
+ItemFields.ENTRY_FIELD_NAMES = table.freeze({
+    'InstanceId',
+    'Id',
+    'Name',
+    'Weight',
+    'Value',
+    'Color',
+    'Light',
+    'Description',
+    'IconAssetId',
+    'ToolTemplateName',
+    'ToolCategory',
+    'StateModel',
+    'InitialState',
+    'CurrentState',
+    'ConsumePerUse',
+    'CooldownSeconds',
+    'LastUsedAt',
+    'SwingRange',
+    'SwingArcDegrees',
+    'KnockbackStrength',
+    'MeleeDamage',
+    'HealHealthPips',
+    'ItemCategory',
+    'MissionCount',
+    'ReadableTitle',
+    'ReadableText',
+    'ClueId',
+    'ThreatHintId',
+    'SourceMarkerId',
+})
+
+return ItemFields
+</string>
+            </Properties>
+          </Item>
+          <Item class="ModuleScript" referent="47">
+            <Properties>
+              <string name="Name">ItemPresentation</string>
+              <string name="Source">-- Shared presentation hints for items (2D icons, 3D template names).
+-- Icon PNGs are recommended square; upload to Roblox, then paste the numeric id into IconAssetId.
+
+local ItemPresentation = {}
+
+ItemPresentation.ICON_RECOMMENDED_PIXELS = 256
+
+ItemPresentation.REPLICATED_STORAGE_ASSETS_FOLDER = 'Assets'
+ItemPresentation.TOOL_TEMPLATES_FOLDER = 'ToolTemplates'
+
+function ItemPresentation.formatIconContentId(contentId: string?): string
+    if contentId == nil or contentId == '' then
+        return ''
+    end
+    if string.sub(contentId, 1, 13) == 'rbxassetid://' then
+        return contentId
+    end
+    if string.sub(contentId, 1, 11) == 'rbxasset://' then
+        return contentId
+    end
+    return 'rbxassetid://' .. contentId
+end
+
+return ItemPresentation
+</string>
+            </Properties>
+          </Item>
+          <Item class="ModuleScript" referent="48">
             <Properties>
               <string name="Name">Items</string>
-              <string name="Source"><![CDATA[local Config = script.Parent
+              <string name="Source">local Config = script.Parent
 
--- 引入探索道具武器库
 local ToolItems = require(Config:WaitForChild('ToolItems'))
 
--- 这是原本的基础物资列表
 local BaseItems = {
     {
         Id = 'ugc-gen-token',
@@ -49,6 +1037,8 @@ local BaseItems = {
         Weight = 1,
         Value = 4,
         Color = Color3.fromRGB(121, 195, 255),
+        ItemCategory = 'Loot',
+        MissionCount = 1,
     },
     {
         Id = 'scrap-bolt',
@@ -56,6 +1046,8 @@ local BaseItems = {
         Weight = 1,
         Value = 8,
         Color = Color3.fromRGB(148, 163, 184),
+        ItemCategory = 'Loot',
+        MissionCount = 1,
     },
     {
         Id = 'signal-core',
@@ -63,6 +1055,8 @@ local BaseItems = {
         Weight = 2,
         Value = 18,
         Color = Color3.fromRGB(80, 227, 194),
+        ItemCategory = 'Loot',
+        MissionCount = 1,
     },
     {
         Id = 'reactor-shell',
@@ -70,6 +1064,8 @@ local BaseItems = {
         Weight = 4,
         Value = 42,
         Color = Color3.fromRGB(248, 196, 113),
+        ItemCategory = 'Loot',
+        MissionCount = 1,
     },
     {
         Id = 'glow-orb',
@@ -82,10 +1078,11 @@ local BaseItems = {
             Range = 18,
             Color = Color3.fromRGB(170, 240, 255),
         },
+        ItemCategory = 'Loot',
+        MissionCount = 1,
     },
 }
 
--- === 自动合并逻辑：把 ToolItems 里的手电筒和撬棍也加进来 ===
 local FinalItems = table.clone(BaseItems)
 
 for _, toolData in pairs(ToolItems) do
@@ -93,13 +1090,13 @@ for _, toolData in pairs(ToolItems) do
 end
 
 return FinalItems
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="5">
+          <Item class="ModuleScript" referent="49">
             <Properties>
               <string name="Name">Monsters</string>
-              <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.Parent.Monsters.MonsterBehaviorCatalog)
+              <string name="Source">local MonsterBehaviorCatalog = require(script.Parent.Parent.Monsters.MonsterBehaviorCatalog)
 local MonsterEffectCatalog = require(script.Parent.Parent.Monsters.MonsterEffectCatalog)
 local MonsterAssetIds = require(script.Parent.Parent.Monsters.MonsterAssetIds)
 local MonsterPresentationCatalog = require(script.Parent.Parent.Monsters.MonsterPresentationCatalog)
@@ -120,10 +1117,14 @@ return {
                 Tool = 'No dedicated suppression tool in v1',
             },
         },
+        Health = {
+            MaxHp = 3,
+        },
         Tuning = {
             AttackCooldownSeconds = 1,
             AttackDamagePips = 1,
             AttackRange = 4,
+            CombatHitPoints = 3,
             Speed = 14,
             SightRange = 36,
             PatrolSpeedMultiplier = 0.45,
@@ -163,13 +1164,13 @@ return {
         },
     },
 }
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="6">
+          <Item class="ModuleScript" referent="50">
             <Properties>
               <string name="Name">Players</string>
-              <string name="Source"><![CDATA[local Players = {}
+              <string name="Source">local Players = {}
 
 Players.DefaultPlayer = table.freeze({
     Id = 'default-player',
@@ -198,13 +1199,13 @@ Players.DefaultPlayer = table.freeze({
 })
 
 return Players
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="7">
+          <Item class="ModuleScript" referent="51">
             <Properties>
               <string name="Name">Roles</string>
-              <string name="Source"><![CDATA[return {
+              <string name="Source">return {
     {
         Id = 'lead',
         PublicRole = 'Crew',
@@ -230,62 +1231,104 @@ return Players
         PermissionTags = { 'TrackInventory' },
     },
 }
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="8">
+          <Item class="ModuleScript" referent="52">
             <Properties>
               <string name="Name">ToolItems</string>
-              <string name="Source"><![CDATA[-- ExplorationToolItems Config v0.1
+              <string name="Source">-- ExplorationToolItems Config v0.1
+-- IconAssetId: Roblox image asset id only, or full rbxassetid:// URI; empty = UI uses Color fallback.
+-- ToolTemplateName: optional Model/Tool name under ReplicatedStorage.Assets.ToolTemplates (see place default.project.json).
 local ToolItems = {
-    -- 手电筒：照明消耗电量
     ['tool-flashlight'] = {
         Id = 'tool-flashlight',
         Name = 'Flashlight',
-        Description = '在黑暗中照亮路径。电量耗尽后无法使用。',
+        Description = '在黑暗中照亮路径。本配置下使用不消耗电量。',
         ToolCategory = 'Flashlight',
+        ItemCategory = 'Tool',
+        MissionCount = 0,
         Weight = 1,
         Value = 0,
         Color = Color3.fromRGB(148, 163, 184),
         IsEquipable = true,
-        -- 状态属性
+        IconAssetId = '',
+        ToolTemplateName = 'ToolFlashlight',
         StateModel = 'Battery',
         InitialState = 100,
-        ConsumePerUse = 1,
+        ConsumePerUse = 0,
         CooldownSeconds = 0,
     },
-
-    -- 撬棍：近战挥舞击退怪物
+    ['tool-rope'] = {
+        Id = 'tool-rope',
+        Name = 'Rope',
+        Description = '攀爬高处、跨越断层、固定目标。',
+        ToolCategory = 'Rope',
+        ItemCategory = 'Tool',
+        MissionCount = 0,
+        Weight = 2,
+        Value = 0,
+        Color = Color3.fromRGB(180, 160, 120),
+        IsEquipable = true,
+        IconAssetId = '',
+        ToolTemplateName = '',
+        StateModel = 'Durability',
+        InitialState = 5,
+        ConsumePerUse = 0,
+        CooldownSeconds = 0.5,
+    },
     ['tool-crowbar'] = {
         Id = 'tool-crowbar',
         Name = 'Crowbar',
-        Description = '近战挥舞可击退前方怪物。',
+        Description = '近战挥舞可对前方怪物造成伤害。本配置下使用不消耗耐久。',
         ToolCategory = 'Crowbar',
+        ItemCategory = 'Tool',
+        MissionCount = 0,
         Weight = 3,
         Value = 0,
         Color = Color3.fromRGB(200, 200, 200),
         IsEquipable = true,
-        -- 状态属性
+        IconAssetId = '',
+        ToolTemplateName = 'ToolCrowbar',
         StateModel = 'Durability',
         InitialState = 10,
-        ConsumePerUse = 1,
+        ConsumePerUse = 0,
         CooldownSeconds = 0.5,
-        -- 战斗参数
-        SwingRange = 6,
-        SwingArcDegrees = 70,
+        SwingRange = 8,
+        SwingArcDegrees = 75,
         KnockbackStrength = 15,
+        MeleeDamage = 1,
+    },
+    ['tool-potion'] = {
+        Id = 'tool-potion',
+        Name = 'Potion',
+        Description = '饮用消耗一次剂量并回复少量生命；仅在迷宫远征中作为工具使用。',
+        ToolCategory = 'Potion',
+        ItemCategory = 'Tool',
+        MissionCount = 0,
+        Weight = 1,
+        Value = 0,
+        Color = Color3.fromRGB(236, 72, 153),
+        IsEquipable = true,
+        IconAssetId = '',
+        ToolTemplateName = 'ToolPotion',
+        StateModel = 'Charges',
+        InitialState = 3,
+        ConsumePerUse = 1,
+        CooldownSeconds = 1,
+        HealHealthPips = 1,
     },
 }
 
 return ToolItems
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="9">
+        <Item class="ModuleScript" referent="53">
           <Properties>
             <string name="Name">ControlState</string>
-            <string name="Source"><![CDATA[local MODE = table.freeze({
+            <string name="Source">local MODE = table.freeze({
     Walk = 'Walk',
     Sprint = 'Sprint',
 })
@@ -314,6 +1357,12 @@ function ControlState:getSummary()
 end
 
 function ControlState:requestSprintStart(playerStateSummary)
+    if type(playerStateSummary) ~= 'table' then
+        self.SprintRequested = false
+        self.Mode = MODE.Walk
+        return false, 'MissingPlayerState'
+    end
+
     if playerStateSummary.IsDead then
         self.SprintRequested = false
         self.Mode = MODE.Walk
@@ -324,6 +1373,15 @@ function ControlState:requestSprintStart(playerStateSummary)
         self.SprintRequested = false
         self.Mode = MODE.Walk
         return false, 'StaminaDepleted'
+    end
+
+    if
+        playerStateSummary.ActiveEffects
+        and playerStateSummary.ActiveEffects['SprintSuppressed']
+    then
+        self.SprintRequested = false
+        self.Mode = MODE.Walk
+        return false, 'SprintSuppressed'
     end
 
     self.SprintRequested = true
@@ -338,6 +1396,12 @@ function ControlState:requestSprintStop()
 end
 
 function ControlState:syncPlayerState(playerStateSummary)
+    if type(playerStateSummary) ~= 'table' then
+        self.SprintRequested = false
+        self.Mode = MODE.Walk
+        return self:getSummary()
+    end
+
     if playerStateSummary.IsDead then
         self.SprintRequested = false
         self.Mode = MODE.Walk
@@ -345,6 +1409,15 @@ function ControlState:syncPlayerState(playerStateSummary)
     end
 
     if playerStateSummary.CanSprint ~= true then
+        self.SprintRequested = false
+        self.Mode = MODE.Walk
+        return self:getSummary()
+    end
+
+    if
+        playerStateSummary.ActiveEffects
+        and playerStateSummary.ActiveEffects['SprintSuppressed']
+    then
         self.SprintRequested = false
         self.Mode = MODE.Walk
         return self:getSummary()
@@ -360,43 +1433,246 @@ function ControlState:syncPlayerState(playerStateSummary)
 end
 
 return ControlState
-]]></string>
+</string>
           </Properties>
         </Item>
-        <Item class="ModuleScript" referent="10">
+        <Item class="ModuleScript" referent="54">
           <Properties>
-            <string name="Name">Inventory</string>
-            <string name="Source"><![CDATA[local Inventory = {}
-Inventory.__index = Inventory
+            <string name="Name">HeldToolUseRequest</string>
+            <string name="Source">--!strict
+-- Shared server path for RequestUseTool (maze + run): consume held state, apply category effects, status line.
+-- PR #289 (gemini-code-assist medium): cache Shared ModuleScript + required table after first flashlight use —
+-- avoids WaitForChild on every toggle; defer resolution to first use to reduce circular-init risk vs eager module-load.
 
-local function cloneLightConfig(lightConfig)
-    if type(lightConfig) ~= 'table' then
-        return nil
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+export type HeldToolUseDependencies = {
+    canManageInventory: (Player) -&gt; boolean,
+    inventoryService: any,
+    monsterService: any?,
+    playerService: any,
+    setStatus: (string) -&gt; (),
+    -- When false for Crowbar, skip consumeHeldItemState entirely (no durability step, no LastUsedAt cooldown).
+    shouldConsumeCrowbarOnUse: ((Player) -&gt; boolean)?,
+}
+
+local HeldToolUseRequest = {}
+
+local sharedModuleScript: Instance? = nil
+local sharedPackageCache: any? = nil
+
+local function getSharedRuntimePackage(): any
+    if sharedPackageCache == nil then
+        if sharedModuleScript == nil then
+            sharedModuleScript = ReplicatedStorage:WaitForChild('Packages'):WaitForChild('Shared')
+        end
+        sharedPackageCache = require(sharedModuleScript)
     end
-
-    return {
-        Brightness = lightConfig.Brightness,
-        Range = lightConfig.Range,
-        Color = lightConfig.Color,
-    }
+    return sharedPackageCache
 end
 
+local function crowbarMeleeMissText(reason: unknown): string
+    local code = if type(reason) == 'string' then reason else nil
+    if code == 'ExpeditionInactive' then
+        return 'No hunt is active yet — open the ship door / start the round before swinging at monsters.'
+    elseif code == 'NoMonster' then
+        return 'Nothing dangerous is in the field to hit right now.'
+    elseif code == 'MissingMonsterPosition' then
+        return 'The threat has no position yet — try again in a moment.'
+    elseif code == 'OutOfRange' then
+        return 'That swing was too short — move closer and try again.'
+    elseif code == 'OutOfSwingArc' then
+        return 'You need to face the threat to connect.'
+    elseif code == 'PathBlocked' then
+        return 'Something solid blocks your swing.'
+    elseif code == 'BlockedLineOfSight' then
+        return 'You need a clear view of the threat.'
+    elseif code == 'InvalidFacing' then
+        return 'You need a clear facing direction to swing.'
+    elseif code == 'NoCharacter' or code == 'MissingHumanoidRoot' then
+        return 'You cannot swing without a ready character.'
+    elseif code == 'MonsterCombatStateMissing' then
+        return 'The threat is not ready to take damage yet.'
+    elseif code == 'InvalidPlayer' then
+        return 'That swing could not be applied.'
+    end
+
+    return string.format('The crowbar whiffs (%s).', tostring(reason))
+end
+
+function HeldToolUseRequest.apply(player: Player, deps: HeldToolUseDependencies)
+    if not deps.canManageInventory(player) then
+        return
+    end
+
+    local summary = deps.playerService:getSummary(player)
+    local playerState = summary and summary.PlayerState
+    if playerState and playerState.IsDead == true then
+        deps.setStatus(string.format('%s cannot use tools while dead.', player.DisplayName))
+        return
+    end
+
+    local inventorySummary = deps.inventoryService:getSummary(player)
+    local heldItem = inventorySummary and inventorySummary.HeldItem
+
+    if not heldItem then
+        deps.setStatus(
+            string.format('%s tried to use a tool, but hands are empty.', player.DisplayName)
+        )
+        return
+    end
+
+    if type(heldItem.CurrentState) ~= 'number' or type(heldItem.ConsumePerUse) ~= 'number' then
+        deps.setStatus(
+            string.format(
+                '%s cannot actively "use" %s (it is not a tool).',
+                player.DisplayName,
+                heldItem.Name
+            )
+        )
+        return
+    end
+
+    if heldItem.ConsumePerUse &gt; 0 and heldItem.CurrentState &lt; heldItem.ConsumePerUse then
+        deps.setStatus(
+            string.format(
+                '%s tried to use %s, but it has no %s left.',
+                player.DisplayName,
+                heldItem.Name,
+                heldItem.StateModel or 'power'
+            )
+        )
+        return
+    end
+
+    if heldItem.ToolCategory == 'Crowbar' and deps.shouldConsumeCrowbarOnUse ~= nil then
+        if not deps.shouldConsumeCrowbarOnUse(player) then
+            deps.setStatus(
+                string.format(
+                    '%s hefted the %s, but the hunt is not live yet — no swing was committed (no use or cooldown).',
+                    player.DisplayName,
+                    heldItem.Name
+                )
+            )
+            return
+        end
+    end
+
+    local consumeSuccess, consumeResult, cooldownRemaining =
+        deps.inventoryService:consumeHeldItemState(player, os.clock())
+    if not consumeSuccess then
+        if consumeResult == 'Cooldown' then
+            deps.setStatus(
+                string.format(
+                    '%s cannot use %s yet (cooldown %.1fs remaining).',
+                    player.DisplayName,
+                    heldItem.Name,
+                    math.max(cooldownRemaining or 0, 0)
+                )
+            )
+        else
+            deps.setStatus(
+                string.format(
+                    '%s could not use %s (%s).',
+                    player.DisplayName,
+                    heldItem.Name,
+                    tostring(consumeResult)
+                )
+            )
+        end
+        return
+    end
+
+    local updatedHeldItem = consumeResult
+
+    local actionWord = 'used'
+    local effectText = 'It worked!'
+
+    if updatedHeldItem.ToolCategory == 'Flashlight' then
+        actionWord = 'flashed'
+        local enabled = getSharedRuntimePackage().Runtime.HeldFlashlightHeadlight.toggle(player)
+        if enabled == nil then
+            effectText = 'Head lamp could not be toggled (no head).'
+        elseif enabled then
+            effectText = 'Headlamp on.'
+        else
+            effectText = 'Headlamp off.'
+        end
+    elseif updatedHeldItem.ToolCategory == 'Crowbar' then
+        actionWord = 'swung'
+        effectText = 'A satisfying swoosh cuts the air!'
+
+        local damagePips = 1
+        if type(updatedHeldItem.MeleeDamage) == 'number' and updatedHeldItem.MeleeDamage &gt;= 1 then
+            damagePips = math.floor(updatedHeldItem.MeleeDamage)
+        end
+
+        local monsterService = deps.monsterService
+        if not monsterService then
+            effectText = 'Monsters are not loaded yet — try again in a moment.'
+        else
+            local meleeOk, meleeResult = monsterService:tryApplyPlayerMeleeHit(player, {
+                DamagePips = damagePips,
+                SwingArcDegrees = updatedHeldItem.SwingArcDegrees,
+                SwingRange = updatedHeldItem.SwingRange,
+            })
+            if meleeOk then
+                if meleeResult and meleeResult.Killed then
+                    effectText = 'The crowbar connects — the threat goes down!'
+                elseif meleeResult and type(meleeResult.RemainingHitPoints) == 'number' then
+                    effectText = string.format(
+                        'The crowbar connects! Foe stamina: ~%d.',
+                        meleeResult.RemainingHitPoints
+                    )
+                end
+            else
+                effectText = crowbarMeleeMissText(meleeResult)
+            end
+        end
+    elseif updatedHeldItem.ToolCategory == 'Potion' then
+        actionWord = 'drank'
+        local healPips = 1
+        if
+            type(updatedHeldItem.HealHealthPips) == 'number'
+            and updatedHeldItem.HealHealthPips &gt;= 1
+        then
+            healPips = math.floor(updatedHeldItem.HealHealthPips)
+        end
+        local healOk, healResult = deps.playerService:healHealthPips(player, healPips)
+        if healOk then
+            effectText = string.format('The brew steadies you — health pips: %d.', healResult)
+        else
+            effectText = string.format('The brew has no effect (%s).', tostring(healResult))
+        end
+    end
+
+    deps.setStatus(
+        string.format(
+            '%s %s the %s. %s (%s remaining: %d)',
+            player.DisplayName,
+            actionWord,
+            updatedHeldItem.Name,
+            effectText,
+            updatedHeldItem.StateModel or 'state',
+            updatedHeldItem.CurrentState
+        )
+    )
+end
+
+return HeldToolUseRequest
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="55">
+          <Properties>
+            <string name="Name">Inventory</string>
+            <string name="Source">local ItemFields = require(script.Parent.Config.ItemFields)
+
+local Inventory = {}
+Inventory.__index = Inventory
+
 local function cloneItemEntry(itemEntry)
-    return {
-        InstanceId = itemEntry.InstanceId,
-        Id = itemEntry.Id,
-        Name = itemEntry.Name,
-        Weight = itemEntry.Weight,
-        Value = itemEntry.Value,
-        Color = itemEntry.Color,
-        Light = cloneLightConfig(itemEntry.Light),
-        ToolCategory = itemEntry.ToolCategory,
-        StateModel = itemEntry.StateModel,
-        CurrentState = itemEntry.CurrentState,
-        ConsumePerUse = itemEntry.ConsumePerUse,
-        CooldownSeconds = itemEntry.CooldownSeconds,
-        LastUsedAt = itemEntry.LastUsedAt,
-    }
+    return ItemFields.copyItemEntry(itemEntry)
 end
 
 local function cloneArray(items)
@@ -409,13 +1685,39 @@ local function cloneArray(items)
     return result
 end
 
-function Inventory.new(capacity)
-    local backpackItems = {}
+local function getItemCategory(itemEntry)
+    if type(itemEntry.ItemCategory) == 'string' and itemEntry.ItemCategory ~= '' then
+        return itemEntry.ItemCategory
+    end
 
+    if type(itemEntry.ToolCategory) == 'string' and itemEntry.ToolCategory ~= '' then
+        return 'Tool'
+    end
+
+    return 'Loot'
+end
+
+local function getMissionCount(itemEntry)
+    if type(itemEntry.MissionCount) == 'number' then
+        return itemEntry.MissionCount
+    end
+
+    if getItemCategory(itemEntry) == 'Loot' then
+        return 1
+    end
+
+    return 0
+end
+
+local function normalizeItemEntry(rawItemEntry)
+    return ItemFields.normalizeItemEntryForLoad(rawItemEntry)
+end
+
+function Inventory.new(capacity)
     return setmetatable({
         Capacity = capacity,
         Weight = 0,
-        BackpackItems = backpackItems,
+        BackpackItems = {},
         HeldItem = nil,
         NextItemInstanceId = 1,
     }, Inventory)
@@ -426,58 +1728,73 @@ function Inventory:getCount()
     return #self.BackpackItems + heldCount
 end
 
+function Inventory:_hasCapacityFor(additionalCount)
+    local nextCount = self:getCount() + (additionalCount or 1)
+    return nextCount &lt;= self.Capacity
+end
+
 function Inventory:_buildItemEntry(itemDef)
-    local itemEntry = {
-        InstanceId = self.NextItemInstanceId,
+    local instanceId = self.NextItemInstanceId
+    self.NextItemInstanceId += 1
+
+    return ItemFields.copyItemEntry({
+        InstanceId = instanceId,
         Id = itemDef.Id,
         Name = itemDef.Name,
         Weight = itemDef.Weight,
         Value = itemDef.Value,
         Color = itemDef.Color,
-        Light = cloneLightConfig(itemDef.Light),
+        Light = itemDef.Light,
+        Description = itemDef.Description,
+        IconAssetId = itemDef.IconAssetId,
+        ToolTemplateName = itemDef.ToolTemplateName,
         ToolCategory = itemDef.ToolCategory,
         StateModel = itemDef.StateModel,
-        CurrentState = itemDef.InitialState,
+        InitialState = itemDef.InitialState,
+        CurrentState = itemDef.CurrentState or itemDef.InitialState,
         ConsumePerUse = itemDef.ConsumePerUse,
         CooldownSeconds = itemDef.CooldownSeconds,
         LastUsedAt = itemDef.LastUsedAt,
-    }
-
-    self.NextItemInstanceId += 1
-
-    return itemEntry
-end
-
-local function normalizeItemEntry(rawItemEntry)
-    if type(rawItemEntry) ~= 'table' or type(rawItemEntry.InstanceId) ~= 'number' then
-        return nil
-    end
-
-    return {
-        InstanceId = rawItemEntry.InstanceId,
-        Id = rawItemEntry.Id,
-        Name = rawItemEntry.Name,
-        Weight = rawItemEntry.Weight or 0,
-        Value = rawItemEntry.Value or 0,
-        Color = rawItemEntry.Color,
-        Light = cloneLightConfig(rawItemEntry.Light),
-        ToolCategory = rawItemEntry.ToolCategory,
-        StateModel = rawItemEntry.StateModel,
-        CurrentState = rawItemEntry.CurrentState,
-        ConsumePerUse = rawItemEntry.ConsumePerUse,
-        CooldownSeconds = rawItemEntry.CooldownSeconds,
-        LastUsedAt = rawItemEntry.LastUsedAt,
-    }
+        SwingRange = itemDef.SwingRange,
+        SwingArcDegrees = itemDef.SwingArcDegrees,
+        KnockbackStrength = itemDef.KnockbackStrength,
+        MeleeDamage = itemDef.MeleeDamage,
+        HealHealthPips = itemDef.HealHealthPips,
+        ItemCategory = itemDef.ItemCategory,
+        MissionCount = itemDef.MissionCount,
+        ReadableTitle = itemDef.ReadableTitle,
+        ReadableText = itemDef.ReadableText,
+        ClueId = itemDef.ClueId,
+        ThreatHintId = itemDef.ThreatHintId,
+        SourceMarkerId = itemDef.SourceMarkerId,
+    })
 end
 
 function Inventory:add(itemDef)
-    if self.Weight + itemDef.Weight > self.Capacity then
-        return false, 'OverCapacity'
+    if not self:_hasCapacityFor(1) then
+        return false, 'InventoryFull'
     end
 
     local itemEntry = self:_buildItemEntry(itemDef)
     table.insert(self.BackpackItems, itemEntry)
-    self.Weight += itemDef.Weight
+    return true, cloneItemEntry(itemEntry)
+end
+
+function Inventory:addEntry(rawItemEntry)
+    if not self:_hasCapacityFor(1) then
+        return false, 'InventoryFull'
+    end
+
+    local itemEntry = normalizeItemEntry(rawItemEntry)
+    if itemEntry == nil then
+        return false, 'InvalidItemEntry'
+    end
+
+    if itemEntry.InstanceId &gt;= self.NextItemInstanceId then
+        self.NextItemInstanceId = itemEntry.InstanceId + 1
+    end
+
+    table.insert(self.BackpackItems, itemEntry)
     return true, cloneItemEntry(itemEntry)
 end
 
@@ -529,48 +1846,82 @@ function Inventory:consumeHeldItemState(nowSeconds)
         return false, 'NotConsumable'
     end
 
-    if heldItem.CurrentState < heldItem.ConsumePerUse then
-        return false, 'Depleted'
-    end
-
     local now = type(nowSeconds) == 'number' and nowSeconds or os.clock()
     local cooldownSeconds = heldItem.CooldownSeconds
-    if type(cooldownSeconds) == 'number' and cooldownSeconds > 0 then
+    if type(cooldownSeconds) == 'number' and cooldownSeconds &gt; 0 then
         local lastUsedAt = heldItem.LastUsedAt
-        if type(lastUsedAt) == 'number' and now - lastUsedAt < cooldownSeconds then
+        if type(lastUsedAt) == 'number' and now - lastUsedAt &lt; cooldownSeconds then
             return false, 'Cooldown', cooldownSeconds - (now - lastUsedAt)
         end
     end
 
-    heldItem.CurrentState -= heldItem.ConsumePerUse
+    if heldItem.ConsumePerUse &gt; 0 then
+        if heldItem.CurrentState &lt; heldItem.ConsumePerUse then
+            return false, 'Depleted'
+        end
+
+        heldItem.CurrentState -= heldItem.ConsumePerUse
+    end
+
     heldItem.LastUsedAt = now
+
     return true, cloneItemEntry(heldItem)
 end
 
 function Inventory:getTotalValue()
-    local totalValue = 0
+    return 0
+end
+
+function Inventory:_summarizeCategories()
+    local counts = {
+        LootCount = 0,
+        ClueCount = 0,
+        ToolCount = 0,
+        MissionCount = 0,
+    }
+
+    local function addItem(itemEntry)
+        if itemEntry == nil then
+            return
+        end
+
+        local itemCategory = getItemCategory(itemEntry)
+        if itemCategory == 'Clue' then
+            counts.ClueCount += 1
+        elseif itemCategory == 'Tool' then
+            counts.ToolCount += 1
+        else
+            counts.LootCount += 1
+        end
+
+        counts.MissionCount += getMissionCount(itemEntry)
+    end
 
     for _, itemEntry in ipairs(self.BackpackItems) do
-        totalValue += itemEntry.Value
+        addItem(itemEntry)
     end
 
-    if self.HeldItem ~= nil then
-        totalValue += self.HeldItem.Value
-    end
+    addItem(self.HeldItem)
 
-    return totalValue
+    return counts
 end
 
 function Inventory:getSummary()
+    local categoryCounts = self:_summarizeCategories()
+
     return {
         Capacity = self.Capacity,
-        Weight = self.Weight,
+        Weight = 0,
         Count = self:getCount(),
         BackpackCount = #self.BackpackItems,
         HeldCount = self.HeldItem and 1 or 0,
-        Value = self:getTotalValue(),
+        Value = 0,
         BackpackItems = cloneArray(self.BackpackItems),
         HeldItem = self.HeldItem and cloneItemEntry(self.HeldItem) or nil,
+        LootCount = categoryCounts.LootCount,
+        ClueCount = categoryCounts.ClueCount,
+        ToolCount = categoryCounts.ToolCount,
+        MissionCount = categoryCounts.MissionCount,
     }
 end
 
@@ -587,11 +1938,8 @@ function Inventory:loadSummary(summary)
     local maxItemInstanceId = 0
     local function processItem(rawItemEntry)
         local itemEntry = normalizeItemEntry(rawItemEntry)
-        if itemEntry ~= nil then
-            self.Weight += itemEntry.Weight
-            if itemEntry.InstanceId > maxItemInstanceId then
-                maxItemInstanceId = itemEntry.InstanceId
-            end
+        if itemEntry ~= nil and itemEntry.InstanceId &gt; maxItemInstanceId then
+            maxItemInstanceId = itemEntry.InstanceId
         end
 
         return itemEntry
@@ -646,7 +1994,6 @@ function Inventory:consumeById(itemId)
     for index, itemEntry in ipairs(self.BackpackItems) do
         if itemEntry.Id == itemId then
             local consumed = table.remove(self.BackpackItems, index)
-            self.Weight -= consumed.Weight
             return true, cloneItemEntry(consumed)
         end
     end
@@ -654,21 +2001,81 @@ function Inventory:consumeById(itemId)
     if self.HeldItem and self.HeldItem.Id == itemId then
         local consumed = self.HeldItem
         self.HeldItem = nil
-        self.Weight -= consumed.Weight
         return true, cloneItemEntry(consumed)
     end
 
     return false, 'ItemNotFound'
 end
 
+function Inventory:extractMissionCargo()
+    local extracted = {}
+    local remaining = {}
+    local missionCount = 0
+
+    for _, itemEntry in ipairs(self.BackpackItems) do
+        if getMissionCount(itemEntry) &gt; 0 then
+            table.insert(extracted, cloneItemEntry(itemEntry))
+            missionCount += getMissionCount(itemEntry)
+        else
+            table.insert(remaining, itemEntry)
+        end
+    end
+
+    self.BackpackItems = remaining
+
+    if self.HeldItem and getMissionCount(self.HeldItem) &gt; 0 then
+        table.insert(extracted, cloneItemEntry(self.HeldItem))
+        missionCount += getMissionCount(self.HeldItem)
+        self.HeldItem = nil
+    end
+
+    return extracted, missionCount
+end
+
+function Inventory:dropAllItems()
+    local dropped = {}
+
+    for _, itemEntry in ipairs(self.BackpackItems) do
+        table.insert(dropped, cloneItemEntry(itemEntry))
+    end
+
+    if self.HeldItem ~= nil then
+        table.insert(dropped, cloneItemEntry(self.HeldItem))
+    end
+
+    self:clear()
+    return dropped
+end
+
+function Inventory:sell(itemId)
+    if type(itemId) ~= 'string' or itemId == '' then
+        return false, 'MissingItemId'
+    end
+
+    for index, itemEntry in ipairs(self.BackpackItems) do
+        if itemEntry.Id == itemId then
+            local sold = table.remove(self.BackpackItems, index)
+            return true, cloneItemEntry(sold), sold.Value or 0
+        end
+    end
+
+    if self.HeldItem and self.HeldItem.Id == itemId then
+        local sold = self.HeldItem
+        self.HeldItem = nil
+        return true, cloneItemEntry(sold), sold.Value or 0
+    end
+
+    return false, 'ItemNotFound'
+end
+
 return Inventory
-]]></string>
+</string>
           </Properties>
         </Item>
-        <Item class="ModuleScript" referent="11">
+        <Item class="ModuleScript" referent="56">
           <Properties>
             <string name="Name">Monsters</string>
-            <string name="Source"><![CDATA[local MonsterCompiler = require(script.MonsterCompiler)
+            <string name="Source">local MonsterCompiler = require(script.MonsterCompiler)
 
 return {
     MonsterComponentConfig = require(script.MonsterComponentConfig),
@@ -688,16 +2095,94 @@ return {
     MonsterRuntimeProfile = require(script.MonsterRuntimeProfile),
     compileMonsterForMaze = MonsterCompiler.compileMonsterForMaze,
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="Folder" referent="12">
+          <Item class="ModuleScript" referent="57">
+            <Properties>
+              <string name="Name">BaseEnemy</string>
+              <string name="Source">local HealthComponent = require(script.Parent.Components.HealthComponent)
+
+local BaseEnemy = {}
+
+function BaseEnemy.setupHealth(self, componentConfig)
+    local maxHp = 1
+    if type(componentConfig) == 'table' and type(componentConfig.Health) == 'table' then
+        local hp = componentConfig.Health.MaxHp
+        if type(hp) == 'number' and hp &gt;= 1 then
+            maxHp = math.floor(hp)
+        end
+    end
+
+    if not self.Components then
+        self.Components = {}
+    end
+
+    self.Components.Health = HealthComponent.new(maxHp)
+end
+
+function BaseEnemy.applyDamage(self, amount, source)
+    local health = self.Components and self.Components.Health
+    if not health then
+        return
+    end
+
+    if type(amount) ~= 'number' or amount &lt;= 0 then
+        return
+    end
+
+    local damageSource = source or 'unknown'
+    health:applyDamage(amount, damageSource)
+
+    if self.Blackboard and health:isDead() then
+        self.Blackboard.Transient.DeathEvent = {
+            MonsterId = if self.Blackboard.Definition then self.Blackboard.Definition.Id else nil,
+            KilledBy = damageSource,
+        }
+    end
+end
+
+function BaseEnemy.heal(self, amount)
+    local health = self.Components and self.Components.Health
+    if not health then
+        return
+    end
+
+    if type(amount) ~= 'number' or amount &lt;= 0 then
+        return
+    end
+
+    health:heal(amount)
+end
+
+function BaseEnemy.getHealth(self)
+    local health = self.Components and self.Components.Health
+    if not health then
+        return {
+            CurrentHp = 0,
+            MaxHp = 0,
+            IsDead = true,
+        }
+    end
+
+    return {
+        CurrentHp = health.CurrentHp,
+        MaxHp = health.MaxHp,
+        IsDead = health:isDead(),
+    }
+end
+
+return BaseEnemy
+</string>
+            </Properties>
+          </Item>
+          <Item class="Folder" referent="58">
             <Properties>
               <string name="Name">Components</string>
             </Properties>
-            <Item class="ModuleScript" referent="13">
+            <Item class="ModuleScript" referent="59">
               <Properties>
                 <string name="Name">AttackComponent</string>
-                <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
+                <string name="Source">local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
 
 local AttackComponent = {}
 AttackComponent.__index = AttackComponent
@@ -755,11 +2240,11 @@ function AttackComponent:update(blackboard, dt)
 
     local attackConfig = readAttackConfig(blackboard.Context)
     local attackRange = attackConfig.Range or DEFAULT_ATTACK_RANGE
-    if (targetPosition - currentPosition).Magnitude > attackRange then
+    if (targetPosition - currentPosition).Magnitude &gt; attackRange then
         return
     end
 
-    if self.CooldownRemaining > 0 then
+    if self.CooldownRemaining &gt; 0 then
         return
     end
 
@@ -776,13 +2261,68 @@ end
 function AttackComponent:destroy(_blackboard) end
 
 return AttackComponent
-]]></string>
+</string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="14">
+            <Item class="ModuleScript" referent="60">
+              <Properties>
+                <string name="Name">HealthComponent</string>
+                <string name="Source">local HealthComponent = {}
+HealthComponent.__index = HealthComponent
+
+function HealthComponent.new(maxHp)
+    local hp = 1
+    if type(maxHp) == 'number' and maxHp &gt;= 1 then
+        hp = math.floor(maxHp)
+    end
+
+    return setmetatable({
+        MaxHp = hp,
+        CurrentHp = hp,
+    }, HealthComponent)
+end
+
+function HealthComponent:init(_blackboard)
+    -- No-op: initialization is done in the constructor.
+end
+
+function HealthComponent:applyDamage(amount, _source)
+    if type(amount) ~= 'number' or amount &lt;= 0 then
+        return
+    end
+
+    self.CurrentHp = math.max(0, self.CurrentHp - amount)
+end
+
+function HealthComponent:heal(amount)
+    if type(amount) ~= 'number' or amount &lt;= 0 then
+        return
+    end
+
+    self.CurrentHp = math.min(self.MaxHp, self.CurrentHp + amount)
+end
+
+function HealthComponent:isDead()
+    return self.CurrentHp &lt;= 0
+end
+
+function HealthComponent:update(_blackboard, _dt)
+    -- No-op: HealthComponent is driven by explicit applyDamage / heal calls,
+    -- not by a per-tick update tick.
+end
+
+function HealthComponent:destroy(_blackboard)
+    -- No-op: no external resources to release.
+end
+
+return HealthComponent
+</string>
+              </Properties>
+            </Item>
+            <Item class="ModuleScript" referent="61">
               <Properties>
                 <string name="Name">MovementComponent</string>
-                <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
+                <string name="Source">local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
 local MonsterLogic = require(script.Parent.Parent.MonsterLogic)
 
 local MovementComponent = {}
@@ -842,14 +2382,14 @@ function MovementComponent:update(blackboard, dt)
 
         if
             (nextPosition - patrolTarget).Magnitude
-            <= (movementConfig.PatrolReachDistance or blackboard.Context.PatrolReachDistance or 2)
+            &lt;= (movementConfig.PatrolReachDistance or blackboard.Context.PatrolReachDistance or 2)
         then
             shouldAdvancePatrol = true
         end
     end
 
     local travelOffset = if nextPosition then nextPosition - currentPosition else Vector3.zero
-    local isMoving = travelOffset.Magnitude > 0
+    local isMoving = travelOffset.Magnitude &gt; 0
 
     blackboard.Transient.NextPosition = nextPosition
     blackboard.Transient.ShouldAdvancePatrol = shouldAdvancePatrol
@@ -865,13 +2405,13 @@ end
 function MovementComponent:destroy(_blackboard) end
 
 return MovementComponent
-]]></string>
+</string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="15">
+            <Item class="ModuleScript" referent="62">
               <Properties>
                 <string name="Name">PerceptionComponent</string>
-                <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
+                <string name="Source">local MonsterBehaviorCatalog = require(script.Parent.Parent.MonsterBehaviorCatalog)
 local MonsterLogic = require(script.Parent.Parent.MonsterLogic)
 
 local PerceptionComponent = {}
@@ -921,14 +2461,15 @@ end
 function PerceptionComponent:destroy(_blackboard) end
 
 return PerceptionComponent
-]]></string>
+</string>
               </Properties>
             </Item>
           </Item>
-          <Item class="ModuleScript" referent="16">
+          <Item class="ModuleScript" referent="63">
             <Properties>
               <string name="Name">Enemy</string>
-              <string name="Source"><![CDATA[local EnemyBlackboard = require(script.Parent.EnemyBlackboard)
+              <string name="Source">local BaseEnemy = require(script.Parent.BaseEnemy)
+local EnemyBlackboard = require(script.Parent.EnemyBlackboard)
 local EnemyStateMachine = require(script.Parent.EnemyStateMachine)
 
 local AttackComponent = require(script.Parent.Components.AttackComponent)
@@ -937,6 +2478,7 @@ local PerceptionComponent = require(script.Parent.Components.PerceptionComponent
 
 local Enemy = {}
 Enemy.__index = Enemy
+setmetatable(Enemy, { __index = BaseEnemy })
 
 local UPDATE_ORDER = table.freeze({
     'Perception',
@@ -963,13 +2505,16 @@ function Enemy.new(definition, options)
     local stateMachine = enemyOptions.StateMachine or EnemyStateMachine.new()
     local components = enemyOptions.Components or defaultComponents()
 
-    return setmetatable({
+    local self = setmetatable({
         Blackboard = blackboard,
         ComponentConfig = enemyOptions.ComponentConfig or {},
         StateMachine = stateMachine,
         Components = components,
         StageObserver = enemyOptions.StageObserver,
     }, Enemy)
+
+    self:setupHealth(self.ComponentConfig)
+    return self
 end
 
 function Enemy:_emitStage(stageName)
@@ -1004,6 +2549,10 @@ function Enemy:update(dt, context)
     self:_emitStage('Attack')
     self.Components.Attack:update(self.Blackboard, dt)
 
+    if self.Components.Health then
+        self.Components.Health:update(self.Blackboard, dt)
+    end
+
     return {
         AttackIntent = self.Blackboard.Transient.AttackIntent,
         State = self.Blackboard:getState(),
@@ -1014,6 +2563,8 @@ function Enemy:update(dt, context)
         DesiredAnimationSpeed = self.Blackboard.Transient.DesiredAnimationSpeed or 1,
         ShouldPlayChaseLoop = self.Blackboard.Transient.ShouldPlayChaseLoop == true,
         TravelOffset = self.Blackboard.Transient.TravelOffset or Vector3.zero,
+        IsDead = self.Components.Health and self.Components.Health:isDead() or false,
+        DeathEvent = self.Blackboard.Transient.DeathEvent,
     }
 end
 
@@ -1028,13 +2579,13 @@ end
 Enemy.UpdateOrder = UPDATE_ORDER
 
 return Enemy
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="17">
+          <Item class="ModuleScript" referent="64">
             <Properties>
               <string name="Name">EnemyBlackboard</string>
-              <string name="Source"><![CDATA[local EnemyBlackboard = {}
+              <string name="Source">local EnemyBlackboard = {}
 EnemyBlackboard.__index = EnemyBlackboard
 
 local function cloneTable(source)
@@ -1073,13 +2624,13 @@ function EnemyBlackboard:getState()
 end
 
 return EnemyBlackboard
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="18">
+          <Item class="ModuleScript" referent="65">
             <Properties>
               <string name="Name">EnemyStateMachine</string>
-              <string name="Source"><![CDATA[local EnemyStateMachine = {}
+              <string name="Source">local EnemyStateMachine = {}
 EnemyStateMachine.__index = EnemyStateMachine
 
 local STATE = table.freeze({
@@ -1119,7 +2670,7 @@ function EnemyStateMachine:update(blackboard)
 
     if self.Current == STATE.Search then
         self.LostTargetTicks += 1
-        if self.LostTargetTicks >= 2 then
+        if self.LostTargetTicks &gt;= 2 then
             self.Current = STATE.Idle
         end
         blackboard:setState(self.Current)
@@ -1134,13 +2685,13 @@ end
 EnemyStateMachine.State = STATE
 
 return EnemyStateMachine
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="19">
+          <Item class="ModuleScript" referent="66">
             <Properties>
               <string name="Name">MazeMonsterSpawnPolicy</string>
-              <string name="Source"><![CDATA[local MazeMonsterSpawnPolicy = {}
+              <string name="Source">local MazeMonsterSpawnPolicy = {}
 
 function MazeMonsterSpawnPolicy.buildInitialSpawnExcludedRoomIds(roomById, campRoomId)
     local excludedRoomIds = {}
@@ -1218,7 +2769,7 @@ function MazeMonsterSpawnPolicy.selectRandomEligiblePatrolIndex(
         if
             eligibleRoomSet[roomId]
             and affordance
-            and #((affordance and affordance.PatrolAnchors) or {}) > 0
+            and #((affordance and affordance.PatrolAnchors) or {}) &gt; 0
         then
             table.insert(roomsWithPatrolAnchors, roomId)
         end
@@ -1246,25 +2797,25 @@ function MazeMonsterSpawnPolicy.selectRandomEligiblePatrolIndex(
 end
 
 return MazeMonsterSpawnPolicy
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="20">
+          <Item class="ModuleScript" referent="67">
             <Properties>
               <string name="Name">MonsterAssetIds</string>
-              <string name="Source"><![CDATA[local MonsterAssetIds = table.freeze({
+              <string name="Source">local MonsterAssetIds = table.freeze({
     DefaultModelAssetId = 9492320977,
     DefaultChaseLoopSoundAssetId = 9118823108,
 })
 
 return MonsterAssetIds
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="21">
+          <Item class="ModuleScript" referent="68">
             <Properties>
               <string name="Name">MonsterAuthorProfile</string>
-              <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
+              <string name="Source">local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
 local MonsterEffectCatalog = require(script.Parent.MonsterEffectCatalog)
 local MonsterPresentationCatalog = require(script.Parent.MonsterPresentationCatalog)
 
@@ -1303,6 +2854,7 @@ local BOUNDARY_REASONS = table.freeze({
     BoundarySemanticsContainsNonSemanticField = true,
     BoundaryTuningContainsNonTuningField = true,
     BoundaryExecutableContainsNonExecutableField = true,
+    BoundaryHealthContainsNonHealthField = true,
 })
 
 MonsterAuthorProfile.ErrorCategory = ERROR_CATEGORY
@@ -1339,7 +2891,7 @@ local function validatePresentation(presentation)
         return false, 'MissingPresentation'
     end
 
-    if type(presentation.ModelAssetId) ~= 'number' or presentation.ModelAssetId <= 0 then
+    if type(presentation.ModelAssetId) ~= 'number' or presentation.ModelAssetId &lt;= 0 then
         return false, 'InvalidModelAssetId'
     end
 
@@ -1355,7 +2907,7 @@ local function validatePresentation(presentation)
         presentation.ChaseLoopSoundAssetId ~= nil
         and (
             type(presentation.ChaseLoopSoundAssetId) ~= 'number'
-            or presentation.ChaseLoopSoundAssetId <= 0
+            or presentation.ChaseLoopSoundAssetId &lt;= 0
         )
     then
         return false, 'InvalidChaseLoopSoundAssetId'
@@ -1423,11 +2975,27 @@ local function normalizeSections(profile)
         return nil, 'BoundaryExecutableContainsNonExecutableField'
     end
 
+    local health = profile.Health
+    if health ~= nil and type(health) ~= 'table' then
+        return nil, 'InvalidHealth'
+    end
+
+    if health ~= nil then
+        if
+            hasAnyField(health, SEMANTIC_FIELDS)
+            or hasAnyField(health, TUNING_FIELDS)
+            or hasAnyField(health, EXECUTABLE_FIELDS)
+        then
+            return nil, 'BoundaryHealthContainsNonHealthField'
+        end
+    end
+
     return {
         SchemaMode = SCHEMA_MODE.Layered,
         Semantics = semantics,
         Tuning = tuning,
         Executable = executable,
+        Health = health,
     }
 end
 
@@ -1485,27 +3053,27 @@ function MonsterAuthorProfile.validate(profile)
     end
 
     local tuning = normalizedSections.Tuning
-    if type(tuning.Speed) ~= 'number' or tuning.Speed <= 0 then
+    if type(tuning.Speed) ~= 'number' or tuning.Speed &lt;= 0 then
         return false, 'InvalidSpeed'
     end
 
-    if type(tuning.SightRange) ~= 'number' or tuning.SightRange <= 0 then
+    if type(tuning.SightRange) ~= 'number' or tuning.SightRange &lt;= 0 then
         return false, 'InvalidSightRange'
     end
 
-    if type(tuning.PatrolSpeedMultiplier) ~= 'number' or tuning.PatrolSpeedMultiplier <= 0 then
+    if type(tuning.PatrolSpeedMultiplier) ~= 'number' or tuning.PatrolSpeedMultiplier &lt;= 0 then
         return false, 'InvalidPatrolSpeedMultiplier'
     end
 
     if
         tuning.AttackRange ~= nil
-        and (type(tuning.AttackRange) ~= 'number' or tuning.AttackRange <= 0)
+        and (type(tuning.AttackRange) ~= 'number' or tuning.AttackRange &lt;= 0)
     then
         return false, 'InvalidAttackRange'
     end
 
     if tuning.AttackCooldownSeconds ~= nil then
-        if type(tuning.AttackCooldownSeconds) ~= 'number' or tuning.AttackCooldownSeconds <= 0 then
+        if type(tuning.AttackCooldownSeconds) ~= 'number' or tuning.AttackCooldownSeconds &lt;= 0 then
             return false, 'InvalidAttackCooldownSeconds'
         end
     end
@@ -1520,6 +3088,16 @@ function MonsterAuthorProfile.validate(profile)
 
     if tuning.SpawnOffset ~= nil and typeof(tuning.SpawnOffset) ~= 'Vector3' then
         return false, 'InvalidSpawnOffset'
+    end
+
+    if tuning.CombatHitPoints ~= nil then
+        if
+            type(tuning.CombatHitPoints) ~= 'number'
+            or tuning.CombatHitPoints &lt; 1
+            or math.floor(tuning.CombatHitPoints) ~= tuning.CombatHitPoints
+        then
+            return false, 'InvalidCombatHitPoints'
+        end
     end
 
     if type(executable.BehaviorIntents) ~= 'table' or #executable.BehaviorIntents == 0 then
@@ -1566,13 +3144,13 @@ function MonsterAuthorProfile.validate(profile)
 end
 
 return MonsterAuthorProfile
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="22">
+          <Item class="ModuleScript" referent="69">
             <Properties>
               <string name="Name">MonsterBehaviorCatalog</string>
-              <string name="Source"><![CDATA[local BEHAVIOR = table.freeze({
+              <string name="Source">local BEHAVIOR = table.freeze({
     Patrol = 'Patrol',
     SenseNearestTarget = 'SenseNearestTarget',
     Chase = 'Chase',
@@ -1598,13 +3176,13 @@ local MonsterBehaviorCatalog = table.freeze({
 })
 
 return MonsterBehaviorCatalog
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="23">
+          <Item class="ModuleScript" referent="70">
             <Properties>
               <string name="Name">MonsterCompiler</string>
-              <string name="Source"><![CDATA[local MonsterAuthorProfile = require(script.Parent.MonsterAuthorProfile)
+              <string name="Source">local MonsterAuthorProfile = require(script.Parent.MonsterAuthorProfile)
 local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
 local MonsterComponentConfig = require(script.Parent.MonsterComponentConfig)
 local MonsterEffectCatalog = require(script.Parent.MonsterEffectCatalog)
@@ -1614,6 +3192,7 @@ local DEFAULT_SPAWN_OFFSET = Vector3.new(0, 4, 0)
 local DEFAULT_ATTACK_COOLDOWN_SECONDS = 1
 local DEFAULT_ATTACK_DAMAGE_PIPS = 1
 local DEFAULT_ATTACK_RANGE = 4
+local DEFAULT_COMBAT_HIT_POINTS = 1
 
 local MonsterCompiler = {}
 
@@ -1677,6 +3256,15 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
         end
     end
 
+    local combatHitPoints = normalizedProfile.Tuning.CombatHitPoints
+    if
+        type(combatHitPoints) ~= 'number'
+        or combatHitPoints &lt; 1
+        or math.floor(combatHitPoints) ~= combatHitPoints
+    then
+        combatHitPoints = DEFAULT_COMBAT_HIT_POINTS
+    end
+
     local runtimeProfile = {
         Id = normalizedProfile.Id,
         Name = normalizedProfile.Name,
@@ -1689,6 +3277,8 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
         SightRange = normalizedProfile.Tuning.SightRange,
         PatrolSpeedMultiplier = normalizedProfile.Tuning.PatrolSpeedMultiplier,
         SpawnOffset = normalizedProfile.Tuning.SpawnOffset or DEFAULT_SPAWN_OFFSET,
+        CombatHitPoints = combatHitPoints,
+        Health = normalizedProfile.Health,
         Behaviors = table.freeze(behaviors),
         Effects = table.freeze(runtimeEffects),
     }
@@ -1713,13 +3303,13 @@ function MonsterCompiler.compileMonsterForMaze(authorProfile)
 end
 
 return MonsterCompiler
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="24">
+          <Item class="ModuleScript" referent="71">
             <Properties>
               <string name="Name">MonsterComponentConfig</string>
-              <string name="Source"><![CDATA[local DEFAULT_ATTACK_COOLDOWN_SECONDS = 1
+              <string name="Source">local DEFAULT_ATTACK_COOLDOWN_SECONDS = 1
 local DEFAULT_ATTACK_DAMAGE_PIPS = 1
 local DEFAULT_ATTACK_HIT_MARKER_NAME = 'Hit'
 local DEFAULT_ATTACK_RANGE = 4
@@ -1730,10 +3320,10 @@ local DEFAULT_SPAWN_OFFSET = Vector3.new(0, 4, 0)
 local MonsterComponentConfig = {}
 
 local function getPositiveNumber(value, fallback, defaultValue)
-    if type(value) == 'number' and value > 0 then
+    if type(value) == 'number' and value &gt; 0 then
         return value
     end
-    if type(fallback) == 'number' and fallback > 0 then
+    if type(fallback) == 'number' and fallback &gt; 0 then
         return fallback
     end
     return defaultValue
@@ -1799,19 +3389,30 @@ function MonsterComponentConfig.fromRuntimeProfile(runtimeProfile)
                 else DEFAULT_ATTACK_HIT_MARKER_NAME,
             Range = getPositiveNumber(attack.Range, profile.AttackRange, DEFAULT_ATTACK_RANGE),
         }),
+        Health = table.freeze({
+            MaxHp = getPositiveNumber(
+                components.Health and components.Health.MaxHp,
+                getPositiveNumber(
+                    profile.Health and profile.Health.MaxHp,
+                    profile.CombatHitPoints,
+                    1
+                ),
+                1
+            ),
+        }),
     }
 
     return table.freeze(componentConfig)
 end
 
 return MonsterComponentConfig
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="25">
+          <Item class="ModuleScript" referent="72">
             <Properties>
               <string name="Name">MonsterEffectCatalog</string>
-              <string name="Source"><![CDATA[local CATEGORY = table.freeze({
+              <string name="Source">local CATEGORY = table.freeze({
     Damage = 'Damage',
     PlayerStatus = 'PlayerStatus',
     MonsterStatus = 'MonsterStatus',
@@ -1859,7 +3460,7 @@ function MonsterEffectCatalog.validateIntent(effectIntent)
 
     if DURATION_EFFECTS[effectIntent.Id] then
         local durationSeconds = effectIntent.DurationSeconds
-        if type(durationSeconds) ~= 'number' or durationSeconds <= 0 then
+        if type(durationSeconds) ~= 'number' or durationSeconds &lt;= 0 then
             return false, 'InvalidEffectPayload'
         end
     end
@@ -1868,13 +3469,13 @@ function MonsterEffectCatalog.validateIntent(effectIntent)
 end
 
 return table.freeze(MonsterEffectCatalog)
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="26">
+          <Item class="ModuleScript" referent="73">
             <Properties>
               <string name="Name">MonsterLogic</string>
-              <string name="Source"><![CDATA[local MonsterLogic = {}
+              <string name="Source">local MonsterLogic = {}
 
 function MonsterLogic.pickNearestTarget(currentPosition, playerPositions, sightRange)
     local closestPlayer = nil
@@ -1882,7 +3483,7 @@ function MonsterLogic.pickNearestTarget(currentPosition, playerPositions, sightR
 
     for player, position in pairs(playerPositions) do
         local distance = (position - currentPosition).Magnitude
-        if distance <= closestDistance then
+        if distance &lt;= closestDistance then
             closestPlayer = player
             closestDistance = distance
         end
@@ -1904,13 +3505,13 @@ function MonsterLogic.stepToward(currentPosition, targetPosition, speed, dt)
 end
 
 return MonsterLogic
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="27">
+          <Item class="ModuleScript" referent="74">
             <Properties>
               <string name="Name">MonsterPresentationCatalog</string>
-              <string name="Source"><![CDATA[local MonsterPresentationCatalog = {}
+              <string name="Source">local MonsterPresentationCatalog = {}
 
 MonsterPresentationCatalog.RigType = table.freeze({
     R6 = 'R6',
@@ -1929,13 +3530,13 @@ MonsterPresentationCatalog.KnownAnimationMode = table.freeze({
 })
 
 return MonsterPresentationCatalog
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="28">
+          <Item class="ModuleScript" referent="75">
             <Properties>
               <string name="Name">MonsterRuntimeProfile</string>
-              <string name="Source"><![CDATA[local MonsterPresentationCatalog = require(script.Parent.MonsterPresentationCatalog)
+              <string name="Source">local MonsterPresentationCatalog = require(script.Parent.MonsterPresentationCatalog)
 
 local MonsterRuntimeProfile = {}
 
@@ -1944,7 +3545,7 @@ local function isNonEmptyString(value)
 end
 
 local function isPositiveNumber(value)
-    return type(value) == 'number' and value > 0
+    return type(value) == 'number' and value &gt; 0
 end
 
 local function isValidDamagePips(value)
@@ -1989,7 +3590,7 @@ function MonsterRuntimeProfile.validate(profile)
         return false, 'MissingRuntimePresentation'
     end
 
-    if type(presentation.ModelAssetId) ~= 'number' or presentation.ModelAssetId <= 0 then
+    if type(presentation.ModelAssetId) ~= 'number' or presentation.ModelAssetId &lt;= 0 then
         return false, 'InvalidRuntimeModelAssetId'
     end
 
@@ -2005,7 +3606,7 @@ function MonsterRuntimeProfile.validate(profile)
         presentation.ChaseLoopSoundAssetId ~= nil
         and (
             type(presentation.ChaseLoopSoundAssetId) ~= 'number'
-            or presentation.ChaseLoopSoundAssetId <= 0
+            or presentation.ChaseLoopSoundAssetId &lt;= 0
         )
     then
         return false, 'InvalidRuntimeChaseLoopSoundAssetId'
@@ -2022,6 +3623,10 @@ function MonsterRuntimeProfile.validate(profile)
     local attackConfig, attackConfigErr = readComponentTable(profile, 'Attack')
     if attackConfigErr then
         return false, attackConfigErr
+    end
+    local healthConfig, healthConfigErr = readComponentTable(profile, 'Health')
+    if healthConfigErr then
+        return false, healthConfigErr
     end
 
     if
@@ -2069,6 +3674,18 @@ function MonsterRuntimeProfile.validate(profile)
         if attackConfig.DamagePips ~= nil and not isValidDamagePips(attackConfig.DamagePips) then
             return false, 'InvalidRuntimeComponentAttackDamagePips'
         end
+    end
+
+    if
+        healthConfig
+        and healthConfig.MaxHp ~= nil
+        and (
+            type(healthConfig.MaxHp) ~= 'number'
+            or healthConfig.MaxHp &lt; 1
+            or math.floor(healthConfig.MaxHp) ~= healthConfig.MaxHp
+        )
+    then
+        return false, 'InvalidRuntimeComponentHealthMaxHp'
     end
 
     local runtimeSpeed = profile.Speed
@@ -2144,17 +3761,26 @@ function MonsterRuntimeProfile.validate(profile)
         return false, 'MissingRuntimeEffects'
     end
 
+    local combatHitPoints = profile.CombatHitPoints
+    if
+        type(combatHitPoints) ~= 'number'
+        or combatHitPoints &lt; 1
+        or math.floor(combatHitPoints) ~= combatHitPoints
+    then
+        return false, 'InvalidRuntimeCombatHitPoints'
+    end
+
     return true
 end
 
 return MonsterRuntimeProfile
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="29">
+          <Item class="ModuleScript" referent="76">
             <Properties>
               <string name="Name">MonsterUgcPipeline</string>
-              <string name="Source"><![CDATA[local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
+              <string name="Source">local MonsterBehaviorCatalog = require(script.Parent.MonsterBehaviorCatalog)
 local MonsterCompiler = require(script.Parent.MonsterCompiler)
 local MonsterEffectCatalog = require(script.Parent.MonsterEffectCatalog)
 local MonsterAssetIds = require(script.Parent.MonsterAssetIds)
@@ -2357,7 +3983,7 @@ local function sanitizeName(value)
     text = string.gsub(text, '%s+', ' ')
     text = trimText(text)
 
-    if #text > 48 then
+    if #text &gt; 48 then
         text = string.sub(text, 1, 48)
     end
 
@@ -2430,7 +4056,7 @@ local function normalizeBrief(rawBrief)
         table.insert(missingFields, 'SuccessCriteria')
     end
 
-    if #missingFields > 0 then
+    if #missingFields &gt; 0 then
         return nil, missingFields
     end
 
@@ -2576,7 +4202,7 @@ local function validateAsset(assetId, assetKind, assetValidator, diagnostics)
         return true
     end
 
-    if type(assetId) ~= 'number' or assetId <= 0 then
+    if type(assetId) ~= 'number' or assetId &lt;= 0 then
         diagnostics.AssetChecks[assetKind] = {
             Status = 'Rejected',
             Reason = 'InvalidAssetId',
@@ -2617,7 +4243,7 @@ local function normalizeSeed(seed)
     end
 
     local normalizedSeed = math.floor(math.abs(seed))
-    if normalizedSeed <= 0 then
+    if normalizedSeed &lt;= 0 then
         normalizedSeed = 1
     end
 
@@ -2647,7 +4273,7 @@ local function buildMonsterName(brief, rng)
 end
 
 local function buildMonsterId(playerUserId, seed)
-    local owner = if type(playerUserId) == 'number' and playerUserId > 0 then playerUserId else 0
+    local owner = if type(playerUserId) == 'number' and playerUserId &gt; 0 then playerUserId else 0
     return string.format('ugc-%d-%d', owner, seed)
 end
 
@@ -2960,7 +4586,7 @@ local function normalizeTelemetry(rawTelemetry)
         if type(value) ~= 'number' then
             return 0
         end
-        if value < 0 then
+        if value &lt; 0 then
             return 0
         end
         return value
@@ -3031,13 +4657,13 @@ function MonsterUgcPipeline.canRunInMazeEffect(intentId)
 end
 
 return MonsterUgcPipeline
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="30">
+          <Item class="ModuleScript" referent="77">
             <Properties>
               <string name="Name">MonsterUgcReviewQueue</string>
-              <string name="Source"><![CDATA[local MonsterUgcReviewQueue = {}
+              <string name="Source">local MonsterUgcReviewQueue = {}
 MonsterUgcReviewQueue.__index = MonsterUgcReviewQueue
 
 MonsterUgcReviewQueue.Status = table.freeze({
@@ -3096,7 +4722,7 @@ function MonsterUgcReviewQueue:submit(bundle, options)
         return false, 'MissingRecipeHash'
     end
 
-    if self:_countPending() >= self.MaxPending then
+    if self:_countPending() &gt;= self.MaxPending then
         return false, 'ReviewQueueFull'
     end
 
@@ -3144,7 +4770,7 @@ function MonsterUgcReviewQueue:listPending()
     end
 
     table.sort(pending, function(left, right)
-        return left.SubmissionId < right.SubmissionId
+        return left.SubmissionId &lt; right.SubmissionId
     end)
 
     return table.freeze(pending)
@@ -3185,14 +4811,14 @@ function MonsterUgcReviewQueue:decide(submissionId, decision, options)
 end
 
 return MonsterUgcReviewQueue
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="31">
+        <Item class="ModuleScript" referent="78">
           <Properties>
             <string name="Name">Player</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
     PlayerComponentConfig = require(script.PlayerComponentConfig),
     Player = require(script.Player),
     PlayerBlackboard = require(script.PlayerBlackboard),
@@ -3202,16 +4828,16 @@ return MonsterUgcReviewQueue
     MovementComponent = require(script.Components.MovementComponent),
     InventoryComponent = require(script.Components.InventoryComponent),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="Folder" referent="32">
+          <Item class="Folder" referent="79">
             <Properties>
               <string name="Name">Components</string>
             </Properties>
-            <Item class="ModuleScript" referent="33">
+            <Item class="ModuleScript" referent="80">
               <Properties>
                 <string name="Name">HealthComponent</string>
-                <string name="Source"><![CDATA[local HealthComponent = {}
+                <string name="Source">local HealthComponent = {}
 HealthComponent.__index = HealthComponent
 
 local DAMAGE_PIP_COST = {
@@ -3219,17 +4845,29 @@ local DAMAGE_PIP_COST = {
     Heavy = 2,
 }
 
+local function getComponentConfig(blackboard, componentName)
+    local context = if type(blackboard) == 'table' and type(blackboard.Context) == 'table'
+        then blackboard.Context
+        else {}
+    local componentConfig = if type(context.ComponentConfig) == 'table'
+        then context.ComponentConfig
+        else {}
+    local config = componentConfig[componentName]
+
+    if type(config) == 'table' then
+        return config
+    end
+
+    return {}
+end
+
 function HealthComponent.new()
     return setmetatable({}, HealthComponent)
 end
 
 function HealthComponent:init(blackboard)
-    local config = blackboard.Context.ComponentConfig.Health
-<<<<<<< HEAD
+    local config = getComponentConfig(blackboard, 'Health')
     local maxHealthPips = if config and config.MaxHealthPips then config.MaxHealthPips else 2
-=======
-    local maxHealthPips = if config and config.MaxHealthPips then config.MaxHealthPips else 2
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
 
     self.MaxHealthPips = maxHealthPips
     self.CurrentHealthPips = maxHealthPips
@@ -3237,11 +4875,7 @@ function HealthComponent:init(blackboard)
     self.CorpseActive = false
 end
 
-<<<<<<< HEAD
-function HealthComponent:applyDamage(blackboard, damageKind)
-=======
-function HealthComponent:applyDamage(blackboard, damageKind)
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
+function HealthComponent:applyDamage(_blackboard, damageKind)
     local pipCost = DAMAGE_PIP_COST[damageKind]
     if pipCost == nil then
         return false, 'UnknownDamageKind'
@@ -3257,11 +4891,22 @@ function HealthComponent:applyDamage(blackboard, damageKind)
     return true, self.CurrentHealthPips
 end
 
-<<<<<<< HEAD
-function HealthComponent:update(blackboard, dt)
-=======
-function HealthComponent:update(blackboard, dt)
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
+function HealthComponent:healPips(blackboard, amount)
+    if self.IsDead then
+        return false, 'Dead'
+    end
+
+    local delta = math.floor(tonumber(amount) or 0)
+    if delta &lt; 1 then
+        return false, 'InvalidAmount'
+    end
+
+    self.CurrentHealthPips = math.min(self.MaxHealthPips, self.CurrentHealthPips + delta)
+    self:update(blackboard, 0)
+    return true, self.CurrentHealthPips
+end
+
+function HealthComponent:update(blackboard, _dt)
     blackboard.Transient.CurrentHealthPips = self.CurrentHealthPips
     blackboard.Transient.MaxHealthPips = self.MaxHealthPips
     blackboard.Transient.IsDead = self.IsDead
@@ -3271,171 +4916,88 @@ end
 function HealthComponent:destroy(_blackboard) end
 
 return HealthComponent
-]]></string>
+</string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="34">
+            <Item class="ModuleScript" referent="81">
               <Properties>
                 <string name="Name">InventoryComponent</string>
-                <string name="Source"><![CDATA[local InventoryComponent = {}
+                <string name="Source">local InventoryComponent = {}
 InventoryComponent.__index = InventoryComponent
+
+local function getComponentConfig(blackboard, componentName)
+    local context = if type(blackboard) == 'table' and type(blackboard.Context) == 'table'
+        then blackboard.Context
+        else {}
+    local componentConfig = if type(context.ComponentConfig) == 'table'
+        then context.ComponentConfig
+        else {}
+    local config = componentConfig[componentName]
+
+    if type(config) == 'table' then
+        return config
+    end
+
+    return {}
+end
 
 function InventoryComponent.new()
     return setmetatable({}, InventoryComponent)
 end
 
+-- Player-local inventory *attributes* only (slot count, pickup range).
+-- Authoritative items and equip/held state live in `Gameplay.Inventory` via
+-- `InventoryService`; this component must not mirror item instances.
 function InventoryComponent:init(blackboard)
-    local config = blackboard.Context.ComponentConfig.Inventory or {}
+    local config = getComponentConfig(blackboard, 'Inventory')
 
     self.SlotCount = config.SlotCount or 8
-    self.Slots = table.create(self.SlotCount, nil)
-    self.EquippedSlot = nil
     self.InteractionRange = config.InteractionRange or 5
-    self.NextInstanceId = 1
 end
 
-function InventoryComponent:addItem(blackboard, itemDef)
-    local emptySlot = nil
-    for i = 1, #self.Slots do
-        if self.Slots[i] == nil then
-            emptySlot = i
-            break
-        end
-    end
-
-    if not emptySlot then
-        return false, 'OverCapacity'
-    end
-
-    local instanceId = self.NextInstanceId
-    self.NextInstanceId += 1
-
-    self.Slots[emptySlot] = {
-        InstanceId = instanceId,
-        Id = itemDef.Id,
-        Name = itemDef.Name,
-        CurrentState = itemDef.InitialState,
-        ConsumePerUse = itemDef.ConsumePerUse,
-        CooldownSeconds = itemDef.CooldownSeconds,
-        LastUsedAt = 0,
-    }
-
-    blackboard.Transient.ItemAdded = emptySlot
-    return true, instanceId
-end
-
-function InventoryComponent:equipSlot(blackboard, slotIndex)
-    if slotIndex < 1 or slotIndex > #self.Slots then
-        return false, 'InvalidSlot'
-    end
-
-    local slot = self.Slots[slotIndex]
-    if not slot then
-        return false, 'SlotEmpty'
-    end
-
-    self.EquippedSlot = slotIndex
-    blackboard.Transient.EquippedSlot = slotIndex
-    return true, slot
-end
-
-function InventoryComponent:unequip(blackboard)
-    if not self.EquippedSlot then
-        return false, 'NothingEquipped'
-    end
-
-    self.EquippedSlot = nil
-    blackboard.Transient.EquippedSlot = nil
-    return true
-end
-
-function InventoryComponent:useItem(blackboard)
-    if not self.EquippedSlot then
-        return false, 'NothingEquipped'
-    end
-
-    local slot = self.Slots[self.EquippedSlot]
-    if not slot then
-        return false, 'SlotEmpty'
-    end
-
-    local now = os.clock()
-    local cooldownRemaining = 0
-    if slot.CooldownSeconds and slot.CooldownSeconds > 0 then
-        cooldownRemaining = math.max(0, slot.LastUsedAt + slot.CooldownSeconds - now)
-        if cooldownRemaining > 0 then
-            return false, 'OnCooldown', cooldownRemaining
-        end
-    end
-
-    slot.LastUsedAt = now
-
-    if slot.ConsumePerUse then
-        slot.CurrentState = (slot.CurrentState or 0) - slot.ConsumePerUse
-        if slot.CurrentState <= 0 then
-            self.Slots[self.EquippedSlot] = nil
-            self.EquippedSlot = nil
-            blackboard.Transient.ItemConsumed = true
-        end
-    end
-
-    blackboard.Transient.ItemUsed = slot.InstanceId
-    return true, slot
-end
-
-<<<<<<< HEAD
-function InventoryComponent:removeItem(blackboard, slotIndex)
-=======
-function InventoryComponent:removeItem(blackboard, slotIndex)
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
-    if slotIndex < 1 or slotIndex > #self.Slots then
-        return false, 'InvalidSlot'
-    end
-
-    if not self.Slots[slotIndex] then
-        return false, 'SlotEmpty'
-    end
-
-    if self.EquippedSlot == slotIndex then
-        self.EquippedSlot = nil
-    end
-
-    self.Slots[slotIndex] = nil
-    return true
-end
-
-<<<<<<< HEAD
-function InventoryComponent:update(blackboard, dt)
-=======
-function InventoryComponent:update(blackboard, dt)
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
-    blackboard.Transient.Slots = self.Slots
-    blackboard.Transient.EquippedSlot = self.EquippedSlot
+function InventoryComponent:update(blackboard, _dt)
+    blackboard.Transient.SlotCount = self.SlotCount
     blackboard.Transient.InteractionRange = self.InteractionRange
 end
 
 function InventoryComponent:destroy(_blackboard) end
 
 return InventoryComponent
-]]></string>
+</string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="35">
+            <Item class="ModuleScript" referent="82">
               <Properties>
                 <string name="Name">MovementComponent</string>
-                <string name="Source"><![CDATA[local MovementComponent = {}
+                <string name="Source">local MovementComponent = {}
 MovementComponent.__index = MovementComponent
 
 local DEFAULT_WALK_SPEED = 16
 local DEFAULT_SPRINT_SPEED = 24
 local DEFAULT_JUMP_VELOCITY = 50
 
+local function getComponentConfig(blackboard, componentName)
+    local context = if type(blackboard) == 'table' and type(blackboard.Context) == 'table'
+        then blackboard.Context
+        else {}
+    local componentConfig = if type(context.ComponentConfig) == 'table'
+        then context.ComponentConfig
+        else {}
+    local config = componentConfig[componentName]
+
+    if type(config) == 'table' then
+        return config
+    end
+
+    return {}
+end
+
 function MovementComponent.new()
     return setmetatable({}, MovementComponent)
 end
 
 function MovementComponent:init(blackboard)
-    local config = blackboard.Context.ComponentConfig.Movement or {}
+    local config = getComponentConfig(blackboard, 'Movement')
 
     self.MaxWalkSpeed = config.MaxWalkSpeed or DEFAULT_WALK_SPEED
     self.MaxSprintSpeed = config.MaxSprintSpeed or DEFAULT_SPRINT_SPEED
@@ -3468,13 +5030,9 @@ function MovementComponent:update(blackboard, dt)
         local direction = (targetPosition - currentPosition)
         local distance = direction.Magnitude
 
-        if distance > 0.1 then
+        if distance &gt; 0.1 then
             isMoving = true
-<<<<<<< HEAD
             local stepSize = math.min(moveSpeed * dt, distance)
-=======
-            local stepSize = math.min(moveSpeed * dt, distance)
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
             nextPosition = currentPosition + (direction.Unit * stepSize)
         end
     end
@@ -3482,17 +5040,10 @@ function MovementComponent:update(blackboard, dt)
     self.IsMoving = isMoving
 
     blackboard.Transient.NextPosition = nextPosition
-<<<<<<< HEAD
     blackboard.Transient.DesiredAnimation = if isSprinting and isMoving
         then 'Run'
         elseif isMoving then 'Walk'
         else 'Idle'
-=======
-    blackboard.Transient.DesiredAnimation = if isSprinting and isMoving
-        then 'Run'
-        elseif isMoving then 'Walk'
-        else 'Idle'
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
     blackboard.Transient.IsMoving = isMoving
     blackboard.Transient.IsJumping = self.IsJumping
 end
@@ -3500,33 +5051,46 @@ end
 function MovementComponent:destroy(_blackboard) end
 
 return MovementComponent
-]]></string>
+</string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="36">
+            <Item class="ModuleScript" referent="83">
               <Properties>
                 <string name="Name">StaminaComponent</string>
-                <string name="Source"><![CDATA[local StaminaComponent = {}
+                <string name="Source">local StaminaComponent = {}
 StaminaComponent.__index = StaminaComponent
 
 local DEFAULT_STAMINA_RECOVERY_DELAY_SECONDS = 1.5
+
+local function getComponentConfig(blackboard, componentName)
+    local context = if type(blackboard) == 'table' and type(blackboard.Context) == 'table'
+        then blackboard.Context
+        else {}
+    local componentConfig = if type(context.ComponentConfig) == 'table'
+        then context.ComponentConfig
+        else {}
+    local config = componentConfig[componentName]
+
+    if type(config) == 'table' then
+        return config
+    end
+
+    return {}
+end
 
 function StaminaComponent.new()
     return setmetatable({}, StaminaComponent)
 end
 
 function StaminaComponent:init(blackboard)
-    local config = blackboard.Context.ComponentConfig.Stamina or {}
+    local config = getComponentConfig(blackboard, 'Stamina')
 
     self.MaxStamina = config.MaxStamina or 100
     self.CurrentStamina = self.MaxStamina
     self.DrainPerSecond = config.DrainPerSecond or 35
     self.RecoveryPerSecond = config.RecoveryPerSecond or 20
-<<<<<<< HEAD
-    self.RecoveryDelaySeconds = config.RecoveryDelaySeconds or DEFAULT_STAMINA_RECOVERY_DELAY_SECONDS
-=======
-    self.RecoveryDelaySeconds = config.RecoveryDelaySeconds or DEFAULT_STAMINA_RECOVERY_DELAY_SECONDS
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
+    self.RecoveryDelaySeconds = config.RecoveryDelaySeconds
+        or DEFAULT_STAMINA_RECOVERY_DELAY_SECONDS
     self.ResumeThreshold = config.ResumeThreshold or 20
 
     self.StaminaRecoveryStartTime = 0
@@ -3534,12 +5098,8 @@ function StaminaComponent:init(blackboard)
     self.CanSprint = true
 end
 
-function StaminaComponent:drainStamina(blackboard, amount)
-<<<<<<< HEAD
+function StaminaComponent:drainStamina(_blackboard, amount)
     if self.IsDead then
-=======
-    if self.IsDead then
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
         return false, 'Dead'
     end
 
@@ -3547,19 +5107,15 @@ function StaminaComponent:drainStamina(blackboard, amount)
     self.StaminaRecoveryStartTime = now + self.RecoveryDelaySeconds
     self.CurrentStamina = math.max(0, self.CurrentStamina - amount)
 
-    if self.CurrentStamina <= 0 then
+    if self.CurrentStamina &lt;= 0 then
         self.CanSprint = false
     end
 
     return true, self.CurrentStamina
 end
 
-function StaminaComponent:setSprinting(blackboard, isSprinting)
-<<<<<<< HEAD
+function StaminaComponent:setSprinting(_blackboard, isSprinting)
     if self.IsDead then
-=======
-    if self.IsDead then
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
         self.IsSprinting = false
         return false, 'Dead'
     end
@@ -3582,11 +5138,7 @@ function StaminaComponent:update(blackboard, dt)
     local deltaTime = math.max(0, dt or 0)
     local now = os.clock()
 
-<<<<<<< HEAD
     if self.IsDead then
-=======
-    if self.IsDead then
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
         blackboard.Transient.CurrentStamina = self.CurrentStamina
         blackboard.Transient.MaxStamina = self.MaxStamina
         blackboard.Transient.CanSprint = false
@@ -3597,25 +5149,16 @@ function StaminaComponent:update(blackboard, dt)
     if self.IsSprinting and self.CanSprint then
         self.CurrentStamina = math.max(0, self.CurrentStamina - self.DrainPerSecond * deltaTime)
 
-        if self.CurrentStamina <= 0 then
+        if self.CurrentStamina &lt;= 0 then
             self.CurrentStamina = 0
             self.CanSprint = false
             self.IsSprinting = false
         end
-    elseif now >= self.StaminaRecoveryStartTime then
-<<<<<<< HEAD
-        self.CurrentStamina = math.min(
-            self.MaxStamina,
-            self.CurrentStamina + self.RecoveryPerSecond * deltaTime
-        )
-=======
-        self.CurrentStamina = math.min(
-            self.MaxStamina,
-            self.CurrentStamina + self.RecoveryPerSecond * deltaTime
-        )
->>>>>>> af646b4 (feat(player): add Player OOP system with component architecture)
+    elseif now &gt;= self.StaminaRecoveryStartTime then
+        self.CurrentStamina =
+            math.min(self.MaxStamina, self.CurrentStamina + self.RecoveryPerSecond * deltaTime)
 
-        if not self.CanSprint and self.CurrentStamina >= self.ResumeThreshold then
+        if not self.CanSprint and self.CurrentStamina &gt;= self.ResumeThreshold then
             self.CanSprint = true
         end
     end
@@ -3629,14 +5172,14 @@ end
 function StaminaComponent:destroy(_blackboard) end
 
 return StaminaComponent
-]]></string>
+</string>
               </Properties>
             </Item>
           </Item>
-          <Item class="ModuleScript" referent="37">
+          <Item class="ModuleScript" referent="84">
             <Properties>
               <string name="Name">Player</string>
-              <string name="Source"><![CDATA[local PlayerBlackboard = require(script.Parent.PlayerBlackboard)
+              <string name="Source">local PlayerBlackboard = require(script.Parent.PlayerBlackboard)
 local PlayerStateMachine = require(script.Parent.PlayerStateMachine)
 
 local Player = {}
@@ -3676,6 +5219,9 @@ end
 
 function Player:spawn()
     self.Blackboard:setState(self.StateMachine:getState())
+    self.Blackboard:beginTick({
+        ComponentConfig = self.ComponentConfig,
+    })
     for _, component in pairs(self.Components) do
         if component.init then
             component:init(self.Blackboard)
@@ -3728,8 +5274,8 @@ function Player:update(dt, context)
             DesiredAnimation = self.Blackboard.Transient.DesiredAnimation or 'Idle',
         },
         Inventory = {
-            Slots = self.Blackboard.Transient.Slots,
-            EquippedSlot = self.Blackboard.Transient.EquippedSlot,
+            SlotCount = self.Blackboard.Transient.SlotCount,
+            InteractionRange = self.Blackboard.Transient.InteractionRange,
         },
     }
 end
@@ -3745,13 +5291,13 @@ end
 Player.UpdateOrder = UPDATE_ORDER
 
 return Player
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="38">
+          <Item class="ModuleScript" referent="85">
             <Properties>
               <string name="Name">PlayerBlackboard</string>
-              <string name="Source"><![CDATA[local PlayerBlackboard = {}
+              <string name="Source">local PlayerBlackboard = {}
 PlayerBlackboard.__index = PlayerBlackboard
 
 local function cloneTable(source)
@@ -3790,13 +5336,13 @@ function PlayerBlackboard:getState()
 end
 
 return PlayerBlackboard
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="39">
+          <Item class="ModuleScript" referent="86">
             <Properties>
               <string name="Name">PlayerComponentConfig</string>
-              <string name="Source"><![CDATA[local PlayerComponentConfig = {}
+              <string name="Source">local PlayerComponentConfig = {}
 
 local DEFAULT_MAX_HEALTH_PIPS = 2
 local DEFAULT_MAX_STAMINA = 100
@@ -3811,7 +5357,7 @@ local DEFAULT_INTERACTION_RANGE = 5
 local DEFAULT_SLOT_COUNT = 8
 
 local function getPositiveNumber(value, defaultValue)
-    if type(value) == 'number' and value > 0 then
+    if type(value) == 'number' and value &gt; 0 then
         return value
     end
     return defaultValue
@@ -3890,13 +5436,13 @@ function PlayerComponentConfig.getDefaults()
 end
 
 return PlayerComponentConfig
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="40">
+          <Item class="ModuleScript" referent="87">
             <Properties>
               <string name="Name">PlayerStateMachine</string>
-              <string name="Source"><![CDATA[local PlayerStateMachine = {}
+              <string name="Source">local PlayerStateMachine = {}
 PlayerStateMachine.__index = PlayerStateMachine
 
 local STATE = table.freeze({
@@ -3955,14 +5501,14 @@ end
 PlayerStateMachine.State = STATE
 
 return PlayerStateMachine
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="41">
+        <Item class="ModuleScript" referent="88">
           <Properties>
             <string name="Name">PlayerState</string>
-            <string name="Source"><![CDATA[local DEFAULT_MAX_HEALTH_PIPS = 2
+            <string name="Source">local DEFAULT_MAX_HEALTH_PIPS = 2
 local DEFAULT_MAX_STAMINA = 100
 local DEFAULT_STAMINA_DRAIN_PER_SECOND = 35
 local DEFAULT_STAMINA_RECOVERY_PER_SECOND = 20
@@ -4013,6 +5559,7 @@ function PlayerState.new(config)
         CanSprint = true,
         CorpseActive = false,
         IsSprinting = false,
+        ActiveEffects = {}, -- {[effectId] = remainingSeconds}
     }, PlayerState)
 end
 
@@ -4025,6 +5572,7 @@ function PlayerState:getSummary()
         IsDead = self.IsDead,
         CanSprint = self.CanSprint,
         CorpseActive = self.CorpseActive,
+        ActiveEffects = self.ActiveEffects,
     }
 end
 
@@ -4060,17 +5608,48 @@ function PlayerState:applyDamage(damageKind)
     return true, self:getSummary()
 end
 
+function PlayerState:applyEffect(effectId, durationSeconds)
+    if type(effectId) ~= 'string' or effectId == '' then
+        return
+    end
+    local duration = if type(durationSeconds) == 'number' and durationSeconds &gt; 0
+        then durationSeconds
+        else math.huge
+    local currentRemaining = self.ActiveEffects[effectId]
+    if currentRemaining == nil or duration &gt; currentRemaining then
+        self.ActiveEffects[effectId] = duration
+    end
+end
+
+function PlayerState:hasEffect(effectId)
+    if type(effectId) ~= 'string' then
+        return false
+    end
+    return self.ActiveEffects[effectId] ~= nil
+end
+
 function PlayerState:step(dt)
     if self.IsDead then
         return self:getSummary()
     end
 
     local deltaTime = math.max(0, dt or 0)
+
+    -- Tick down active effects
+    for effectId, remaining in pairs(self.ActiveEffects) do
+        local nextRemaining = remaining - deltaTime
+        if nextRemaining &lt;= 0 then
+            self.ActiveEffects[effectId] = nil
+        else
+            self.ActiveEffects[effectId] = nextRemaining
+        end
+    end
+
     if self.IsSprinting and self.CanSprint then
         self.CurrentStamina =
             clamp(self.CurrentStamina - self.StaminaDrainPerSecond * deltaTime, 0, self.MaxStamina)
 
-        if self.CurrentStamina <= 0 then
+        if self.CurrentStamina &lt;= 0 then
             self.CurrentStamina = 0
             self.CanSprint = false
             self.IsSprinting = false
@@ -4082,7 +5661,7 @@ function PlayerState:step(dt)
             self.MaxStamina
         )
 
-        if not self.CanSprint and self.CurrentStamina >= self.SprintResumeThreshold then
+        if not self.CanSprint and self.CurrentStamina &gt;= self.SprintResumeThreshold then
             self.CanSprint = true
         end
     end
@@ -4091,25 +5670,25 @@ function PlayerState:step(dt)
 end
 
 return PlayerState
-]]></string>
+</string>
           </Properties>
         </Item>
-        <Item class="ModuleScript" referent="42">
+        <Item class="ModuleScript" referent="89">
           <Properties>
             <string name="Name">ProcGen</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
     HexRoomPrefabs = require(script.HexRoomPrefabs),
     MazeBuilder = require(script.MazeBuilder),
     MazePassageTemplates = require(script.MazePassageTemplates),
     MazeRoomArchetypes = require(script.MazeRoomArchetypes),
     MazeRoomTemplates = require(script.MazeRoomTemplates),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="43">
+          <Item class="ModuleScript" referent="90">
             <Properties>
               <string name="Name">HexRoomPrefabs</string>
-              <string name="Source"><![CDATA[local HexRoomPrefabs = {}
+              <string name="Source">local HexRoomPrefabs = {}
 
 HexRoomPrefabs.Directions = table.freeze({
     A = 1,
@@ -4288,13 +5867,13 @@ function HexRoomPrefabs.getDefinition(typeId)
 end
 
 return HexRoomPrefabs
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="44">
+          <Item class="ModuleScript" referent="91">
             <Properties>
               <string name="Name">MazeBuilder</string>
-              <string name="Source"><![CDATA[local MazeBuilder = {}
+              <string name="Source">local MazeBuilder = {}
 
 local HexRoomPrefabs = require(script.Parent.HexRoomPrefabs)
 local MazePassageTemplates = require(script.Parent.MazePassageTemplates)
@@ -4518,7 +6097,7 @@ local function removeFrontier(frontier, frontierIndexByKey, roomId, directionInd
     frontier[lastIndex] = nil
     frontierIndexByKey[key] = nil
 
-    if swapped and index <= #frontier then
+    if swapped and index &lt;= #frontier then
         frontierIndexByKey[swapped.RoomId .. ':' .. swapped.Direction] = index
     end
 end
@@ -4559,32 +6138,32 @@ local function buildPrefabQuotas(roomCount)
 
     table_sort(remainders, function(left, right)
         if left.Value ~= right.Value then
-            return left.Value > right.Value
+            return left.Value &gt; right.Value
         end
 
         if left.Weight ~= right.Weight then
-            return left.Weight > right.Weight
+            return left.Weight &gt; right.Weight
         end
 
-        return left.TypeId < right.TypeId
+        return left.TypeId &lt; right.TypeId
     end)
 
     local remaining = roomCount - assigned
     local remainderIndex = 1
-    while remaining > 0 do
+    while remaining &gt; 0 do
         local remainder = remainders[remainderIndex]
         quotas[remainder.TypeId] += 1
         remaining -= 1
 
         remainderIndex += 1
-        if remainderIndex > #remainders then
+        if remainderIndex &gt; #remainders then
             remainderIndex = 1
         end
     end
 
     local hasStartType = false
     for _, typeId in ipairs(START_TYPE_IDS) do
-        if quotas[typeId] > 0 then
+        if quotas[typeId] &gt; 0 then
             hasStartType = true
             break
         end
@@ -4592,7 +6171,7 @@ local function buildPrefabQuotas(roomCount)
 
     if not hasStartType then
         for _, donorTypeId in ipairs(RATIO_TYPE_ORDER) do
-            if quotas[donorTypeId] > 1 then
+            if quotas[donorTypeId] &gt; 1 then
                 quotas[donorTypeId] -= 1
                 quotas[START_TYPE_IDS[1]] += 1
                 hasStartType = true
@@ -4614,7 +6193,7 @@ local function pickWeightedType(random, quotas, typeIds)
         totalWeight += math.max(0, quotas[typeId] or 0)
     end
 
-    if totalWeight <= 0 then
+    if totalWeight &lt;= 0 then
         return nil
     end
 
@@ -4622,7 +6201,7 @@ local function pickWeightedType(random, quotas, typeIds)
     local running = 0
     for _, typeId in ipairs(typeIds) do
         running += math.max(0, quotas[typeId] or 0)
-        if roll <= running then
+        if roll &lt;= running then
             return typeId
         end
     end
@@ -4679,7 +6258,7 @@ local function enumeratePlacementCandidates(
     local totalWeight = 0
     for _, typeId in ipairs(RATIO_TYPE_ORDER) do
         local quota = quotas[typeId] or 0
-        if quota <= 0 then
+        if quota &lt;= 0 then
             continue
         end
 
@@ -4694,7 +6273,7 @@ local function enumeratePlacementCandidates(
         end
     end
 
-    if totalWeight <= 0 then
+    if totalWeight &lt;= 0 then
         return nil
     end
 
@@ -4702,7 +6281,7 @@ local function enumeratePlacementCandidates(
     local running = 0
     for _, typeId in ipairs(RATIO_TYPE_ORDER) do
         local quota = quotas[typeId] or 0
-        if quota <= 0 then
+        if quota &lt;= 0 then
             continue
         end
 
@@ -4713,7 +6292,7 @@ local function enumeratePlacementCandidates(
                 and bit32_band(mask, mustNotHaveMask) == 0
             then
                 running += quota
-                if roll <= running then
+                if roll &lt;= running then
                     return variant
                 end
             end
@@ -4723,7 +6302,7 @@ local function enumeratePlacementCandidates(
     -- Fallback for floating point precision issues
     for _, typeId in ipairs(RATIO_TYPE_ORDER) do
         local quota = quotas[typeId] or 0
-        if quota <= 0 then
+        if quota &lt;= 0 then
             continue
         end
 
@@ -4748,7 +6327,7 @@ local function computeDistances(rooms, startRoomId)
     local queue = { startRoomId }
     local queueIndex = 1
 
-    while queueIndex <= #queue do
+    while queueIndex &lt;= #queue do
         local roomId = queue[queueIndex]
         queueIndex += 1
 
@@ -4773,8 +6352,8 @@ local function selectExtractionRoom(rooms, campRoomId)
 
     for roomId, distance in pairs(distances) do
         if
-            distance > selectedDistance
-            or (distance == selectedDistance and roomId < selectedRoomId)
+            distance &gt; selectedDistance
+            or (distance == selectedDistance and roomId &lt; selectedRoomId)
         then
             selectedDistance = distance
             selectedRoomId = roomId
@@ -4792,7 +6371,7 @@ local function buildMainPath(rooms, startRoomId, targetRoomId)
     local queue = { startRoomId }
     local queueIndex = 1
 
-    while queueIndex <= #queue do
+    while queueIndex &lt;= #queue do
         local roomId = queue[queueIndex]
         queueIndex += 1
 
@@ -4912,7 +6491,7 @@ local function buildLoopMetadata(rooms, doorways, campRoomId)
     local queueIndex = 1
     local treeEdges = {}
 
-    while queueIndex <= #queue do
+    while queueIndex &lt;= #queue do
         local roomId = queue[queueIndex]
         queueIndex += 1
         local room = rooms[roomId]
@@ -4920,7 +6499,7 @@ local function buildLoopMetadata(rooms, doorways, campRoomId)
         for _, neighborRoomId in ipairs(collectSortedNeighborRoomIds(room)) do
             if not visited[neighborRoomId] then
                 visited[neighborRoomId] = true
-                local edgeKey = if roomId < neighborRoomId
+                local edgeKey = if roomId &lt; neighborRoomId
                     then roomId .. '|' .. neighborRoomId
                     else neighborRoomId .. '|' .. roomId
                 treeEdges[edgeKey] = true
@@ -4962,8 +6541,8 @@ local function selectScoredRoomId(roomIds, rooms, excludedRoomIds, predicate, sc
                 local score = scoreFn(roomId, room)
                 if
                     bestScore == nil
-                    or score > bestScore
-                    or (score == bestScore and roomId < bestRoomId)
+                    or score &gt; bestScore
+                    or (score == bestScore and roomId &lt; bestRoomId)
                 then
                     bestRoomId = roomId
                     bestScore = score
@@ -5013,8 +6592,8 @@ local function assignRoomTemplates(rooms, campRoomId, extractionRoomId, mainPath
         assignedRoomIds,
         function(roomId, room)
             return room.Kind == 'Loot'
-                and distances[roomId] >= 2
-                and countEntries(room.Neighbors) >= 2
+                and distances[roomId] &gt;= 2
+                and countEntries(room.Neighbors) &gt;= 2
         end,
         function(roomId, room)
             local distanceScore = math_max(0, 10 - math_abs(distances[roomId] - midDepth) * 2)
@@ -5030,7 +6609,7 @@ local function assignRoomTemplates(rooms, campRoomId, extractionRoomId, mainPath
         rooms,
         assignedRoomIds,
         function(roomId, room)
-            return room.Kind == 'Loot' and distances[roomId] >= 2
+            return room.Kind == 'Loot' and distances[roomId] &gt;= 2
         end,
         function(roomId, room)
             local deadEndBonus = room.DoorCount == 1 and 25 or 0
@@ -5047,9 +6626,9 @@ local function assignRoomTemplates(rooms, campRoomId, extractionRoomId, mainPath
         function(roomId, room)
             return room.Kind == 'Loot'
                 and mainPathSet[roomId]
-                and distances[roomId] >= 1
-                and distances[roomId] < maxDistance
-                and countEntries(room.Neighbors) >= 2
+                and distances[roomId] &gt;= 1
+                and distances[roomId] &lt; maxDistance
+                and countEntries(room.Neighbors) &gt;= 2
         end,
         function(roomId, room)
             local targetDepth = math_max(1, math_floor(maxDistance * 0.45))
@@ -5066,8 +6645,8 @@ local function assignRoomTemplates(rooms, campRoomId, extractionRoomId, mainPath
         assignedRoomIds,
         function(roomId, room)
             return room.Kind == 'Loot'
-                and (loopMetadata.LoopRoomSet[roomId] or countEntries(room.Neighbors) >= 3)
-                and distances[roomId] >= 2
+                and (loopMetadata.LoopRoomSet[roomId] or countEntries(room.Neighbors) &gt;= 3)
+                and distances[roomId] &gt;= 2
         end,
         function(roomId, room)
             local loopBonus = loopMetadata.LoopRoomSet[roomId] and 20 or 0
@@ -5097,13 +6676,13 @@ local function assignRoomTemplates(rooms, campRoomId, extractionRoomId, mainPath
             + (countEntries(rightRoom.Neighbors) * 4)
             - distances[right]
         if leftScore ~= rightScore then
-            return leftScore > rightScore
+            return leftScore &gt; rightScore
         end
-        return left < right
+        return left &lt; right
     end)
 
     local transitTarget = 0
-    if #remainingLootRoomIds > 1 then
+    if #remainingLootRoomIds &gt; 1 then
         transitTarget = math_max(
             1,
             math.min(math_floor(#remainingLootRoomIds * 0.35), #remainingLootRoomIds - 1)
@@ -5111,7 +6690,7 @@ local function assignRoomTemplates(rooms, campRoomId, extractionRoomId, mainPath
     end
 
     for index, roomId in ipairs(remainingLootRoomIds) do
-        if index <= transitTarget then
+        if index &lt;= transitTarget then
             assign(roomId, 'TransitHall')
         else
             assign(roomId, 'SearchCluster')
@@ -5200,7 +6779,7 @@ local function buildMacroGraph(roomIds, rooms, mainPath, loopMetadata, assignmen
 
     local landmarkRoomIds = {}
     for _, roomId in ipairs(roomIds) do
-        if (rooms[roomId].LandmarkWeight or 0) >= 3 then
+        if (rooms[roomId].LandmarkWeight or 0) &gt;= 3 then
             table_insert(landmarkRoomIds, roomId)
         end
     end
@@ -5284,7 +6863,7 @@ local function buildSearchDistribution(roomIds, rooms)
     for _, roomId in ipairs(roomIds) do
         local room = rooms[roomId]
         table_insert(roomIdsByTemplate[room.RoomTemplateId], roomId)
-        if (room.RiskTier or 0) >= 3 then
+        if (room.RiskTier or 0) &gt;= 3 then
             table_insert(riskRoomIds, roomId)
         end
     end
@@ -5299,7 +6878,7 @@ local function buildLandmarkNodes(roomIds, rooms)
     local nodes = {}
     for _, roomId in ipairs(roomIds) do
         local room = rooms[roomId]
-        if (room.LandmarkWeight or 0) >= 3 then
+        if (room.LandmarkWeight or 0) &gt;= 3 then
             table_insert(nodes, {
                 RoomId = roomId,
                 RoomTemplateId = room.RoomTemplateId,
@@ -5346,7 +6925,7 @@ local function buildAttempt(seed, config)
 
         local edgeRoomA, edgeRoomB = roomA, roomB
         local edgeDirectionFromA, edgeDirectionFromB = directionFromA, directionFromB
-        if roomA.Id > roomB.Id then
+        if roomA.Id &gt; roomB.Id then
             edgeRoomA, edgeRoomB = roomB, roomA
             edgeDirectionFromA, edgeDirectionFromB = directionFromB, directionFromA
         end
@@ -5402,7 +6981,7 @@ local function buildAttempt(seed, config)
         end
     end
 
-    while #roomIds < roomCount do
+    while #roomIds &lt; roomCount do
         local frontierEntry = popRandomFrontier(frontier, frontierIndexByKey, random)
         if not frontierEntry then
             return nil, 'InsufficientExpansionFrontier'
@@ -5451,9 +7030,9 @@ local function buildAttempt(seed, config)
             continue
         end
 
-        local roomId = if #roomIds < 9
+        local roomId = if #roomIds &lt; 9
             then 'Room_00' .. (#roomIds + 1)
-            elseif #roomIds < 99 then 'Room_0' .. (#roomIds + 1)
+            elseif #roomIds &lt; 99 then 'Room_0' .. (#roomIds + 1)
             else 'Room_' .. (#roomIds + 1)
 
         local newRoom = createRoom(
@@ -5522,7 +7101,7 @@ local function buildAttempt(seed, config)
             RoomB = edge.RoomB,
             DirectionFromA = edge.DirectionFromA,
             DirectionFromB = edge.DirectionFromB,
-            HasDoorLeaves = random:NextNumber() < doorLeafChance,
+            HasDoorLeaves = random:NextNumber() &lt; doorLeafChance,
         }
     end
 
@@ -5535,7 +7114,7 @@ local function buildAttempt(seed, config)
 
     local mainPath = buildMainPath(rooms, campRoomId, extractionRoomId)
     local loopMetadata = buildLoopMetadata(rooms, doorways, campRoomId)
-    if loopMetadata.LoopCount < 1 then
+    if loopMetadata.LoopCount &lt; 1 then
         return nil, 'LoopingFacilityRequired'
     end
 
@@ -5588,13 +7167,13 @@ function MazeBuilder.build(seed, config)
 end
 
 return MazeBuilder
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="45">
+          <Item class="ModuleScript" referent="92">
             <Properties>
               <string name="Name">MazePassageTemplates</string>
-              <string name="Source"><![CDATA[local MazePassageTemplates = {}
+              <string name="Source">local MazePassageTemplates = {}
 
 MazePassageTemplates.EndpointType = table.freeze({
     Hall = 'hall',
@@ -5697,13 +7276,13 @@ function MazePassageTemplates.resolveExternalArchetype(_room)
 end
 
 return MazePassageTemplates
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="46">
+          <Item class="ModuleScript" referent="93">
             <Properties>
               <string name="Name">MazeRoomArchetypes</string>
-              <string name="Source"><![CDATA[local MazeRoomTemplates = require(script.Parent.MazeRoomTemplates)
+              <string name="Source">local MazeRoomTemplates = require(script.Parent.MazeRoomTemplates)
 
 local MazeRoomArchetypes = {}
 
@@ -5786,7 +7365,7 @@ end
 function MazeRoomArchetypes.classifyRoom(room)
     local templateId = room.RoomTemplateId
         or LEGACY_FALLBACKS[room.Kind]
-        or (room.DoorCount <= 2 and 'SearchCluster' or 'TransitHall')
+        or (room.DoorCount &lt;= 2 and 'SearchCluster' or 'TransitHall')
 
     local template = MazeRoomTemplates.getDefinition(templateId)
     local archetypeId = template and template.Id or 'SearchCluster'
@@ -5794,13 +7373,13 @@ function MazeRoomArchetypes.classifyRoom(room)
 end
 
 return MazeRoomArchetypes
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="47">
+          <Item class="ModuleScript" referent="94">
             <Properties>
               <string name="Name">MazeRoomTemplates</string>
-              <string name="Source"><![CDATA[local MazePassageTemplates = require(script.Parent.MazePassageTemplates)
+              <string name="Source">local MazePassageTemplates = require(script.Parent.MazePassageTemplates)
 
 local MazeRoomTemplates = {}
 
@@ -6015,33 +7594,33 @@ function MazeRoomTemplates.buildEndpointDefs(room)
     end
 
     table.sort(endpointDefs, function(left, right)
-        return left.Direction < right.Direction
+        return left.Direction &lt; right.Direction
     end)
 
     return endpointDefs
 end
 
 return MazeRoomTemplates
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="48">
+        <Item class="ModuleScript" referent="95">
           <Properties>
             <string name="Name">Roles</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
     RoleAllocator = require(script.RoleAllocator),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="49">
+          <Item class="ModuleScript" referent="96">
             <Properties>
               <string name="Name">RoleAllocator</string>
-              <string name="Source"><![CDATA[local RoleAllocator = {}
+              <string name="Source">local RoleAllocator = {}
 
 function RoleAllocator.assign(players, roleDefinitions)
     table.sort(players, function(left, right)
-        return left.UserId < right.UserId
+        return left.UserId &lt; right.UserId
     end)
 
     local assignments = {}
@@ -6063,23 +7642,23 @@ function RoleAllocator.assign(players, roleDefinitions)
 end
 
 return RoleAllocator
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="50">
+        <Item class="ModuleScript" referent="97">
           <Properties>
             <string name="Name">Session</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
     MazeRunTracker = require(script.MazeRunTracker),
     SessionStateMachine = require(script.SessionStateMachine),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="51">
+          <Item class="ModuleScript" referent="98">
             <Properties>
               <string name="Name">MazeRunTracker</string>
-              <string name="Source"><![CDATA[local SessionStateMachine = require(script.Parent.SessionStateMachine)
+              <string name="Source">local SessionStateMachine = require(script.Parent.SessionStateMachine)
 
 local MazeRunTracker = {}
 MazeRunTracker.__index = MazeRunTracker
@@ -6092,8 +7671,12 @@ local function cloneSummary(summary)
         Value = summary.Value or 0,
         ItemCount = summary.ItemCount or 0,
         Weight = summary.Weight or 0,
-        WasExtracted = summary.WasExtracted == true,
         WasSettled = summary.WasSettled == true,
+        CountedInSettlement = summary.CountedInSettlement ~= false,
+        LootItemCount = summary.LootItemCount or summary.MissionCount or summary.ItemCount or 0,
+        ClueCount = summary.ClueCount or 0,
+        ToolCount = summary.ToolCount or 0,
+        MissionCount = summary.MissionCount or summary.LootItemCount or summary.ItemCount or 0,
     }
 end
 
@@ -6216,13 +7799,13 @@ function MazeRunTracker:completeSettlement(summaries)
 end
 
 return MazeRunTracker
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="52">
+          <Item class="ModuleScript" referent="99">
             <Properties>
               <string name="Name">SessionStateMachine</string>
-              <string name="Source"><![CDATA[local TRANSITIONS = {
+              <string name="Source">local TRANSITIONS = {
     Camp = {
         Expedition = true,
     },
@@ -6254,7 +7837,7 @@ end
 
 function SessionStateMachine:transition(nextState)
     if not self:canTransition(nextState) then
-        error(string.format('Invalid session transition: %s -> %s', self.Current, nextState))
+        error(string.format('Invalid session transition: %s -&gt; %s', self.Current, nextState))
     end
 
     self.Current = nextState
@@ -6262,15 +7845,15 @@ function SessionStateMachine:transition(nextState)
 end
 
 return SessionStateMachine
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
       </Item>
-      <Item class="ModuleScript" referent="53">
+      <Item class="ModuleScript" referent="100">
         <Properties>
           <string name="Name">Shared</string>
-          <string name="Source"><![CDATA[return {
+          <string name="Source">return {
     Client = require(script.Client),
     Config = require(script.Config),
     Enums = require(script.Enums),
@@ -6279,30 +7862,27 @@ return SessionStateMachine
     Session = require(script.Session),
     Util = require(script.Util),
 }
-]]></string>
+</string>
         </Properties>
-        <Item class="ModuleScript" referent="54">
+        <Item class="ModuleScript" referent="101">
           <Properties>
             <string name="Name">Client</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
     FirstPersonController = require(script.FirstPersonController),
     HeldItemController = require(script.HeldItemController),
+    HeldToolVisual = require(script.HeldToolVisual),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="55">
+          <Item class="ModuleScript" referent="102">
             <Properties>
               <string name="Name">FirstPersonController</string>
-              <string name="Source"><![CDATA[local FirstPersonController = {}
+              <string name="Source">local FirstPersonController = {}
 
 local TARGET_PLAYER_PROPERTIES = {
     CameraMode = Enum.CameraMode.LockFirstPerson,
     CameraMinZoomDistance = 0.5,
     CameraMaxZoomDistance = 0.5,
-}
-
-local OPTIONAL_PLAYER_PROPERTIES = {
-    DevEnableMouseLock = false,
 }
 
 FirstPersonController.StarterPlayerProperties = {
@@ -6320,17 +7900,8 @@ local function applyProperties(target, properties)
     end
 end
 
-local function applyOptionalProperties(target, properties)
-    for propertyName, value in pairs(properties) do
-        pcall(function()
-            target[propertyName] = value
-        end)
-    end
-end
-
 function FirstPersonController.applyToPlayer(player)
     applyProperties(player, TARGET_PLAYER_PROPERTIES)
-    applyOptionalProperties(player, OPTIONAL_PLAYER_PROPERTIES)
 end
 
 function FirstPersonController.start(player)
@@ -6355,20 +7926,6 @@ function FirstPersonController.start(player)
         )
     end
 
-    for propertyName, targetValue in pairs(OPTIONAL_PLAYER_PROPERTIES) do
-        local ok, connection = pcall(function()
-            return player:GetPropertyChangedSignal(propertyName):Connect(function()
-                if player[propertyName] ~= targetValue then
-                    reapply()
-                end
-            end)
-        end)
-
-        if ok and connection ~= nil then
-            table.insert(connections, connection)
-        end
-    end
-
     return function()
         for _, connection in ipairs(connections) do
             connection:Disconnect()
@@ -6377,13 +7934,15 @@ function FirstPersonController.start(player)
 end
 
 return FirstPersonController
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="56">
+          <Item class="ModuleScript" referent="103">
             <Properties>
               <string name="Name">HeldItemController</string>
-              <string name="Source"><![CDATA[local HeldItemController = {}
+              <string name="Source">local HeldToolVisual = require(script.Parent.HeldToolVisual)
+
+local HeldItemController = {}
 HeldItemController.__index = HeldItemController
 
 local LIGHT_ATTACHMENT_NAME = 'HeldItemGlowAttachment'
@@ -6414,8 +7973,9 @@ function HeldItemController.new(player)
     )
     table.insert(
         self.Connections,
-        player.CharacterRemoving:Connect(function()
+        player.CharacterRemoving:Connect(function(character)
             self:_clearLight()
+            HeldToolVisual.clear(character)
         end)
     )
 
@@ -6438,14 +7998,23 @@ function HeldItemController:_clearLight()
 end
 
 function HeldItemController:_refresh()
+    local character = self.Player.Character
     local heldItem = self.Inventory and self.Inventory.HeldItem
+
+    if character then
+        HeldToolVisual.sync(character, heldItem)
+    end
+
     local lightConfig = heldItem and heldItem.Light
     if type(lightConfig) ~= 'table' then
         self:_clearLight()
         return
     end
 
-    local character = self.Player.Character
+    if not character then
+        return
+    end
+
     local lightParent = getLightParent(character)
     if not lightParent then
         return
@@ -6483,39 +8052,335 @@ function HeldItemController:destroy()
 
     self.Connections = {}
     self:_clearLight()
+    HeldToolVisual.clear(self.Player.Character)
 end
 
 return HeldItemController
-]]></string>
+</string>
+            </Properties>
+          </Item>
+          <Item class="ModuleScript" referent="104">
+            <Properties>
+              <string name="Name">HeldToolVisual</string>
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local RunService = game:GetService('RunService')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+local ItemPresentation = Gameplay.Config.ItemPresentation
+
+local CLONE_NAME = 'HeldToolVisualClone'
+
+-- PR #289 (gemini-code-assist high): one in-flight cosmetic swing cleanup per character — a single module-level
+-- slot would let two characters overwrite each other's restore callbacks.
+local swingCleanupByCharacter: { [Model]: () -&gt; () } = {}
+
+local HeldToolVisual = {}
+HeldToolVisual.CLONE_NAME = CLONE_NAME
+
+local function cancelSwingCleanupForCharacter(character: Model)
+    local cleanup = swingCleanupByCharacter[character]
+    if cleanup then
+        cleanup()
+        swingCleanupByCharacter[character] = nil
+    end
+end
+
+local function getHandPart(character: Model): BasePart?
+    local hand = character:FindFirstChild('RightHand') or character:FindFirstChild('Right Arm')
+    return hand and hand:IsA('BasePart') and hand or nil
+end
+
+function HeldToolVisual.clear(character: Model?)
+    if character then
+        cancelSwingCleanupForCharacter(character)
+    end
+
+    if not character then
+        return
+    end
+
+    local hand = getHandPart(character)
+    if hand then
+        local existing = hand:FindFirstChild(CLONE_NAME)
+        if existing then
+            existing:Destroy()
+        end
+    end
+end
+
+local function addRigidEdge(adj: { [BasePart]: { BasePart } }, partA: BasePart, partB: BasePart)
+    adj[partA] = adj[partA] or {}
+    adj[partB] = adj[partB] or {}
+    table.insert(adj[partA], partB)
+    table.insert(adj[partB], partA)
+end
+
+-- Parts already rigidly linked to `handle` through WeldConstraint / Motor6D inside `root`.
+local function partsRigidlyConnectedToHandle(
+    root: Instance,
+    handle: BasePart
+): { [BasePart]: boolean }
+    local adj: { [BasePart]: { BasePart } } = {}
+    for _, inst in root:GetDescendants() do
+        if inst:IsA('WeldConstraint') or inst:IsA('Motor6D') then
+            local p0, p1 = inst.Part0, inst.Part1
+            if p0 and p1 and p0:IsA('BasePart') and p1:IsA('BasePart') then
+                addRigidEdge(adj, p0, p1)
+            end
+        end
+    end
+
+    local seen: { [BasePart]: boolean } = { [handle] = true }
+    local queue = { handle }
+    local index = 1
+    while index &lt;= #queue do
+        local current = queue[index]
+        index += 1
+        for _, neighbor in adj[current] or {} do
+            if not seen[neighbor] then
+                seen[neighbor] = true
+                table.insert(queue, neighbor)
+            end
+        end
+    end
+
+    return seen
+end
+
+local function tryWeldToHand(hand: BasePart, root: Instance)
+    local handle = root:FindFirstChild('Handle', true)
+    if not (handle and handle:IsA('BasePart')) then
+        return
+    end
+
+    for _, inst in root:GetDescendants() do
+        if inst:IsA('BasePart') then
+            inst.Anchored = false
+            inst.CanCollide = false
+            inst.Massless = true
+        end
+    end
+
+    if root:IsA('Model') then
+        local model = root :: Model
+        if model.PrimaryPart ~= nil then
+            model:PivotTo(hand.CFrame)
+        else
+            handle.CFrame = hand.CFrame
+        end
+    else
+        handle.CFrame = hand.CFrame
+    end
+
+    local connected = partsRigidlyConnectedToHandle(root, handle)
+    for _, inst in root:GetDescendants() do
+        if inst:IsA('BasePart') and inst ~= handle and not connected[inst] then
+            local w = Instance.new('WeldConstraint')
+            w.Part0 = handle
+            w.Part1 = inst
+            w.Parent = inst
+            connected[inst] = true
+        end
+    end
+
+    local handWeld = Instance.new('WeldConstraint')
+    handWeld.Part0 = hand
+    handWeld.Part1 = handle
+    handWeld.Parent = handle
+end
+
+function HeldToolVisual.sync(character: Model?, heldItem: any?)
+    if not character then
+        return
+    end
+
+    HeldToolVisual.clear(character)
+
+    if type(heldItem) ~= 'table' then
+        return
+    end
+
+    local templateName = heldItem.ToolTemplateName
+    if type(templateName) ~= 'string' or templateName == '' then
+        return
+    end
+
+    local assetsFolder =
+        ReplicatedStorage:FindFirstChild(ItemPresentation.REPLICATED_STORAGE_ASSETS_FOLDER)
+    if not assetsFolder then
+        return
+    end
+
+    local templatesFolder = assetsFolder:FindFirstChild(ItemPresentation.TOOL_TEMPLATES_FOLDER)
+    if not templatesFolder then
+        return
+    end
+
+    local template = templatesFolder:FindFirstChild(templateName)
+    if not template or (not template:IsA('Model') and not template:IsA('Tool')) then
+        return
+    end
+
+    local hand = getHandPart(character)
+    if not hand then
+        return
+    end
+
+    local clone = template:Clone()
+    clone.Name = CLONE_NAME
+    clone.Parent = hand
+
+    if clone:IsA('Model') then
+        if clone.PrimaryPart == nil then
+            local h = clone:FindFirstChild('Handle')
+            if h and h:IsA('BasePart') then
+                clone.PrimaryPart = h
+            end
+        end
+        tryWeldToHand(hand, clone)
+    elseif clone:IsA('Tool') then
+        tryWeldToHand(hand, clone)
+    end
+end
+
+local function hasHandHandleWeld(hand: BasePart, handle: BasePart): boolean
+    for _, inst in handle:GetChildren() do
+        if inst:IsA('WeldConstraint') then
+            local w = inst :: WeldConstraint
+            if
+                (w.Part0 == hand and w.Part1 == handle) or (w.Part1 == hand and w.Part0 == handle)
+            then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+-- Cosmetic only: breaks the hand↔handle weld briefly, rotates the handle, then re-welds.
+-- Server hit detection stays on RequestUseTool; do not use this for gameplay authority.
+function HeldToolVisual.playCrowbarSwingFeedback(character: Model?)
+    if not character then
+        return
+    end
+
+    cancelSwingCleanupForCharacter(character)
+
+    local hand = getHandPart(character)
+    if not hand then
+        return
+    end
+
+    local clone = hand:FindFirstChild(CLONE_NAME)
+    if not clone then
+        return
+    end
+
+    local handle = clone:FindFirstChild('Handle', true)
+    if not (handle and handle:IsA('BasePart')) then
+        return
+    end
+
+    local handWeld: WeldConstraint? = nil
+    for _, inst in handle:GetChildren() do
+        if inst:IsA('WeldConstraint') then
+            local w = inst :: WeldConstraint
+            if
+                (w.Part0 == hand and w.Part1 == handle) or (w.Part1 == hand and w.Part0 == handle)
+            then
+                handWeld = w
+                break
+            end
+        end
+    end
+    if not handWeld then
+        return
+    end
+
+    handWeld:Destroy()
+    local offset = hand.CFrame:ToObjectSpace(handle.CFrame)
+    local duration = 0.22
+    local elapsed = 0.0
+
+    local connection: RBXScriptConnection?
+    local finished = false
+
+    local function restoreWeld()
+        if finished then
+            return
+        end
+        finished = true
+        swingCleanupByCharacter[character] = nil
+        if connection then
+            connection:Disconnect()
+            connection = nil
+        end
+        if handle.Parent and hand.Parent then
+            handle.CFrame = hand.CFrame * offset
+            if not hasHandHandleWeld(hand, handle) then
+                local restored = Instance.new('WeldConstraint')
+                restored.Part0 = hand
+                restored.Part1 = handle
+                restored.Parent = handle
+            end
+        end
+    end
+
+    swingCleanupByCharacter[character] = restoreWeld
+
+    connection = RunService.Heartbeat:Connect(function(dt)
+        if not handle.Parent or not hand.Parent then
+            restoreWeld()
+            return
+        end
+
+        elapsed += dt
+        if elapsed &gt;= duration then
+            restoreWeld()
+            return
+        end
+
+        local alpha = elapsed / duration
+        local swing = math.sin(alpha * math.pi)
+        local extra = CFrame.Angles(math.rad(58) * swing, math.rad(14) * swing, 0)
+        handle.CFrame = hand.CFrame * offset * extra
+    end)
+end
+
+return HeldToolVisual
+</string>
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="57">
+        <Item class="ModuleScript" referent="105">
           <Properties>
             <string name="Name">Config</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
     SessionConfig = require(script.SessionConfig),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="58">
+          <Item class="ModuleScript" referent="106">
             <Properties>
               <string name="Name">SessionConfig</string>
-              <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local DEFAULT_PLACE_IDS = {
     Lobby = 99207062749924,
     Maze = 114148445477110,
     Run = 137478567439901,
+    Library = 0,
 }
 local DEFAULT_DEBUG_LOCAL_MAZE_HANDOFF = false
 
-local PLACE_ID_KEYS = { 'Lobby', 'Maze', 'Run' }
+local PLACE_ID_KEYS = { 'Lobby', 'Maze', 'Run', 'Library' }
 
 local function coercePlaceId(value)
     local numericValue = tonumber(value)
 
-    if type(numericValue) ~= 'number' or numericValue <= 0 then
+    if type(numericValue) ~= 'number' or numericValue &lt;= 0 then
         return nil
     end
 
@@ -6562,10 +8427,19 @@ local SessionConfig = {
     MinPlayers = 1,
     MaxPlayers = 4,
     DefaultSeed = 12345,
-    DefaultQuota = 120,
-    DefaultRunDurationSeconds = 180,
+    DefaultQuota = 12,
+    DefaultRunDurationSeconds = 15 * 60,
     SettlementDurationSeconds = 8,
     InventoryCapacity = 5,
+    Mission = table.freeze({
+        RoundCount = 5,
+        TargetItemCount = 12,
+    }),
+    TOD = table.freeze({
+        RoundMinutes = 15,
+        StartHour = 7,
+        EndHour = 22,
+    }),
     ProcGen = {
         RoomCount = 20,
         ExitMin = 2,
@@ -6579,96 +8453,74 @@ local SessionConfig = {
 }
 
 return SessionConfig
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="59">
+        <Item class="ModuleScript" referent="107">
           <Properties>
             <string name="Name">Enums</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
     RunState = require(script.RunState),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="60">
+          <Item class="ModuleScript" referent="108">
             <Properties>
               <string name="Name">RunState</string>
-              <string name="Source"><![CDATA[return {
+              <string name="Source">return {
     Camp = 'Camp',
     Expedition = 'Expedition',
     Extraction = 'Extraction',
     Settlement = 'Settlement',
 }
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="61">
+        <Item class="ModuleScript" referent="109">
           <Properties>
             <string name="Name">Network</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
     Remotes = require(script.Remotes),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="62">
+          <Item class="ModuleScript" referent="110">
             <Properties>
               <string name="Name">Remotes</string>
-              <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 local RunService = game:GetService('RunService')
 
 local Remotes = {}
 
 Remotes.Scope = table.freeze({
-    Lobby = 'Lobby',
     Run = 'Run',
     Maze = 'Maze',
 })
 
 local REMOTE_NAMES_BY_SCOPE = table.freeze({
-    [Remotes.Scope.Lobby] = {
-        'LobbyAction',
-        'LobbyState',
-    },
-    [Remotes.Scope.Run] = {
+    [Remotes.Scope.Run] = table.freeze({
         'RunAction',
         'RunState',
         'RunPrivateState',
-        'ShowNarrative',
-        'GetInventory',
-        'EquipItem',
-        'UseItem',
-        'UseItemFunction',
-        'GetInteractables',
-        'GetItemData',
-        'ItemUsageFeedback',
-    },
-    [Remotes.Scope.Maze] = {
+    }),
+    [Remotes.Scope.Maze] = table.freeze({
         'MazeAction',
         'MazeState',
         'MazePrivateState',
-    },
+    }),
 })
 
-local ALL_REMOTE_NAMES = {
-    'LobbyAction',
-    'LobbyState',
+local ALL_REMOTE_NAMES = table.freeze({
     'RunAction',
     'RunState',
     'RunPrivateState',
-    'ShowNarrative',
-    'GetInventory',
-    'EquipItem',
-    'UseItem',
-    'UseItemFunction',
-    'GetInteractables',
-    'GetItemData',
-    'ItemUsageFeedback',
     'MazeAction',
     'MazeState',
     'MazePrivateState',
-}
+    'TODState',
+})
 
 local function assertServer(operationName)
     if RunService:IsClient() then
@@ -6688,12 +8540,7 @@ local function ensureContainer()
     return container
 end
 
--- 需要使用RemoteFunction的remote名称
-local REMOTE_FUNCTION_NAMES = {
-    'GetInventory',
-    'GetInteractables',
-    'GetItemData',
-}
+local REMOTE_FUNCTION_NAMES = {}
 
 local function ensureRemote(container, name)
     local remote = container:FindFirstChild(name)
@@ -6775,7 +8622,7 @@ function Remotes.waitForScope(scope, timeoutSeconds)
 
         local elapsed = os.clock() - startTime
         local remaining = timeoutSeconds - elapsed
-        if remaining < 0 then
+        if remaining &lt; 0 then
             return 0
         end
 
@@ -6802,14 +8649,15 @@ function Remotes.waitForScope(scope, timeoutSeconds)
 end
 
 return Remotes
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="63">
+        <Item class="ModuleScript" referent="111">
           <Properties>
             <string name="Name">Runtime</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
+    HeldFlashlightHeadlight = require(script.HeldFlashlightHeadlight),
     ControlStateService = require(script.ControlStateService),
     FormalLocomotion = require(script.FormalLocomotion),
     HexMazeWorldRenderer = require(script.HexMazeWorldRenderer),
@@ -6824,14 +8672,17 @@ return Remotes
     MonsterService = require(script.MonsterService),
     PlayerService = require(script.PlayerService),
     PlayerStateService = require(script.PlayerStateService),
+    RoundSignalBus = require(script.RoundSignalBus),
+    TODProfile = require(script.TODProfile),
+    TODService = require(script.TODService),
     TeleportInventoryHydrator = require(script.TeleportInventoryHydrator),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="64">
+          <Item class="ModuleScript" referent="112">
             <Properties>
               <string name="Name">ControlStateService</string>
-              <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
@@ -6907,13 +8758,13 @@ function ControlStateService:reset()
 end
 
 return ControlStateService
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="65">
+          <Item class="ModuleScript" referent="113">
             <Properties>
               <string name="Name">FormalLocomotion</string>
-              <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
@@ -6976,13 +8827,91 @@ function FormalLocomotion.applyToHumanoid(humanoid, movementSummary)
 end
 
 return FormalLocomotion
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="66">
+          <Item class="ModuleScript" referent="114">
+            <Properties>
+              <string name="Name">HeldFlashlightHeadlight</string>
+              <string name="Source">--!strict
+-- Server-side head-mounted spotlight for tool flashlight use (replicates on character).
+local LIGHT_NAME = 'FlashlightLight'
+
+local HeldFlashlightHeadlight = {}
+
+-- Returns nil if the character has no Head; otherwise the new Enabled state after toggle.
+function HeldFlashlightHeadlight.toggle(player: Player): boolean?
+    local character = player.Character
+    if not character then
+        return nil
+    end
+
+    local head = character:FindFirstChild('Head')
+    if not head or not head:IsA('BasePart') then
+        return nil
+    end
+
+    local existing = head:FindFirstChild(LIGHT_NAME)
+    local flashlightLight: SpotLight
+    local isNewLight = false
+
+    if existing and existing:IsA('SpotLight') then
+        flashlightLight = existing
+        flashlightLight.Enabled = not flashlightLight.Enabled
+    else
+        if existing then
+            existing:Destroy()
+        end
+        flashlightLight = Instance.new('SpotLight')
+        flashlightLight.Name = LIGHT_NAME
+        flashlightLight.Color = Color3.fromRGB(255, 255, 240)
+        flashlightLight.Brightness = 2
+        flashlightLight.Range = 50
+        flashlightLight.Angle = 45
+        flashlightLight.Face = Enum.NormalId.Front
+        flashlightLight.Parent = head
+        isNewLight = true
+    end
+
+    if isNewLight then
+        flashlightLight.Enabled = true
+    end
+
+    return flashlightLight.Enabled
+end
+
+function HeldFlashlightHeadlight.clear(player: Player)
+    local character = player.Character
+    if not character then
+        return
+    end
+
+    local head = character:FindFirstChild('Head')
+    if not head then
+        return
+    end
+
+    local inst = head:FindFirstChild(LIGHT_NAME)
+    if inst then
+        inst:Destroy()
+    end
+end
+
+-- Destroy head spotlight when the player is no longer holding a flashlight.
+function HeldFlashlightHeadlight.syncHeldItem(player: Player, heldItem: any?)
+    if type(heldItem) ~= 'table' or heldItem.ToolCategory ~= 'Flashlight' then
+        HeldFlashlightHeadlight.clear(player)
+    end
+end
+
+return HeldFlashlightHeadlight
+</string>
+            </Properties>
+          </Item>
+          <Item class="ModuleScript" referent="115">
             <Properties>
               <string name="Name">HexMazeWorldRenderer</string>
-              <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 local Workspace = game:GetService('Workspace')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
@@ -7001,9 +8930,12 @@ local math_rad = math.rad
 local math_cos = math.cos
 local math_sin = math.sin
 local math_tan = math.tan
+local math_abs = math.abs
 local math_pi = math.pi
+local math_huge = math.huge
 
 local Vector3_new = Vector3.new
+local Vector3_zero = Vector3.zero
 local CFrame_new = CFrame.new
 local CFrame_lookAt = CFrame.lookAt
 local Instance_new = Instance.new
@@ -7029,11 +8961,22 @@ local SIDE_ANGLE_OFFSET_DEGREES = 0
 
 local SIDE_NORMALS_X = {}
 local SIDE_NORMALS_Z = {}
+local SIDE_VECTORS_NORMAL = {}
+local SIDE_VECTORS_TANGENT = {}
+
 for directionIndex = 1, 6 do
     local angle = math_rad((-(directionIndex - 1) * 60) + SIDE_ANGLE_OFFSET_DEGREES)
-    SIDE_NORMALS_X[directionIndex] = math_cos(angle)
-    SIDE_NORMALS_Z[directionIndex] = math_sin(angle)
+    local nx = math_cos(angle)
+    local nz = math_sin(angle)
+    SIDE_NORMALS_X[directionIndex] = nx
+    SIDE_NORMALS_Z[directionIndex] = nz
+    SIDE_VECTORS_NORMAL[directionIndex] = Vector3_new(nx, 0, nz)
+    SIDE_VECTORS_TANGENT[directionIndex] = Vector3_new(-nz, 0, nx)
 end
+
+local TILE_BUFFER_A = FLOOR_TILE_SIZE / 2
+local TILE_BUFFER_B = (FLOOR_TILE_SIZE / 2) * (math_cos(math_rad(60)) + math_sin(math_rad(60)))
+local SIN_60 = math_sin(math_rad(60))
 
 local DEFAULT_SURFACE_PALETTE = table.freeze({
     WallMaterial = Enum.Material.Concrete,
@@ -7062,14 +9005,6 @@ local function resolveSurfacePalette(surfacePalette)
     end
 
     return resolvedPalette
-end
-
-local function edgeKey(roomIdA, roomIdB)
-    if roomIdA < roomIdB then
-        return roomIdA .. '|' .. roomIdB
-    end
-
-    return roomIdB .. '|' .. roomIdA
 end
 
 local function createPart(config, parent)
@@ -7182,25 +9117,28 @@ local function createConnectorAuthoringSockets(connectorFolder, connectorPivot)
     return authoringFolder
 end
 
+local function addDecorPart(parent, roomCenter, name, size, offset, color, material, transparency)
+    local part = Instance_new('Part')
+    part.Name = name
+    part.Anchored = true
+    part.Size = size
+    part.CFrame = CFrame_new(roomCenter + offset)
+    part.Color = color
+    part.Material = material or Enum.Material.SmoothPlastic
+    part.Transparency = transparency or 0
+    part.CanCollide = false
+    part.Parent = parent
+end
+
 local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem, surfacePalette)
     local decorFolder = Instance_new('Folder')
     decorFolder.Name = 'RoomTemplateDecor'
     decorFolder.Parent = roomFolder
 
-    local function addDecorPart(name, size, offset, color, material, transparency)
-        createPart({
-            Name = name,
-            Size = size,
-            CFrame = CFrame_new(roomCenter + offset),
-            Color = color,
-            Material = material,
-            Transparency = transparency or 0,
-            CanCollide = false,
-        }, decorFolder)
-    end
-
     if room.RoomTemplateId == 'EntrySafe' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'StagingPad',
             Vector3_new(roomApothem * 0.9, 0.4, roomApothem * 0.9),
             Vector3_new(0, 0.25, 0),
@@ -7208,6 +9146,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'OrientationPylon',
             Vector3_new(2, 9, 2),
             Vector3_new(0, 4.5, roomApothem * 0.22),
@@ -7219,6 +9159,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'TransitHall' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'TransitBeam',
             Vector3_new(roomApothem * 1.05, 1.2, 3),
             Vector3_new(0, 10, 0),
@@ -7226,6 +9168,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'TransitStripe',
             Vector3_new(roomApothem * 0.75, 0.15, 2),
             Vector3_new(0, 0.2, 0),
@@ -7238,6 +9182,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'SearchCluster' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'SearchCrateA',
             Vector3_new(5, 3, 4),
             Vector3_new(-roomApothem * 0.22, 1.5, 0),
@@ -7245,6 +9191,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.WoodPlanks
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'SearchCrateB',
             Vector3_new(4, 2.2, 3),
             Vector3_new(roomApothem * 0.2, 1.1, roomApothem * 0.1),
@@ -7256,6 +9204,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'HighValueRisk' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'VaultCore',
             Vector3_new(7, 6, 7),
             Vector3_new(0, 3, 0),
@@ -7263,6 +9213,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'HazardStrip',
             Vector3_new(roomApothem * 0.8, 0.2, 2),
             Vector3_new(0, 0.15, -roomApothem * 0.18),
@@ -7275,6 +9227,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'LandmarkFacility' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'LandmarkTower',
             Vector3_new(5, 12, 5),
             Vector3_new(0, 6, 0),
@@ -7282,6 +9236,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'LandmarkRing',
             Vector3_new(roomApothem * 0.95, 0.2, roomApothem * 0.95),
             Vector3_new(0, 0.2, 0),
@@ -7294,6 +9250,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'ExtractionReturn' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'ExtractionFrame',
             Vector3_new(roomApothem * 0.95, 0.25, roomApothem * 0.95),
             Vector3_new(0, 0.2, 0),
@@ -7302,6 +9260,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             0.35
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'ExtractionBeacon',
             Vector3_new(2.5, 10, 2.5),
             Vector3_new(0, 5, 0),
@@ -7313,6 +9273,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'BulkheadGate' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'BulkheadFrame',
             Vector3_new(roomApothem * 0.92, 7, 2),
             Vector3_new(0, 3.5, 0),
@@ -7320,6 +9282,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'BulkheadThreshold',
             Vector3_new(roomApothem * 0.9, 0.2, 3),
             Vector3_new(0, 0.2, 0),
@@ -7332,6 +9296,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 
     if room.RoomTemplateId == 'ShortcutLoop' then
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'ShortcutBrace',
             Vector3_new(roomApothem * 0.8, 1.2, 3),
             Vector3_new(0, 9, 0),
@@ -7339,6 +9305,8 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
             Enum.Material.Metal
         )
         addDecorPart(
+            decorFolder,
+            roomCenter,
             'ShortcutMarker',
             Vector3_new(roomApothem * 0.75, 0.15, 1.5),
             Vector3_new(0, 0.2, 0),
@@ -7350,32 +9318,7 @@ local function buildRoomTemplateDecor(roomFolder, room, roomCenter, roomApothem,
 end
 
 local function sideVectors(directionIndex)
-    local nx, nz = SIDE_NORMALS_X[directionIndex], SIDE_NORMALS_Z[directionIndex]
-    local normal = Vector3_new(nx, 0, nz)
-    local tangent = Vector3_new(-nz, 0, nx)
-    return normal, tangent
-end
-
-local function isInsideHexNumeric(ox, oz, apothem)
-    if ox * SIDE_NORMALS_X[1] + oz * SIDE_NORMALS_Z[1] > apothem then
-        return false
-    end
-    if ox * SIDE_NORMALS_X[2] + oz * SIDE_NORMALS_Z[2] > apothem then
-        return false
-    end
-    if ox * SIDE_NORMALS_X[3] + oz * SIDE_NORMALS_Z[3] > apothem then
-        return false
-    end
-    if ox * SIDE_NORMALS_X[4] + oz * SIDE_NORMALS_Z[4] > apothem then
-        return false
-    end
-    if ox * SIDE_NORMALS_X[5] + oz * SIDE_NORMALS_Z[5] > apothem then
-        return false
-    end
-    if ox * SIDE_NORMALS_X[6] + oz * SIDE_NORMALS_Z[6] > apothem then
-        return false
-    end
-    return true
+    return SIDE_VECTORS_NORMAL[directionIndex], SIDE_VECTORS_TANGENT[directionIndex]
 end
 
 local function createHexTiledSlab(parent, name, center, apothem, yOffset, color, material)
@@ -7383,37 +9326,34 @@ local function createHexTiledSlab(parent, name, center, apothem, yOffset, color,
     slabFolder.Name = name
     slabFolder.Parent = parent
 
-    local radius = apothem * HEX_CIRCUMRADIUS_MULTIPLIER
-    local halfTile = FLOOR_TILE_SIZE / 2
-    local maxOffset = math_ceil(radius / FLOOR_TILE_SIZE) * FLOOR_TILE_SIZE
-    local tileCount = 0
-
     local cx, cy, cz = center.X, center.Y, center.Z
+    local tileSizeVector = Vector3_new(FLOOR_TILE_SIZE, SLAB_THICKNESS, FLOOR_TILE_SIZE)
 
-    for x = -maxOffset, maxOffset, FLOOR_TILE_SIZE do
-        for z = -maxOffset, maxOffset, FLOOR_TILE_SIZE do
-            local cornersInside = true
+    -- Bolt: Optimized loop bounds to eliminate redundant inner-loop condition checks.
+    -- The hex boundary is defined by:
+    --   |x| + TILE_BUFFER_A &lt;= apothem
+    --   |0.5x +/- SIN_60 * z| + TILE_BUFFER_B &lt;= apothem
+    local xLimit = apothem - TILE_BUFFER_A
+    local xStart = math_ceil(-xLimit / FLOOR_TILE_SIZE) * FLOOR_TILE_SIZE
+    local xEnd = math_floor(xLimit / FLOOR_TILE_SIZE) * FLOOR_TILE_SIZE
+    local bPrime = apothem - TILE_BUFFER_B
 
-            -- Unrolled corner check to avoid Vector3 and table allocations
-            if
-                not isInsideHexNumeric(x - halfTile, z - halfTile, apothem)
-                or not isInsideHexNumeric(x + halfTile, z - halfTile, apothem)
-                or not isInsideHexNumeric(x - halfTile, z + halfTile, apothem)
-                or not isInsideHexNumeric(x + halfTile, z + halfTile, apothem)
-            then
-                cornersInside = false
-            end
+    for x = xStart, xEnd, FLOOR_TILE_SIZE do
+        -- Solve for z: |0.5x +/- SIN_60 * z| &lt;= bPrime
+        -- Yields: - (bPrime - 0.5|x|) / SIN_60 &lt;= z &lt;= (bPrime - 0.5|x|) / SIN_60
+        local zMax = (bPrime - 0.5 * math_abs(x)) / SIN_60
+        local zStart = math_ceil(-zMax / FLOOR_TILE_SIZE) * FLOOR_TILE_SIZE
+        local zEnd = math_floor(zMax / FLOOR_TILE_SIZE) * FLOOR_TILE_SIZE
 
-            if cornersInside then
-                tileCount += 1
-                createPart({
-                    Name = name .. 'Tile_' .. tileCount,
-                    Size = Vector3_new(FLOOR_TILE_SIZE, SLAB_THICKNESS, FLOOR_TILE_SIZE),
-                    CFrame = CFrame_new(cx + x, cy + yOffset, cz + z),
-                    Color = color,
-                    Material = material,
-                }, slabFolder)
-            end
+        for z = zStart, zEnd, FLOOR_TILE_SIZE do
+            local part = Instance_new('Part')
+            part.Name = 'Tile'
+            part.Anchored = true
+            part.Size = tileSizeVector
+            part.CFrame = CFrame_new(cx + x, cy + yOffset, cz + z)
+            part.Color = color
+            part.Material = material
+            part.Parent = slabFolder
         end
     end
 
@@ -7458,7 +9398,7 @@ local function createHexSideWall(
     end
 
     local lintelHeight = WALL_HEIGHT - DOORWAY_HEIGHT
-    if lintelHeight > 0 then
+    if lintelHeight &gt; 0 then
         createPart({
             Name = string.format('Wall_%d_Lintel', directionIndex),
             Size = Vector3_new(DOORWAY_WIDTH, lintelHeight, WALL_THICKNESS),
@@ -7520,7 +9460,7 @@ local function createDoorwayInstance(
         + tangent * openOffset
         + Vector3_new(0, DOORWAY_HEIGHT / 2, 0)
 
-    local leafOrientation = CFrame_lookAt(Vector3.zero, normal)
+    local leafOrientation = CFrame_lookAt(Vector3_zero, normal)
     doorway.ClosedLeftCFrame = CFrame_new(closedLeftCenter) * leafOrientation
     doorway.ClosedRightCFrame = CFrame_new(closedRightCenter) * leafOrientation
     doorway.OpenLeftCFrame = CFrame_new(openLeftCenter) * leafOrientation
@@ -7598,11 +9538,6 @@ local function buildRoom(parent, room, roomCenter, roomApothem, options)
         }, roomFolder)
     end
 
-    local doorwayDirections = {}
-    for directionIndex in pairs(room.Neighbors) do
-        doorwayDirections[directionIndex] = true
-    end
-
     local sideLength = 2 * roomApothem * TAN_PI_6
     for directionIndex = 1, 6 do
         createHexSideWall(
@@ -7611,7 +9546,7 @@ local function buildRoom(parent, room, roomCenter, roomApothem, options)
             directionIndex,
             roomApothem,
             sideLength,
-            doorwayDirections[directionIndex] == true,
+            room.Neighbors[directionIndex] ~= nil,
             options.SurfacePalette
         )
     end
@@ -7704,7 +9639,7 @@ local function buildPassageInstance(
     local passageDefinition = resolvePassageDefinition(passageArchetypeId)
     local passagePivot = CFrame_new(
         passageCenter + Vector3_new(0, (passageDefinition.Height or ROOM_CLEAR_HEIGHT) / 2, 0)
-    ) * CFrame_lookAt(Vector3.zero, corridorForward.LookVector)
+    ) * CFrame_lookAt(Vector3_zero, corridorForward.LookVector)
 
     local passageFolder = Instance_new('Folder')
     passageFolder.Name = folderName
@@ -7820,7 +9755,7 @@ end
 function HexMazeWorldRenderer.build(params)
     local worldName = params.WorldName or 'GeneratedMazeWorld'
     local layout = params.Layout
-    local originOffset = params.OriginOffset or Vector3.zero
+    local originOffset = params.OriginOffset or Vector3_zero
     local roomApothem = math.max(8, params.RoomApothem or ROOM_APOTHEM_DEFAULT)
     local includeRoomMarker = params.IncludeRoomMarker ~= false
     local parent = params.Parent or Workspace
@@ -7846,6 +9781,7 @@ function HexMazeWorldRenderer.build(params)
     local connectors = {}
     local exitPassages = {}
     local doorways = {}
+    local doorwayByRoomIds = {}
     local externalDoorwaysByRoomId = {}
 
     for _, externalDoorway in ipairs(layout.ExternalDoorways or {}) do
@@ -7933,29 +9869,41 @@ function HexMazeWorldRenderer.build(params)
         doorway.DirectionFromA = doorwayLayout.DirectionFromA
         doorway.DirectionFromB = doorwayLayout.DirectionFromB
         doorways[doorwayId] = doorway
+
+        local roomAId = doorwayLayout.RoomA
+        local roomBId = doorwayLayout.RoomB
+
+        if not doorwayByRoomIds[roomAId] then
+            doorwayByRoomIds[roomAId] = {}
+        end
+        if not doorwayByRoomIds[roomBId] then
+            doorwayByRoomIds[roomBId] = {}
+        end
+        doorwayByRoomIds[roomAId][roomBId] = doorway
+        doorwayByRoomIds[roomBId][roomAId] = doorway
     end
 
     local detectionRadius = roomApothem + detectionBuffer
     local detectionRadiusSq = detectionRadius * detectionRadius
     local searchRadiusCells = math_ceil(detectionRadius / cellSize)
-    if searchRadiusCells < 1 then
+    if searchRadiusCells &lt; 1 then
         searchRadiusCells = 1
     end
 
     local function findRoomByPosition(position)
         local nearestRoom = nil
-        local nearestDistanceSq = math.huge
+        local nearestDistanceSq = math_huge
 
         local px, pz = position.X, position.Z
         local pq = math_floor(px / cellSize)
         local pr = math_floor(pz / cellSize)
 
         for dq = -searchRadiusCells, searchRadiusCells do
+            -- Bolt: Hoist the bit-shifted component out of the inner dr loop
+            local qPart = bit32_lshift(bit32_band(pq + dq, 0xFFFF), 16)
+
             for dr = -searchRadiusCells, searchRadiusCells do
-                local key = bit32_bor(
-                    bit32_lshift(bit32_band(pq + dq, 0xFFFF), 16),
-                    bit32_band(pr + dr, 0xFFFF)
-                )
+                local key = bit32_bor(qPart, bit32_band(pr + dr, 0xFFFF))
                 local cell = spatialHash[key]
                 if cell then
                     for _, roomId in ipairs(cell) do
@@ -7963,7 +9911,7 @@ function HexMazeWorldRenderer.build(params)
                         local dx = roomCenter.X - px
                         local dz = roomCenter.Z - pz
                         local distSq = dx * dx + dz * dz
-                        if distSq < nearestDistanceSq then
+                        if distSq &lt; nearestDistanceSq then
                             nearestDistanceSq = distSq
                             nearestRoom = roomById[roomId]
                         end
@@ -7972,11 +9920,12 @@ function HexMazeWorldRenderer.build(params)
             end
         end
 
-        if nearestDistanceSq <= detectionRadiusSq then
-            return nearestRoom, math_sqrt(nearestDistanceSq)
+        local nearestDistance = math_sqrt(nearestDistanceSq)
+        if nearestDistanceSq &lt;= detectionRadiusSq then
+            return nearestRoom, nearestDistance
         end
 
-        return nil, math_sqrt(nearestDistanceSq)
+        return nil, nearestDistance
     end
 
     local function canTraverseBetweenPositions(fromPosition, toPosition)
@@ -7987,16 +9936,19 @@ function HexMazeWorldRenderer.build(params)
             return true
         end
 
-        if fromRoom.Id == toRoom.Id then
+        local fromRoomId = fromRoom.Id
+        local toRoomId = toRoom.Id
+
+        if fromRoomId == toRoomId then
             return true
         end
 
-        local doorwayId = edgeKey(fromRoom.Id, toRoom.Id)
-        local doorway = doorways[doorwayId]
+        -- Bolt: Replaced string-based edgeKey with O(1) nested table lookup
+        local doorway = doorwayByRoomIds[fromRoom.Id] and doorwayByRoomIds[fromRoom.Id][toRoom.Id]
         if not doorway then
             return false
         end
-        if doorway and doorway.HasDoorLeaves and not doorway.IsOpen then
+        if doorway.HasDoorLeaves and not doorway.IsOpen then
             return false
         end
 
@@ -8030,13 +9982,13 @@ function HexMazeWorldRenderer.build(params)
 end
 
 return HexMazeWorldRenderer
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="67">
+          <Item class="ModuleScript" referent="116">
             <Properties>
               <string name="Name">InventoryService</string>
-              <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
@@ -8074,6 +10026,15 @@ function InventoryService:pickup(player, itemDef)
     return inventory:add(itemDef)
 end
 
+function InventoryService:pickupEntry(player, rawItemEntry)
+    local inventory = self:get(player)
+    if not inventory then
+        return false, 'MissingInventory'
+    end
+
+    return inventory:addEntry(rawItemEntry)
+end
+
 function InventoryService:equip(player, itemInstanceId)
     local inventory = self:get(player)
     if not inventory then
@@ -8107,9 +10068,26 @@ function InventoryService:deposit(player)
         return 0
     end
 
-    local totalValue = inventory:getTotalValue()
-    inventory:clear()
-    return totalValue
+    local _, missionCount = inventory:extractMissionCargo()
+    return missionCount
+end
+
+function InventoryService:extractMissionCargo(player)
+    local inventory = self:get(player)
+    if not inventory then
+        return {}, 0
+    end
+
+    return inventory:extractMissionCargo()
+end
+
+function InventoryService:dropAllItems(player)
+    local inventory = self:get(player)
+    if not inventory then
+        return {}
+    end
+
+    return inventory:dropAllItems()
 end
 
 function InventoryService:loadSummary(player, summary)
@@ -8133,6 +10111,10 @@ function InventoryService:getSummary(player)
             Value = 0,
             BackpackItems = {},
             HeldItem = nil,
+            LootCount = 0,
+            ClueCount = 0,
+            ToolCount = 0,
+            MissionCount = 0,
         }
     end
 
@@ -8157,14 +10139,23 @@ function InventoryService:consumeByItemId(player, itemId)
     return inventory:consumeById(itemId)
 end
 
+function InventoryService:sell(player, itemId)
+    local inventory = self:get(player)
+    if not inventory then
+        return false, 'MissingInventory'
+    end
+
+    return inventory:sell(itemId)
+end
+
 return InventoryService
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="68">
+          <Item class="ModuleScript" referent="117">
             <Properties>
               <string name="Name">MazeDebugWorldComposer</string>
-              <string name="Source"><![CDATA[local MazeWorldShellBuilder = require(script.Parent.MazeWorldShellBuilder)
+              <string name="Source">local MazeWorldShellBuilder = require(script.Parent.MazeWorldShellBuilder)
 local MazeInteractionPartFactory = require(script.Parent.MazeInteractionPartFactory)
 
 local MazeDebugWorldComposer = {}
@@ -8197,13 +10188,13 @@ function MazeDebugWorldComposer.build(seed, config, options)
 end
 
 return MazeDebugWorldComposer
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="69">
+          <Item class="ModuleScript" referent="118">
             <Properties>
               <string name="Name">MazeFormalWorldComposer</string>
-              <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
@@ -8343,7 +10334,7 @@ local function finalizeAffordances(roomAffordances)
     for _, affordance in pairs(roomAffordances) do
         table.sort(affordance.TraversalMask.DoorwayIds)
         table.sort(affordance.DoorControlPoints, function(left, right)
-            return left.DoorwayId < right.DoorwayId
+            return left.DoorwayId &lt; right.DoorwayId
         end)
     end
 end
@@ -8423,32 +10414,11 @@ function MazeFormalWorldComposer.build(seed, config, options)
         Color = Color3.fromRGB(77, 147, 196),
         Material = Enum.Material.Neon,
         ActionText = 'Return',
-        ObjectText = 'Run Entrance',
+        ObjectText = 'Run',
         Transparency = 0.2,
         CanCollide = false,
         MaxActivationDistance = 12,
     }, shell.Root)
-
-    local extractionNodeId = 'PrimaryExtraction'
-    local _, extractionPrompt = MazeInteractionPartFactory.createPromptPart({
-        Name = 'ExtractionMarker',
-        Size = Vector3.new(6, 1, 6),
-        CFrame = CFrame.new(shell.ExtractionCenter + Vector3.new(0, 0.5, 0)),
-        Color = Color3.fromRGB(214, 170, 94),
-        Material = Enum.Material.Neon,
-        ActionText = 'Return',
-        ObjectText = resolvedOptions.ExtractionObjectText or 'Run Entrance',
-        CanCollide = false,
-        MaxActivationDistance = resolvedOptions.ExtractionMaxActivationDistance or 12,
-    }, shell.Root)
-
-    local extractionNodes = {
-        [extractionNodeId] = {
-            Id = extractionNodeId,
-            Prompt = extractionPrompt,
-            Position = shell.ExtractionCenter,
-        },
-    }
 
     local doorwayIds = {}
     for doorwayId in pairs(shell.Doorways or {}) do
@@ -8474,25 +10444,24 @@ function MazeFormalWorldComposer.build(seed, config, options)
     shell.RoomAffordances = roomAffordances
     shell.PatrolPoints = collectPatrolPointsFromAffordances(shell.RoomIds, roomAffordances)
     shell.InitialMonsterPatrolIndex = initialMonsterPatrolIndex
-        or (#shell.PatrolPoints > 0 and 1 or nil)
+        or (#shell.PatrolPoints &gt; 0 and 1 or nil)
     shell.InitialMonsterSpawnRoomId = initialMonsterSpawnRoomId
     shell.ReturnHoldPad = {
         Prompt = returnHoldPrompt,
         Position = returnHoldPadPosition,
     }
-    shell.ExtractionNodes = extractionNodes
 
     return shell
 end
 
 return MazeFormalWorldComposer
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="70">
+          <Item class="ModuleScript" referent="119">
             <Properties>
               <string name="Name">MazeInteractionPartFactory</string>
-              <string name="Source"><![CDATA[local MazeInteractionPartFactory = {}
+              <string name="Source">local MazeInteractionPartFactory = {}
 
 local DEFAULT_PROMPT_PART_SIZE = Vector3.new(4, 4, 4)
 local DEFAULT_PROMPT_PART_MATERIAL = Enum.Material.Metal
@@ -8540,13 +10509,13 @@ function MazeInteractionPartFactory.createPromptPart(config, parent)
 end
 
 return MazeInteractionPartFactory
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="71">
+          <Item class="ModuleScript" referent="120">
             <Properties>
               <string name="Name">MazeLightingProfile</string>
-              <string name="Source"><![CDATA[local MazeLightingProfile = {}
+              <string name="Source">local MazeLightingProfile = {}
 
 local EFFECT_NAMES = table.freeze({
     Atmosphere = 'MazeAtmosphere',
@@ -8859,20 +10828,19 @@ function MazeLightingProfile.apply(lighting, options)
 end
 
 return MazeLightingProfile
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="72">
+          <Item class="ModuleScript" referent="121">
             <Properties>
               <string name="Name">MazeModuleAssetContract</string>
-              <string name="Source"><![CDATA[local MazeModuleAssetContract = {}
+              <string name="Source">local MazeModuleAssetContract = {}
 
 MazeModuleAssetContract.RequiredModuleNames = table.freeze({
     'WallSegment',
     'DoorFrame',
     'DoorLeaf',
     'FloorPanel',
-    'ExtractionMarker',
 })
 
 MazeModuleAssetContract.OptionalAuthoringFolderName = 'RoomArchetypes'
@@ -8972,24 +10940,24 @@ function MazeModuleAssetContract.getConnectorShellModel(root, connectorArchetype
 end
 
 return MazeModuleAssetContract
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="73">
+          <Item class="ModuleScript" referent="122">
             <Properties>
               <string name="Name">MazeWorldScanner</string>
-              <string name="Source"><![CDATA[--[[
+              <string name="Source">--[[
     MazeWorldScanner
     运行时扫描 Workspace 中的静态房间实例，建立供 MazeSessionService 使用的数据结构。
 
     Authoring guide:
     - `Workspace/MazeStaticWorld` is the authored root for the maze place.
-    - Each room is a Model tagged `RoomType/<TypeId>`.
-    - Supported room metadata lives on Attributes such as `IsCamp`, `IsExtraction`,
-      `DifficultyTier`, `MonsterBudget`, `LootBudget`, `DetectionRadius`,
+    - Each room is a Model tagged `RoomType/&lt;TypeId&gt;`.
+    - Supported room metadata lives on Attributes such as `IsCamp`, `DifficultyTier`,
+      `MonsterBudget`, `LootBudget`, `DetectionRadius`,
       `RoomTemplateId`, and `RoomCategory`.
     - Supported authored room nodes include `MonsterSpawns/SpawnPoint_*`,
-      `LootSocket_*`, `Doorway_*`, `LootPrompt`, and `ExtractionMarker`.
+      `LootSocket_*`, `LootPrompt`, and `Doorway_*`.
 ]]
 
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
@@ -9005,7 +10973,10 @@ local DEFAULT_SCAN_ROOT = Workspace
 local STATIC_WORLD_ROOT_NAME = 'MazeStaticWorld'
 local DEFAULT_ROOM_KIND = 'Loot'
 local DEFAULT_RETURN_ACTION_TEXT = 'Return'
-local DEFAULT_RETURN_OBJECT_TEXT = 'Run Entrance'
+local DEFAULT_RETURN_OBJECT_TEXT = 'Run'
+
+local NEIGHBOR_DISTANCE_THRESHOLD = 50
+local DEFAULT_DETECTION_RADIUS = 18
 
 local SCAN_CONFIG = {
     RoomTagPrefix = 'RoomType/',
@@ -9023,7 +10994,6 @@ local DEFAULT_ATTRIBUTES = {
     MonsterBudget = 0,
     LootBudget = 0,
     IsCamp = false,
-    IsExtraction = false,
     IsScenery = false,
 }
 
@@ -9042,7 +11012,7 @@ end
 
 local function sortByName(instances)
     table.sort(instances, function(left, right)
-        return left.Name < right.Name
+        return left.Name &lt; right.Name
     end)
     return instances
 end
@@ -9152,6 +11122,10 @@ local function collectSpawnPoints(roomInstance)
     return collectNamedPoints(monsterSpawns, 'SpawnPoint', 'Unknown')
 end
 
+local function requiresMonsterPatrolAnchors(room, affordance)
+    return room.MonsterBudget &gt; 0 or affordance.HasMonsterSpawner
+end
+
 local function collectLootSockets(roomInstance)
     return collectNamedPoints(roomInstance, 'LootSocket', 'Unknown')
 end
@@ -9163,10 +11137,6 @@ end
 local function pickRoomKind(instance)
     if readAttribute(instance, 'IsCamp', DEFAULT_ATTRIBUTES.IsCamp) == true then
         return 'Camp'
-    end
-
-    if readAttribute(instance, 'IsExtraction', DEFAULT_ATTRIBUTES.IsExtraction) == true then
-        return 'Extraction'
     end
 
     return readAttribute(instance, 'RoomKind', DEFAULT_ROOM_KIND)
@@ -9211,7 +11181,6 @@ local function buildRoomData(instance)
         MonsterBudget = readAttribute(instance, 'MonsterBudget', DEFAULT_ATTRIBUTES.MonsterBudget),
         LootBudget = readAttribute(instance, 'LootBudget', DEFAULT_ATTRIBUTES.LootBudget),
         IsCamp = readAttribute(instance, 'IsCamp', DEFAULT_ATTRIBUTES.IsCamp),
-        IsExtraction = readAttribute(instance, 'IsExtraction', DEFAULT_ATTRIBUTES.IsExtraction),
         RoomTemplateId = readAttribute(instance, 'RoomTemplateId', roomType),
         RoomCategory = readAttribute(instance, 'RoomCategory', roomType),
         SearchProfile = {
@@ -9255,7 +11224,7 @@ local function getNearestRoomId(roomIds, roomById, position)
         local room = roomById[roomId]
         if room then
             local distance = (room.Position - position).Magnitude
-            if distance < bestDistance then
+            if distance &lt; bestDistance then
                 bestDistance = distance
                 bestRoomId = roomId
             end
@@ -9314,7 +11283,7 @@ function MazeWorldScanner.Scan(scanRoot)
             local roomB = roomById[idB]
             if idA ~= idB then
                 local distance = (roomB.Position - roomA.Position).Magnitude
-                if distance < 50 then
+                if distance &lt; NEIGHBOR_DISTANCE_THRESHOLD then
                     table.insert(roomA.Neighbors, idB)
                     table.insert(roomAffordances[idA].TraversalMask.NeighborRoomIds, idB)
                 end
@@ -9437,7 +11406,6 @@ function MazeWorldScanner.BuildStaticWorld(scanRoot)
 
     local roomCenters = {}
     local lootNodes = {}
-    local extractionNodes = {}
     local patrolPoints = {}
     local doorwayState = {}
     local roomInstancesById = {}
@@ -9472,7 +11440,17 @@ function MazeWorldScanner.BuildStaticWorld(scanRoot)
             end
         end
 
-        if room.MonsterBudget > 0 or affordance.HasMonsterSpawner then
+        if requiresMonsterPatrolAnchors(room, affordance) and #affordance.PatrolAnchors == 0 then
+            error(
+                string.format(
+                    'Maze room "%s" requires authored MonsterSpawns/SpawnPoint_* patrol anchors.',
+                    roomId
+                ),
+                0
+            )
+        end
+
+        if requiresMonsterPatrolAnchors(room, affordance) then
             for _, patrolAnchor in ipairs(affordance.PatrolAnchors) do
                 table.insert(patrolPoints, patrolAnchor.Position)
             end
@@ -9480,22 +11458,14 @@ function MazeWorldScanner.BuildStaticWorld(scanRoot)
 
         local extractionPart = roomInstance
             and roomInstance:FindFirstChild('ExtractionMarker', true)
-        local extractionPrompt = findPromptOnPart(extractionPart)
-        if extractionPart and extractionPrompt then
-            extractionPrompt.ActionText = extractionPrompt.ActionText ~= ''
-                    and extractionPrompt.ActionText
-                or DEFAULT_RETURN_ACTION_TEXT
-            extractionPrompt.ObjectText = extractionPrompt.ObjectText ~= ''
-                    and extractionPrompt.ObjectText
-                or DEFAULT_RETURN_OBJECT_TEXT
-
-            local extractionNodeId = extractionPart:GetAttribute('ExtractionNodeId')
-                or string.format('%s_Extraction', roomId)
-            extractionNodes[extractionNodeId] = {
-                Id = extractionNodeId,
-                Prompt = extractionPrompt,
-                Position = extractionPart.Position,
-            }
+        if extractionPart ~= nil then
+            error(
+                string.format(
+                    'Maze room "%s" still contains deprecated authored part "ExtractionMarker". Use only ReturnHoldPad for maze exits.',
+                    roomId
+                ),
+                0
+            )
         end
 
         if room.Kind == 'Loot' then
@@ -9555,7 +11525,7 @@ function MazeWorldScanner.BuildStaticWorld(scanRoot)
         end
 
         local room = world.RoomById[nearestRoomId]
-        if nearestDistance > (room.DetectionRadius or 18) then
+        if nearestDistance &gt; (room.DetectionRadius or DEFAULT_DETECTION_RADIUS) then
             return nil
         end
 
@@ -9588,12 +11558,11 @@ function MazeWorldScanner.BuildStaticWorld(scanRoot)
         Prompt = returnHoldPrompt,
         Position = returnHoldPadPart.Position,
     }
-    world.ExtractionNodes = extractionNodes
     world.LootNodes = lootNodes
     world.Doorways = doorwayState
     world.PatrolPoints = patrolPoints
-    world.InitialMonsterPatrolIndex = #patrolPoints > 0 and 1 or nil
-    world.InitialMonsterSpawnRoomId = #world.RoomIds > 0
+    world.InitialMonsterPatrolIndex = #patrolPoints &gt; 0 and 1 or nil
+    world.InitialMonsterSpawnRoomId = #world.RoomIds &gt; 0
             and world.RoomIds[math.min(2, #world.RoomIds)]
         or nil
     world.FindRoomByPosition = findRoomByPosition
@@ -9606,13 +11575,13 @@ function MazeWorldScanner.BuildStaticWorld(scanRoot)
 end
 
 return MazeWorldScanner
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="74">
+          <Item class="ModuleScript" referent="123">
             <Properties>
               <string name="Name">MazeWorldShellBuilder</string>
-              <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
@@ -9668,13 +11637,13 @@ function MazeWorldShellBuilder.build(seed, config, options)
 end
 
 return MazeWorldShellBuilder
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="75">
+          <Item class="ModuleScript" referent="124">
             <Properties>
               <string name="Name">MonsterRuntime</string>
-              <string name="Source"><![CDATA[return {
+              <string name="Source">return {
     EnemyBlackboard = require(script.EnemyBlackboard),
     EnemyRuntime = require(script.EnemyRuntime),
     EnemyStateMachine = require(script.EnemyStateMachine),
@@ -9683,12 +11652,12 @@ return MazeWorldShellBuilder
     AttackComponent = require(script.AttackComponent),
     HealthComponent = require(script.HealthComponent),
 }
-]]></string>
+</string>
             </Properties>
-            <Item class="ModuleScript" referent="76">
+            <Item class="ModuleScript" referent="125">
               <Properties>
                 <string name="Name">AttackComponent</string>
-                <string name="Source"><![CDATA[local AttackComponent = {}
+                <string name="Source">local AttackComponent = {}
 AttackComponent.__index = AttackComponent
 
 function AttackComponent.new(options)
@@ -9714,15 +11683,15 @@ function AttackComponent:tryQueueAttack(currentPosition, blackboard)
     end
 
     local now = self.Clock()
-    if (now - self.LastAttackAt) < self.CooldownSeconds then
+    if (now - self.LastAttackAt) &lt; self.CooldownSeconds then
         return false
     end
 
-    if self.AttackRange <= 0 then
+    if self.AttackRange &lt;= 0 then
         return false
     end
 
-    if (targetPosition - currentPosition).Magnitude > self.AttackRange then
+    if (targetPosition - currentPosition).Magnitude &gt; self.AttackRange then
         return false
     end
 
@@ -9731,13 +11700,13 @@ function AttackComponent:tryQueueAttack(currentPosition, blackboard)
 end
 
 return AttackComponent
-]]></string>
+</string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="77">
+            <Item class="ModuleScript" referent="126">
               <Properties>
                 <string name="Name">EnemyBlackboard</string>
-                <string name="Source"><![CDATA[local EnemyBlackboard = {}
+                <string name="Source">local EnemyBlackboard = {}
 EnemyBlackboard.__index = EnemyBlackboard
 
 function EnemyBlackboard.new(options)
@@ -9774,17 +11743,17 @@ function EnemyBlackboard:canUseLastSeen(now)
         return false
     end
 
-    return (now - self.LastSeenAt) <= self.MemoryDurationSeconds
+    return (now - self.LastSeenAt) &lt;= self.MemoryDurationSeconds
 end
 
 return EnemyBlackboard
-]]></string>
+</string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="78">
+            <Item class="ModuleScript" referent="127">
               <Properties>
                 <string name="Name">EnemyRuntime</string>
-                <string name="Source"><![CDATA[local EnemyBlackboard = require(script.Parent.EnemyBlackboard)
+                <string name="Source">local EnemyBlackboard = require(script.Parent.EnemyBlackboard)
 local EnemyStateMachine = require(script.Parent.EnemyStateMachine)
 local PerceptionComponent = require(script.Parent.PerceptionComponent)
 local MovementComponent = require(script.Parent.MovementComponent)
@@ -9813,6 +11782,7 @@ function EnemyRuntime.new(options)
             PatrolIndex = 1,
         },
         Clock = runtimeOptions.Clock or os.clock,
+        PendingDeathEvent = nil,
     }, EnemyRuntime)
 end
 
@@ -9828,6 +11798,21 @@ function EnemyRuntime:reset(patrolPoints, initialPatrolIndex)
     self.Blackboard.LastSeenAt = nil
     self.StateMachine.Current = EnemyStateMachine.State.Idle
     self.StateMachine.Previous = nil
+    self.PendingDeathEvent = nil
+    self.Health:reset()
+end
+
+function EnemyRuntime:spawn() end
+
+function EnemyRuntime:applyDamage(amount, source)
+    local remainingHealth = self.Health:applyDamage(amount)
+    if remainingHealth &lt;= 0 and self.PendingDeathEvent == nil then
+        self.PendingDeathEvent = {
+            KilledBy = source or 'unknown',
+        }
+    end
+
+    return remainingHealth
 end
 
 function EnemyRuntime:update(dt)
@@ -9841,6 +11826,8 @@ function EnemyRuntime:update(dt)
             StateChanged = false,
             AttackQueued = false,
             PerceptionState = self.Blackboard.PerceptionState,
+            IsDead = true,
+            DeathEvent = self.PendingDeathEvent,
         }
     end
 
@@ -9861,17 +11848,39 @@ function EnemyRuntime:update(dt)
         StateChanged = stateChanged,
         AttackQueued = attackQueued,
         PerceptionState = state,
+        State = state,
+        TargetPlayer = self.Blackboard.CurrentTarget,
+        IsDead = false,
+        DeathEvent = nil,
     }
 end
 
+function EnemyRuntime:destroy()
+    for _, component in ipairs({ self.Perception, self.Movement, self.Attack, self.Health }) do
+        if component and component.destroy then
+            component:destroy()
+        end
+    end
+
+    self.Blackboard = nil
+    self.StateMachine = nil
+    self.Perception = nil
+    self.Movement = nil
+    self.Attack = nil
+    self.Health = nil
+    self.Context = nil
+    self.Clock = nil
+    self.PendingDeathEvent = nil
+end
+
 return EnemyRuntime
-]]></string>
+</string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="79">
+            <Item class="ModuleScript" referent="128">
               <Properties>
                 <string name="Name">EnemyStateMachine</string>
-                <string name="Source"><![CDATA[local EnemyStateMachine = {}
+                <string name="Source">local EnemyStateMachine = {}
 EnemyStateMachine.__index = EnemyStateMachine
 
 EnemyStateMachine.State = table.freeze({
@@ -9908,18 +11917,22 @@ function EnemyStateMachine:update(blackboard, now)
 end
 
 return EnemyStateMachine
-]]></string>
+</string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="80">
+            <Item class="ModuleScript" referent="129">
               <Properties>
                 <string name="Name">HealthComponent</string>
-                <string name="Source"><![CDATA[local HealthComponent = {}
+                <string name="Source">local HealthComponent = {}
 HealthComponent.__index = HealthComponent
 
 function HealthComponent.new(options)
     local runtimeOptions = options or {}
-    local maxHealth = runtimeOptions.MaxHealth or 1
+    local maxHealth = runtimeOptions.MaxHp or runtimeOptions.MaxHealth or 1
+    if type(maxHealth) ~= 'number' or maxHealth &lt; 1 then
+        maxHealth = 1
+    end
+    maxHealth = math.max(1, math.floor(maxHealth))
 
     return setmetatable({
         MaxHealth = maxHealth,
@@ -9928,7 +11941,11 @@ function HealthComponent.new(options)
 end
 
 function HealthComponent:isAlive()
-    return self.CurrentHealth > 0
+    return self.CurrentHealth &gt; 0
+end
+
+function HealthComponent:isDead()
+    return not self:isAlive()
 end
 
 function HealthComponent:applyDamage(amount)
@@ -9937,14 +11954,19 @@ function HealthComponent:applyDamage(amount)
     return self.CurrentHealth
 end
 
+function HealthComponent:reset()
+    self.CurrentHealth = self.MaxHealth
+    return self.CurrentHealth
+end
+
 return HealthComponent
-]]></string>
+</string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="81">
+            <Item class="ModuleScript" referent="130">
               <Properties>
                 <string name="Name">MovementComponent</string>
-                <string name="Source"><![CDATA[local EnemyStateMachine = require(script.Parent.EnemyStateMachine)
+                <string name="Source">local EnemyStateMachine = require(script.Parent.EnemyStateMachine)
 
 local MovementComponent = {}
 MovementComponent.__index = MovementComponent
@@ -9988,7 +12010,7 @@ function MovementComponent:update(context, blackboard, state, dt)
     elseif state == EnemyStateMachine.State.Search and blackboard.LastSeenPosition ~= nil then
         nextPosition = self.StepToward(currentPosition, blackboard.LastSeenPosition, self.Speed, dt)
         animationName = 'Walk'
-    elseif self.EnablePatrol and #context.PatrolPoints > 0 then
+    elseif self.EnablePatrol and #context.PatrolPoints &gt; 0 then
         local patrolTarget = context.PatrolPoints[context.PatrolIndex] + self.SpawnOffset
         nextPosition = self.StepToward(
             currentPosition,
@@ -9998,7 +12020,7 @@ function MovementComponent:update(context, blackboard, state, dt)
         )
         animationName = 'Walk'
 
-        if (nextPosition - patrolTarget).Magnitude <= self.ArrivalThreshold then
+        if (nextPosition - patrolTarget).Magnitude &lt;= self.ArrivalThreshold then
             context.PatrolIndex = (context.PatrolIndex % #context.PatrolPoints) + 1
         end
     end
@@ -10012,13 +12034,13 @@ function MovementComponent:update(context, blackboard, state, dt)
 end
 
 return MovementComponent
-]]></string>
+</string>
               </Properties>
             </Item>
-            <Item class="ModuleScript" referent="82">
+            <Item class="ModuleScript" referent="131">
               <Properties>
                 <string name="Name">PerceptionComponent</string>
-                <string name="Source"><![CDATA[local PerceptionComponent = {}
+                <string name="Source">local PerceptionComponent = {}
 PerceptionComponent.__index = PerceptionComponent
 
 function PerceptionComponent.new(options)
@@ -10064,14 +12086,14 @@ function PerceptionComponent:update(blackboard)
 end
 
 return PerceptionComponent
-]]></string>
+</string>
               </Properties>
             </Item>
           </Item>
-          <Item class="ModuleScript" referent="83">
+          <Item class="ModuleScript" referent="132">
             <Properties>
               <string name="Name">MonsterService</string>
-              <string name="Source"><![CDATA[local InsertService = game:GetService('InsertService')
+              <string name="Source">local InsertService = game:GetService('InsertService')
 local Players = game:GetService('Players')
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 local RunService = game:GetService('RunService')
@@ -10083,8 +12105,8 @@ local Gameplay = require(Packages:WaitForChild('Gameplay'))
 local MonsterBehaviorCatalog = Gameplay.Monsters.MonsterBehaviorCatalog
 local MonsterComponentConfig = Gameplay.Monsters.MonsterComponentConfig
 local MonsterLogic = Gameplay.Monsters.MonsterLogic
-local Enemy = Gameplay.Monsters.Enemy
 local MonsterRuntimeProfile = Gameplay.Monsters.MonsterRuntimeProfile
+local PlayerMonsterMelee = Gameplay.Combat.PlayerMonsterMelee
 local EnemyRuntime = require(script.Parent.MonsterRuntime.EnemyRuntime)
 
 local MonsterService = {}
@@ -10164,8 +12186,35 @@ local function defaultCreateLoopSound(parent, soundAssetId, soundName)
     return sound
 end
 
-local function defaultEnemyFactory(monsterRuntimeProfile, options)
-    return Enemy.new(monsterRuntimeProfile, options)
+local function defaultEnemyFactory(_monsterRuntimeProfile, runtimeOptions)
+    return EnemyRuntime.new(runtimeOptions)
+end
+
+local function validateEnemyRuntimeContract(enemyRuntime)
+    if type(enemyRuntime) ~= 'table' then
+        error('Monster runtime factory must return a table', 0)
+    end
+
+    local requiredMethods = {
+        'reset',
+        'update',
+        'destroy',
+        'applyDamage',
+    }
+
+    for _, methodName in ipairs(requiredMethods) do
+        if type(enemyRuntime[methodName]) ~= 'function' then
+            error(string.format('Monster runtime missing required method %s()', methodName), 0)
+        end
+    end
+
+    if type(enemyRuntime.Context) ~= 'table' then
+        error('Monster runtime missing Context table', 0)
+    end
+
+    if type(enemyRuntime.Blackboard) ~= 'table' then
+        error('Monster runtime missing Blackboard table', 0)
+    end
 end
 
 function MonsterService.new(
@@ -10182,14 +12231,14 @@ function MonsterService.new(
 
     local runtimeOptions = options or {}
     local logicTickRateHz = runtimeOptions.LogicTickRateHz or DEFAULT_LOGIC_TICK_RATE_HZ
-    if type(logicTickRateHz) ~= 'number' or logicTickRateHz <= 0 then
+    if type(logicTickRateHz) ~= 'number' or logicTickRateHz &lt;= 0 then
         logicTickRateHz = DEFAULT_LOGIC_TICK_RATE_HZ
     end
 
     local randomSeed = runtimeOptions.RandomSeed
     if type(randomSeed) == 'number' then
         randomSeed = math.floor(randomSeed)
-        if randomSeed <= 0 then
+        if randomSeed &lt;= 0 then
             randomSeed = nil
         end
     else
@@ -10225,7 +12274,6 @@ function MonsterService.new(
         LoadMonsterModel = runtimeOptions.AssetLoader or defaultLoadMonsterModel,
         LoadAnimationTrack = runtimeOptions.LoadAnimationTrack or defaultLoadAnimationTrack,
         CreateLoopSound = runtimeOptions.CreateLoopSound or defaultCreateLoopSound,
-        EnemyFactory = runtimeOptions.EnemyFactory or defaultEnemyFactory,
         OnAttackHit = runtimeOptions.OnAttackHit or defaultOnAttackHit,
         Raycast = runtimeOptions.Raycast or defaultRaycast,
         GetPlayers = runtimeOptions.GetPlayers or function()
@@ -10251,49 +12299,75 @@ function MonsterService.new(
         DecisionLog = {},
         DecisionLogSink = runtimeOptions.DecisionLogSink,
         DecisionLogSequence = 0,
+        RuntimeClock = runtimeOptions.Clock or os.clock,
+        MemoryDurationSeconds = runtimeOptions.MemoryDurationSeconds,
         RandomSeed = randomSeed,
         RandomSource = runtimeOptions.RandomSource
             or if randomSeed ~= nil then Random.new(randomSeed) else Random.new(),
+        EnemyRuntimeFactory = runtimeOptions.EnemyRuntimeFactory
+            or runtimeOptions.EnemyFactory
+            or defaultEnemyFactory,
     }, MonsterService)
 
-    service.EnemyRuntime = EnemyRuntime.new({
-        MemoryDurationSeconds = runtimeOptions.MemoryDurationSeconds,
+    local combatHp = service.ComponentConfig.Health.MaxHp
+    if type(combatHp) ~= 'number' or combatHp &lt; 1 or math.floor(combatHp) ~= combatHp then
+        combatHp = 1
+    else
+        combatHp = math.floor(combatHp)
+    end
+    service.CombatMaxHealth = combatHp
+    service.CombatCurrentHealth = combatHp
+
+    return service
+end
+
+function MonsterService:_buildEnemyRuntimeOptions()
+    return {
+        MemoryDurationSeconds = self.MemoryDurationSeconds,
+        Clock = self.RuntimeClock,
         Perception = {
             GetPlayers = function()
-                return service.GetPlayers()
+                return self.GetPlayers()
             end,
             CanTargetPlayer = function(player)
-                return service.CanTargetPlayer(player)
+                return self.CanTargetPlayer(player)
             end,
             GetCurrentPosition = function()
-                return service:_getCurrentPosition()
+                return self:_getCurrentPosition()
             end,
             PickNearestTarget = MonsterLogic.pickNearestTarget,
-            SightRange = monsterRuntimeProfile.SightRange,
-            EnableSenseNearestTarget = monsterRuntimeProfile.Behaviors[MonsterBehaviorCatalog.Behavior.SenseNearestTarget]
+            SightRange = self.ComponentConfig.Perception.SightRange,
+            EnableSenseNearestTarget = self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.SenseNearestTarget]
                 == true,
-            GetNow = os.clock,
+            GetNow = self.RuntimeClock,
         },
         Movement = {
             StepToward = MonsterLogic.stepToward,
             GetCurrentPosition = function()
-                return service:_getCurrentPosition()
+                return self:_getCurrentPosition()
             end,
-            SpawnOffset = monsterRuntimeProfile.SpawnOffset,
-            Speed = monsterRuntimeProfile.Speed,
-            PatrolSpeedMultiplier = monsterRuntimeProfile.PatrolSpeedMultiplier,
-            EnableChase = monsterRuntimeProfile.Behaviors[MonsterBehaviorCatalog.Behavior.Chase]
+            SpawnOffset = self.ComponentConfig.Movement.SpawnOffset,
+            Speed = self.ComponentConfig.Movement.Speed,
+            PatrolSpeedMultiplier = self.ComponentConfig.Movement.PatrolSpeedMultiplier,
+            EnableChase = self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.Chase] == true,
+            EnablePatrol = self.Definition.Behaviors[MonsterBehaviorCatalog.Behavior.Patrol]
                 == true,
-            EnablePatrol = monsterRuntimeProfile.Behaviors[MonsterBehaviorCatalog.Behavior.Patrol]
-                == true,
+            ArrivalThreshold = self.ComponentConfig.Movement.PatrolReachDistance,
         },
         Attack = {
-            AttackRange = monsterRuntimeProfile.AttackRange or 0,
-            CooldownSeconds = monsterRuntimeProfile.AttackCooldownSeconds,
+            AttackRange = self.ComponentConfig.Attack.Range,
+            CooldownSeconds = self.ComponentConfig.Attack.CooldownSeconds,
         },
-    })
+        Health = {
+            MaxHp = self.ComponentConfig.Health.MaxHp,
+        },
+    }
+end
 
-    return service
+function MonsterService:_createEnemyRuntime()
+    local enemyRuntime = self.EnemyRuntimeFactory(self.Definition, self:_buildEnemyRuntimeOptions())
+    validateEnemyRuntimeContract(enemyRuntime)
+    return enemyRuntime
 end
 
 function MonsterService:_emitDecisionLog(eventName, fields)
@@ -10467,7 +12541,7 @@ end
 
 function MonsterService:_attachChaseLoopSound(parent)
     local soundAssetId = self.Definition.Presentation.ChaseLoopSoundAssetId
-    if parent == nil or type(soundAssetId) ~= 'number' or soundAssetId <= 0 then
+    if parent == nil or type(soundAssetId) ~= 'number' or soundAssetId &lt;= 0 then
         return
     end
 
@@ -10511,9 +12585,31 @@ function MonsterService:_spawnModel(spawnPosition)
     self.MonsterRoot = preparedModel
     self.MonsterPositionPart = rootPart
     self.LogicalPosition = spawnPosition
+    if self.MonsterHumanoid == nil then
+        self.MonsterHumanoid = humanoid
+    end
     self:_attachChaseLoopSound(rootPart)
 
     return true
+end
+
+function MonsterService:_applyDefinitionCombatHealth()
+    local maxPips = self.ComponentConfig.Health.MaxHp
+    if type(maxPips) ~= 'number' or maxPips &lt; 1 or math.floor(maxPips) ~= maxPips then
+        maxPips = 1
+    end
+
+    self.CombatMaxHealth = maxPips
+
+    local humanoid = self.MonsterHumanoid
+    if humanoid then
+        humanoid.MaxHealth = maxPips
+        humanoid.Health = maxPips
+        self.CombatCurrentHealth = maxPips
+        return
+    end
+
+    self.CombatCurrentHealth = maxPips
 end
 
 function MonsterService:_setAnimationState(animationName, speedMultiplier)
@@ -10583,7 +12679,7 @@ function MonsterService:_applyVisualCFrame(nextCFrame, dt)
 
     local appliedCFrame = nextCFrame
     local smoothingAlpha = 1
-    if type(dt) == 'number' and dt > 0 then
+    if type(dt) == 'number' and dt &gt; 0 then
         smoothingAlpha = 1 - math.exp(-self.VisualSmoothingSpeed * dt)
         smoothingAlpha = math.clamp(smoothingAlpha, 0, 1)
     end
@@ -10595,7 +12691,7 @@ function MonsterService:_applyVisualCFrame(nextCFrame, dt)
         currentCFrame = self.MonsterRoot.CFrame
     end
 
-    if currentCFrame and smoothingAlpha < 1 then
+    if currentCFrame and smoothingAlpha &lt; 1 then
         appliedCFrame = currentCFrame:Lerp(nextCFrame, smoothingAlpha)
     end
 
@@ -10621,7 +12717,7 @@ function MonsterService:_recordDecisionEvent(eventName, fields)
     end
 
     table.insert(self.DecisionLog, entry)
-    if #self.DecisionLog > self.DecisionLogLimit then
+    if #self.DecisionLog &gt; self.DecisionLogLimit then
         table.remove(self.DecisionLog, 1)
     end
 
@@ -10647,7 +12743,7 @@ function MonsterService:setDeterministicSeed(seed, randomSource)
     local normalizedSeed = seed
     if type(normalizedSeed) == 'number' then
         normalizedSeed = math.floor(normalizedSeed)
-        if normalizedSeed <= 0 then
+        if normalizedSeed &lt;= 0 then
             normalizedSeed = nil
         end
     else
@@ -10729,7 +12825,7 @@ function MonsterService:_getAttackFacingDirection()
     end
 
     local horizontalLook = Vector3.new(lookVector.X, 0, lookVector.Z)
-    if horizontalLook.Magnitude <= 1e-5 then
+    if horizontalLook.Magnitude &lt;= 1e-5 then
         return lookVector.Unit
     end
 
@@ -10739,13 +12835,13 @@ end
 function MonsterService:_isWithinAttackArc(monsterPosition, targetPosition, arcDegrees)
     local toTarget = targetPosition - monsterPosition
     local horizontalToTarget = Vector3.new(toTarget.X, 0, toTarget.Z)
-    if horizontalToTarget.Magnitude <= 1e-5 then
+    if horizontalToTarget.Magnitude &lt;= 1e-5 then
         return true
     end
 
     local facingDirection = self:_getAttackFacingDirection()
     local facingHorizontal = Vector3.new(facingDirection.X, 0, facingDirection.Z)
-    if facingHorizontal.Magnitude <= 1e-5 then
+    if facingHorizontal.Magnitude &lt;= 1e-5 then
         return true
     end
     facingHorizontal = facingHorizontal.Unit
@@ -10753,12 +12849,12 @@ function MonsterService:_isWithinAttackArc(monsterPosition, targetPosition, arcD
     local targetDirection = horizontalToTarget.Unit
     local halfArcCosine = math.cos(math.rad((arcDegrees or DEFAULT_ATTACK_ARC_DEGREES) * 0.5))
     local dot = facingHorizontal:Dot(targetDirection)
-    return dot + 1e-6 >= halfArcCosine
+    return dot + 1e-6 &gt;= halfArcCosine
 end
 
 function MonsterService:_hasLineOfSight(targetPlayer, originPosition, targetPosition)
     local direction = targetPosition - originPosition
-    if direction.Magnitude <= 1e-5 then
+    if direction.Magnitude &lt;= 1e-5 then
         return true
     end
 
@@ -10814,7 +12910,7 @@ function MonsterService:_resolveAttackHitContext(pendingAttack)
 
     local targetPosition = targetRoot.Position
     local distance = (targetPosition - monsterPosition).Magnitude
-    if distance > pendingAttack.Range then
+    if distance &gt; pendingAttack.Range then
         return {
             Hit = false,
             Reason = 'OutOfRange',
@@ -10839,6 +12935,7 @@ function MonsterService:_resolveAttackHitContext(pendingAttack)
         Hit = true,
         Reason = 'HitConfirmed',
         Distance = distance,
+        Effects = pendingAttack.Effects,
     }
 end
 
@@ -10879,7 +12976,7 @@ function MonsterService:_queueAttackIntent(attackIntent)
     end
 
     local range = attackIntent.Range
-    if type(range) ~= 'number' or range <= 0 then
+    if type(range) ~= 'number' or range &lt;= 0 then
         return
     end
 
@@ -10908,6 +13005,17 @@ function MonsterService:_queueAttackIntent(attackIntent)
     if hasMarkerConnection and not animationPlayed then
         self.PendingAttack = nil
     end
+
+    if not hasMarkerConnection or not animationPlayed then
+        self:_resolveQueuedAttack({
+            ArcDegrees = attackIntent.ArcDegrees or DEFAULT_ATTACK_ARC_DEGREES,
+            DamagePips = damagePips,
+            Effects = attackIntent.Effects,
+            MarkerName = markerName,
+            Range = range,
+            TargetPlayer = targetPlayer,
+        })
+    end
 end
 
 function MonsterService:_stepPendingAttack(dt)
@@ -10916,7 +13024,7 @@ function MonsterService:_stepPendingAttack(dt)
     end
 
     self.PendingAttack.RemainingWindowSeconds -= math.max(0, dt or 0)
-    if self.PendingAttack.RemainingWindowSeconds <= 0 then
+    if self.PendingAttack.RemainingWindowSeconds &lt;= 0 then
         self.PendingAttack = nil
     end
 end
@@ -10933,13 +13041,167 @@ function MonsterService:_onAttackMarkerReached(markerName)
 
     self.PendingAttack = nil
 
+    self:_resolveQueuedAttack(pendingAttack)
+end
+
+function MonsterService:_resolveQueuedAttack(pendingAttack)
+    if type(pendingAttack) ~= 'table' then
+        return false
+    end
+
     local hitContext = self:_resolveAttackHitContext(pendingAttack)
     if hitContext.Hit ~= true then
-        return
+        self:_recordDecisionEvent('AttackResolved', {
+            DamagePips = pendingAttack.DamagePips,
+            Reason = hitContext.Reason,
+            Result = 'Miss',
+            TargetUserId = self:_resolveTargetUserId(pendingAttack.TargetPlayer),
+        })
+        return false
     end
 
     self.OnAttackHit(pendingAttack.TargetPlayer, pendingAttack.DamagePips, hitContext)
+    self:_recordDecisionEvent('AttackResolved', {
+        DamagePips = pendingAttack.DamagePips,
+        Distance = hitContext.Distance,
+        Reason = hitContext.Reason,
+        Result = 'Hit',
+        TargetUserId = self:_resolveTargetUserId(pendingAttack.TargetPlayer),
+    })
+    return true
 end
+
+function MonsterService:_playerMeleeLineOfSightClear(player, playerPosition, monsterPosition)
+    local offset = monsterPosition - playerPosition
+    local distance = offset.Magnitude
+    if distance &lt;= 1e-3 then
+        return true
+    end
+
+    local character = player and player.Character
+    local raycastParams = RaycastParams.new()
+    raycastParams.FilterType = Enum.RaycastFilterType.Exclude
+    raycastParams.IgnoreWater = true
+    if character then
+        raycastParams.FilterDescendantsInstances = { character }
+    end
+
+    local direction = offset.Unit * (distance + 0.25)
+    local result = self.Raycast(playerPosition, direction, raycastParams)
+    if result == nil then
+        return true
+    end
+
+    if
+        self.MonsterRoot
+        and result.Instance
+        and result.Instance:IsDescendantOf(self.MonsterRoot)
+    then
+        return true
+    end
+
+    return false
+end
+
+function MonsterService:tryApplyPlayerMeleeHit(player, meleeOptions)
+    if not self.IsExpeditionActive() then
+        return false, 'ExpeditionInactive'
+    end
+
+    if self.MonsterRoot == nil then
+        return false, 'NoMonster'
+    end
+
+    local isPlayerInstance = typeof(player) == 'Instance' and player:IsA('Player')
+    local isTestStub = type(player) == 'table' and type(player.UserId) == 'number'
+    if not isPlayerInstance and not isTestStub then
+        return false, 'InvalidPlayer'
+    end
+
+    local character = player.Character
+    if character == nil then
+        return false, 'NoCharacter'
+    end
+
+    local humanoidRoot = character:FindFirstChild('HumanoidRootPart')
+    if humanoidRoot == nil or not humanoidRoot:IsA('BasePart') then
+        return false, 'MissingHumanoidRoot'
+    end
+
+    local options = meleeOptions or {}
+    local swingRange = options.SwingRange
+    if type(swingRange) ~= 'number' or swingRange &lt;= 0 then
+        swingRange = 6
+    end
+
+    local swingArcDegrees = options.SwingArcDegrees
+    if type(swingArcDegrees) ~= 'number' or swingArcDegrees &lt;= 0 then
+        swingArcDegrees = 70
+    end
+
+    local damagePips = options.DamagePips
+    if type(damagePips) ~= 'number' or damagePips &lt; 1 then
+        damagePips = 1
+    end
+    damagePips = math.floor(damagePips)
+
+    local monsterPosition = self:_getCurrentPosition()
+    if typeof(monsterPosition) ~= 'Vector3' then
+        return false, 'MissingMonsterPosition'
+    end
+
+    local playerPosition = humanoidRoot.Position
+    local playerLook = humanoidRoot.CFrame.LookVector
+
+    local geometryOk, geometryReason = PlayerMonsterMelee.evaluateSwing(
+        playerPosition,
+        playerLook,
+        monsterPosition,
+        swingRange,
+        swingArcDegrees
+    )
+    if geometryOk ~= true then
+        return false, geometryReason
+    end
+
+    if not self.CanTraverse(playerPosition, monsterPosition) then
+        return false, 'PathBlocked'
+    end
+
+    if not self:_playerMeleeLineOfSightClear(player, playerPosition, monsterPosition) then
+        return false, 'BlockedLineOfSight'
+    end
+
+    if not self.EnemyRuntime then
+        return false, 'MonsterCombatStateMissing'
+    end
+
+    local remainingHitPoints = self.EnemyRuntime:applyDamage(damagePips, 'player')
+    local killed = remainingHitPoints &lt;= 0
+    self.CombatCurrentHealth = remainingHitPoints
+
+    local monsterHumanoid = self.MonsterHumanoid
+    if monsterHumanoid then
+        monsterHumanoid.Health = remainingHitPoints
+    end
+
+    self:_recordDecisionEvent('PlayerMeleeHit', {
+        DamagePips = damagePips,
+        Killed = killed,
+        RemainingHitPoints = remainingHitPoints,
+        TargetUserId = player.UserId,
+    })
+
+    if killed then
+        self:destroy()
+    end
+
+    return true, {
+        Killed = killed,
+        RemainingHitPoints = remainingHitPoints,
+    }
+end
+
 function MonsterService:spawn(patrolPoints, initialPatrolIndex)
     self:destroy()
     self.PatrolPoints = patrolPoints
@@ -10956,8 +13218,9 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
     end
 
     self.PatrolIndex = math.clamp(initialPatrolIndex or 1, 1, #patrolPoints)
+    self.EnemyRuntime = self:_createEnemyRuntime()
     self.EnemyRuntime:reset(self.PatrolPoints, self.PatrolIndex)
-    local spawnPosition = patrolPoints[self.PatrolIndex] + self.Definition.SpawnOffset
+    local spawnPosition = patrolPoints[self.PatrolIndex] + self.ComponentConfig.Movement.SpawnOffset
     local spawnOk, spawnReason = self:_spawnModel(spawnPosition)
     if not spawnOk then
         self:_warnFallback(spawnReason)
@@ -10966,9 +13229,7 @@ function MonsterService:spawn(patrolPoints, initialPatrolIndex)
         self:_setAnimationState('Idle', 1)
     end
 
-    self.EnemyRuntime = self.EnemyFactory(self.Definition, {
-        ComponentConfig = self.ComponentConfig,
-    })
+    self:_applyDefinitionCombatHealth()
     if self.EnemyRuntime and self.EnemyRuntime.spawn then
         self.EnemyRuntime:spawn()
     end
@@ -10989,6 +13250,15 @@ function MonsterService:_runLogicStep(dt)
     local decision = self.EnemyRuntime:update(dt)
     self.PatrolIndex = self.EnemyRuntime.Context.PatrolIndex
 
+    if decision.IsDead then
+        self:_recordDecisionEvent('Died', {
+            MonsterId = self.Definition.Id,
+            DeathEvent = decision.DeathEvent,
+        })
+        self:destroy()
+        return
+    end
+
     if decision.TargetChanged then
         self:_emitDecisionLog('TargetChanged', {
             MonsterId = self.Definition.Id,
@@ -11005,6 +13275,17 @@ function MonsterService:_runLogicStep(dt)
         self:_emitDecisionLog('AttackQueued', {
             MonsterId = self.Definition.Id,
         })
+        local target = self.EnemyRuntime.Blackboard.CurrentTarget
+        if target then
+            self:_queueAttackIntent({
+                TargetPlayer = target,
+                DamagePips = self.ComponentConfig.Attack.DamagePips,
+                Range = self.ComponentConfig.Attack.Range,
+                ArcDegrees = self.ComponentConfig.Attack.ArcDegrees,
+                MarkerName = self.ComponentConfig.Attack.HitMarkerName,
+                Effects = self.Definition.Effects,
+            })
+        end
     end
 
     local nextPosition = decision.NextPosition
@@ -11017,7 +13298,7 @@ function MonsterService:_runLogicStep(dt)
         elseif self.MonsterRoot and self.MonsterRoot:IsA('BasePart') then
             currentRotation = self.MonsterRoot.CFrame.Rotation
         end
-        local facingCFrame = if travelOffset.Magnitude > 0
+        local facingCFrame = if travelOffset.Magnitude &gt; 0
             then CFrame.lookAt(nextPosition, nextPosition + travelOffset.Unit)
             else currentRotation + nextPosition
         self.PendingVisualCFrame = facingCFrame
@@ -11038,25 +13319,25 @@ function MonsterService:update(dt)
         return
     end
 
-    local elapsed = if type(dt) == 'number' and dt > 0 then dt else 0
+    local elapsed = if type(dt) == 'number' and dt &gt; 0 then dt else 0
     self:_stepPendingAttack(elapsed)
     self.LogicAccumulator += elapsed
 
     local maxSteps = self.MaxLogicStepsPerUpdate
-    if type(maxSteps) ~= 'number' or maxSteps < 1 then
+    if type(maxSteps) ~= 'number' or maxSteps &lt; 1 then
         maxSteps = DEFAULT_MAX_LOGIC_STEPS_PER_UPDATE
     end
     maxSteps = math.max(1, math.floor(maxSteps))
 
     local executed = 0
-    while self.LogicAccumulator >= self.LogicTickSeconds and executed < maxSteps do
+    while self.LogicAccumulator &gt;= self.LogicTickSeconds and executed &lt; maxSteps do
         self.LogicAccumulator -= self.LogicTickSeconds
         self.LogicTickCount += 1
         executed += 1
         self:_runLogicStep(self.LogicTickSeconds)
     end
 
-    if self.LogicAccumulator >= self.LogicTickSeconds then
+    if self.LogicAccumulator &gt;= self.LogicTickSeconds then
         local droppedTime = self.LogicAccumulator - (self.LogicAccumulator % self.LogicTickSeconds)
         self.LogicAccumulator = self.LogicAccumulator % self.LogicTickSeconds
         self:_recordDecisionEvent('TickDrop', {
@@ -11073,13 +13354,13 @@ function MonsterService:update(dt)
 end
 
 return MonsterService
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="84">
+          <Item class="ModuleScript" referent="133">
             <Properties>
               <string name="Name">PlayerService</string>
-              <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
@@ -11147,6 +13428,16 @@ function PlayerService:applyDamage(player, damageKind)
     return health:applyDamage(p.Blackboard, damageKind)
 end
 
+function PlayerService:healHealthPips(player, amount)
+    local p = self:get(player)
+    if not p then
+        return false, 'MissingPlayer'
+    end
+
+    local health = p.Components.Health
+    return health:healPips(p.Blackboard, amount)
+end
+
 function PlayerService:setSprinting(player, isSprinting)
     local p = self:get(player)
     if not p then
@@ -11157,78 +13448,59 @@ function PlayerService:setSprinting(player, isSprinting)
     return stamina:setSprinting(p.Blackboard, isSprinting)
 end
 
-function PlayerService:addItem(player, itemDef)
-    local p = self:get(player)
-    if not p then
-        return false, 'MissingPlayer'
-    end
-
-    local inventory = p.Components.Inventory
-    return inventory:addItem(p.Blackboard, itemDef)
-end
-
-function PlayerService:equipSlot(player, slotIndex)
-    local p = self:get(player)
-    if not p then
-        return false, 'MissingPlayer'
-    end
-
-    local inventory = p.Components.Inventory
-    return inventory:equipSlot(p.Blackboard, slotIndex)
-end
-
-function PlayerService:unequip(player)
-    local p = self:get(player)
-    if not p then
-        return false, 'MissingPlayer'
-    end
-
-    local inventory = p.Components.Inventory
-    return inventory:unequip(p.Blackboard)
-end
-
-function PlayerService:useItem(player)
-    local p = self:get(player)
-    if not p then
-        return false, 'MissingPlayer'
-    end
-
-    local inventory = p.Components.Inventory
-    return inventory:useItem(p.Blackboard)
-end
-
 function PlayerService:getSummary(player)
     local p = self:get(player)
     if not p then
         return nil
     end
 
+    local health = p.Components.Health
+    local stamina = p.Components.Stamina
+    local activeEffects = {}
+    if type(p.Blackboard) == 'table' and type(p.Blackboard.ActiveEffects) == 'table' then
+        for effectId, effectState in pairs(p.Blackboard.ActiveEffects) do
+            if effectState then
+                activeEffects[effectId] = effectState
+            end
+        end
+    end
+
     return {
         UserId = player.UserId,
         Health = {
-            CurrentHealthPips = p.Components.Health.CurrentHealthPips,
-            MaxHealthPips = p.Components.Health.MaxHealthPips,
-            IsDead = p.Components.Health.IsDead,
-            CorpseActive = p.Components.Health.CorpseActive,
+            CurrentHealthPips = health.CurrentHealthPips,
+            MaxHealthPips = health.MaxHealthPips,
+            IsDead = health.IsDead,
+            CorpseActive = health.CorpseActive,
         },
         Stamina = {
-            CurrentStamina = p.Components.Stamina.CurrentStamina,
-            MaxStamina = p.Components.Stamina.MaxStamina,
-            CanSprint = p.Components.Stamina.CanSprint,
-            IsSprinting = p.Components.Stamina.IsSprinting,
+            CurrentStamina = stamina.CurrentStamina,
+            MaxStamina = stamina.MaxStamina,
+            CanSprint = stamina.CanSprint,
+            IsSprinting = stamina.IsSprinting,
         },
         State = p.StateMachine:getState(),
-        Slots = p.Components.Inventory.Slots,
-        EquippedSlot = p.Components.Inventory.EquippedSlot,
+        SlotCount = p.Components.Inventory.SlotCount,
+        InteractionRange = p.Components.Inventory.InteractionRange,
+        -- Backward compatibility: movement/control services still expect the flat player-state shape.
+        CurrentHealthPips = health.CurrentHealthPips,
+        MaxHealthPips = health.MaxHealthPips,
+        CurrentStamina = stamina.CurrentStamina,
+        MaxStamina = stamina.MaxStamina,
+        IsDead = health.IsDead,
+        CanSprint = stamina.CanSprint,
+        CorpseActive = health.CorpseActive,
+        ActiveEffects = activeEffects,
         -- Backward compatibility: mirrors PlayerStateService:getSummary format
         PlayerState = {
-            HealthPips = p.Components.Health.CurrentHealthPips,
-            MaxHealthPips = p.Components.Health.MaxHealthPips,
-            CurrentStamina = p.Components.Stamina.CurrentStamina,
-            MaxStamina = p.Components.Stamina.MaxStamina,
-            IsDead = p.Components.Health.IsDead,
-            CanSprint = p.Components.Stamina.CanSprint,
-            CorpseActive = p.Components.Health.CorpseActive,
+            HealthPips = health.CurrentHealthPips,
+            MaxHealthPips = health.MaxHealthPips,
+            CurrentStamina = stamina.CurrentStamina,
+            MaxStamina = stamina.MaxStamina,
+            IsDead = health.IsDead,
+            CanSprint = stamina.CanSprint,
+            CorpseActive = health.CorpseActive,
+            ActiveEffects = activeEffects,
         },
     }
 end
@@ -11250,13 +13522,13 @@ function PlayerService:reset()
 end
 
 return PlayerService
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="85">
+          <Item class="ModuleScript" referent="134">
             <Properties>
               <string name="Name">PlayerStateService</string>
-              <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Gameplay = require(Packages:WaitForChild('Gameplay'))
@@ -11310,6 +13582,24 @@ function PlayerStateService:applyDamage(player, damageKind)
     return state:applyDamage(damageKind)
 end
 
+function PlayerStateService:applyEffect(player, effectId, durationSeconds)
+    local state = self:get(player)
+    if not state then
+        return
+    end
+
+    state:applyEffect(effectId, durationSeconds)
+end
+
+function PlayerStateService:hasEffect(player, effectId)
+    local state = self:get(player)
+    if not state then
+        return false
+    end
+
+    return state:hasEffect(effectId)
+end
+
 function PlayerStateService:setSprinting(player, isSprinting)
     local state = self:get(player)
     if not state then
@@ -11330,13 +13620,731 @@ function PlayerStateService:reset()
 end
 
 return PlayerStateService
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="86">
+          <Item class="ModuleScript" referent="135">
+            <Properties>
+              <string name="Name">RoundSignalBus</string>
+              <string name="Source">local MessagingService = game:GetService('MessagingService')
+
+local RoundSignalBus = {}
+RoundSignalBus.__index = RoundSignalBus
+
+RoundSignalBus.MessageKind = table.freeze({
+    RoundClosure = 'RoundClosure',
+    MazePresence = 'MazePresence',
+})
+
+local DEFAULT_TOPIC_PREFIX = 'roblox-experience-round-v1'
+
+local function resolveScopeKey(session)
+    if type(session) ~= 'table' then
+        return nil
+    end
+
+    if type(session.SignalScope) == 'string' and session.SignalScope ~= '' then
+        return session.SignalScope
+    end
+
+    if type(session.SessionId) == 'string' and session.SessionId ~= '' then
+        return session.SessionId
+    end
+
+    return nil
+end
+
+function RoundSignalBus.new(options)
+    local resolved = options or {}
+
+    return setmetatable({
+        MessagingService = resolved.MessagingService or MessagingService,
+        TopicPrefix = resolved.TopicPrefix or DEFAULT_TOPIC_PREFIX,
+        Warn = resolved.Warn or warn,
+    }, RoundSignalBus)
+end
+
+function RoundSignalBus:_resolveTopic(session)
+    local scopeKey = resolveScopeKey(session)
+    if scopeKey == nil then
+        return nil
+    end
+
+    return string.format('%s:%s', self.TopicPrefix, scopeKey)
+end
+
+function RoundSignalBus:publish(session, payload)
+    local topic = self:_resolveTopic(session)
+    if topic == nil or type(payload) ~= 'table' then
+        return false, 'MissingSignalScope'
+    end
+
+    local ok, result = pcall(function()
+        self.MessagingService:PublishAsync(topic, payload)
+    end)
+
+    if not ok then
+        self.Warn(string.format('[RoundSignalBus] publish failed: %s', tostring(result)))
+        return false, tostring(result)
+    end
+
+    return true
+end
+
+function RoundSignalBus:subscribe(session, handler)
+    local topic = self:_resolveTopic(session)
+    if topic == nil or type(handler) ~= 'function' then
+        return nil, false, 'MissingSignalScope'
+    end
+
+    local ok, result = pcall(function()
+        return self.MessagingService:SubscribeAsync(topic, function(message)
+            local data = message and message.Data
+            if type(data) == 'table' then
+                handler(data)
+            end
+        end)
+    end)
+
+    if not ok then
+        self.Warn(string.format('[RoundSignalBus] subscribe failed: %s', tostring(result)))
+        return nil, false, tostring(result)
+    end
+
+    return result, true
+end
+
+return RoundSignalBus
+</string>
+            </Properties>
+          </Item>
+          <Item class="ModuleScript" referent="136">
+            <Properties>
+              <string name="Name">TODProfile</string>
+              <string name="Source">local TODProfile = {}
+
+TODProfile.LightingPropertyNames = table.freeze({
+    'Brightness',
+    'ClockTime',
+    'ExposureCompensation',
+    'ShadowSoftness',
+    'Ambient',
+    'OutdoorAmbient',
+    'EnvironmentDiffuseScale',
+    'EnvironmentSpecularScale',
+})
+
+TODProfile.AtmospherePropertyNames = table.freeze({
+    'Color',
+    'Decay',
+    'Density',
+    'Glare',
+    'Haze',
+    'Offset',
+})
+
+TODProfile.ColorGradingPropertyNames = table.freeze({
+    'Brightness',
+    'Contrast',
+    'Saturation',
+    'TintColor',
+})
+
+TODProfile.Keyframes = table.freeze({
+    {
+        Hour = 7,
+        Lighting = table.freeze({
+            Brightness = 1.9,
+            ClockTime = 7,
+            ExposureCompensation = -0.15,
+            ShadowSoftness = 0.2,
+            Ambient = Color3.fromRGB(70, 72, 76),
+            OutdoorAmbient = Color3.fromRGB(90, 94, 100),
+            EnvironmentDiffuseScale = 0.45,
+            EnvironmentSpecularScale = 0.25,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(199, 171, 140),
+            Decay = Color3.fromRGB(111, 94, 80),
+            Density = 0.28,
+            Glare = 0.05,
+            Haze = 1.8,
+            Offset = -0.15,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = -0.02,
+            Contrast = 0.06,
+            Saturation = -0.08,
+            TintColor = Color3.fromRGB(255, 232, 214),
+        }),
+    },
+    {
+        Hour = 10,
+        Lighting = table.freeze({
+            Brightness = 2.05,
+            ClockTime = 10,
+            ExposureCompensation = -0.02,
+            ShadowSoftness = 0.24,
+            Ambient = Color3.fromRGB(94, 98, 106),
+            OutdoorAmbient = Color3.fromRGB(124, 132, 142),
+            EnvironmentDiffuseScale = 0.5,
+            EnvironmentSpecularScale = 0.3,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(182, 196, 216),
+            Decay = Color3.fromRGB(116, 130, 154),
+            Density = 0.22,
+            Glare = 0.08,
+            Haze = 1.1,
+            Offset = -0.08,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = 0.01,
+            Contrast = 0.1,
+            Saturation = -0.02,
+            TintColor = Color3.fromRGB(238, 244, 255),
+        }),
+    },
+    {
+        Hour = 13,
+        Lighting = table.freeze({
+            Brightness = 2.2,
+            ClockTime = 13,
+            ExposureCompensation = 0.08,
+            ShadowSoftness = 0.28,
+            Ambient = Color3.fromRGB(110, 116, 128),
+            OutdoorAmbient = Color3.fromRGB(148, 160, 174),
+            EnvironmentDiffuseScale = 0.58,
+            EnvironmentSpecularScale = 0.34,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(166, 198, 235),
+            Decay = Color3.fromRGB(127, 155, 191),
+            Density = 0.18,
+            Glare = 0.12,
+            Haze = 0.65,
+            Offset = -0.04,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = 0.03,
+            Contrast = 0.14,
+            Saturation = 0.02,
+            TintColor = Color3.fromRGB(255, 255, 255),
+        }),
+    },
+    {
+        Hour = 16,
+        Lighting = table.freeze({
+            Brightness = 2.08,
+            ClockTime = 16,
+            ExposureCompensation = 0.02,
+            ShadowSoftness = 0.3,
+            Ambient = Color3.fromRGB(102, 100, 108),
+            OutdoorAmbient = Color3.fromRGB(142, 136, 146),
+            EnvironmentDiffuseScale = 0.55,
+            EnvironmentSpecularScale = 0.31,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(214, 189, 156),
+            Decay = Color3.fromRGB(164, 128, 102),
+            Density = 0.21,
+            Glare = 0.09,
+            Haze = 0.95,
+            Offset = -0.08,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = 0.01,
+            Contrast = 0.12,
+            Saturation = -0.02,
+            TintColor = Color3.fromRGB(255, 238, 214),
+        }),
+    },
+    {
+        Hour = 19,
+        Lighting = table.freeze({
+            Brightness = 1.72,
+            ClockTime = 19,
+            ExposureCompensation = -0.22,
+            ShadowSoftness = 0.34,
+            Ambient = Color3.fromRGB(74, 64, 82),
+            OutdoorAmbient = Color3.fromRGB(104, 92, 118),
+            EnvironmentDiffuseScale = 0.42,
+            EnvironmentSpecularScale = 0.24,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(170, 125, 134),
+            Decay = Color3.fromRGB(84, 62, 97),
+            Density = 0.28,
+            Glare = 0.04,
+            Haze = 1.45,
+            Offset = -0.16,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = -0.03,
+            Contrast = 0.16,
+            Saturation = -0.08,
+            TintColor = Color3.fromRGB(238, 214, 255),
+        }),
+    },
+    {
+        Hour = 22,
+        Lighting = table.freeze({
+            Brightness = 1.34,
+            ClockTime = 22,
+            ExposureCompensation = -0.45,
+            ShadowSoftness = 0.38,
+            Ambient = Color3.fromRGB(36, 38, 56),
+            OutdoorAmbient = Color3.fromRGB(54, 58, 86),
+            EnvironmentDiffuseScale = 0.26,
+            EnvironmentSpecularScale = 0.18,
+        }),
+        Atmosphere = table.freeze({
+            Color = Color3.fromRGB(88, 100, 136),
+            Decay = Color3.fromRGB(24, 28, 42),
+            Density = 0.34,
+            Glare = 0.02,
+            Haze = 2.1,
+            Offset = -0.22,
+        }),
+        ColorGrading = table.freeze({
+            Brightness = -0.08,
+            Contrast = 0.18,
+            Saturation = -0.14,
+            TintColor = Color3.fromRGB(208, 220, 255),
+        }),
+    },
+})
+
+local function lerpValue(leftValue, rightValue, alpha)
+    local leftType = typeof(leftValue)
+    if leftType == 'Color3' then
+        return leftValue:Lerp(rightValue, alpha)
+    end
+
+    if leftType == 'number' then
+        return leftValue + ((rightValue - leftValue) * alpha)
+    end
+
+    if alpha &gt;= 1 then
+        return rightValue
+    end
+
+    return leftValue
+end
+
+local function interpolateTable(leftTable, rightTable, alpha)
+    local resolved = {}
+
+    for propertyName, leftValue in pairs(leftTable) do
+        resolved[propertyName] = lerpValue(leftValue, rightTable[propertyName], alpha)
+    end
+
+    return resolved
+end
+
+function TODProfile.getDurationSeconds(config)
+    return math.max(0, math.floor((config.RoundMinutes or 0) * 60 + 0.5))
+end
+
+function TODProfile.evaluate(config, elapsedRoundSeconds)
+    local startHour = config.StartHour or 7
+    local endHour = config.EndHour or 22
+    local durationSeconds = TODProfile.getDurationSeconds(config)
+    local clampedElapsed = math.clamp(elapsedRoundSeconds or 0, 0, durationSeconds)
+    local progress = if durationSeconds &lt;= 0 then 1 else clampedElapsed / durationSeconds
+    local currentHour = startHour + ((endHour - startHour) * progress)
+
+    local leftKeyframe = TODProfile.Keyframes[1]
+    local rightKeyframe = TODProfile.Keyframes[#TODProfile.Keyframes]
+
+    for keyframeIndex = 1, #TODProfile.Keyframes - 1 do
+        local candidateLeft = TODProfile.Keyframes[keyframeIndex]
+        local candidateRight = TODProfile.Keyframes[keyframeIndex + 1]
+
+        if currentHour &lt;= candidateRight.Hour then
+            leftKeyframe = candidateLeft
+            rightKeyframe = candidateRight
+            break
+        end
+    end
+
+    local frameSpan = math.max(rightKeyframe.Hour - leftKeyframe.Hour, 0.0001)
+    local frameAlpha = math.clamp((currentHour - leftKeyframe.Hour) / frameSpan, 0, 1)
+    local lighting = interpolateTable(leftKeyframe.Lighting, rightKeyframe.Lighting, frameAlpha)
+    lighting.ClockTime = currentHour
+
+    return {
+        ClockTime = currentHour,
+        ElapsedRoundSeconds = clampedElapsed,
+        RoundTimeRemainingSeconds = math.max(0, durationSeconds - clampedElapsed),
+        Progress = progress,
+        Lighting = lighting,
+        Atmosphere = interpolateTable(
+            leftKeyframe.Atmosphere,
+            rightKeyframe.Atmosphere,
+            frameAlpha
+        ),
+        ColorGrading = interpolateTable(
+            leftKeyframe.ColorGrading,
+            rightKeyframe.ColorGrading,
+            frameAlpha
+        ),
+    }
+end
+
+return TODProfile
+</string>
+            </Properties>
+          </Item>
+          <Item class="ModuleScript" referent="137">
+            <Properties>
+              <string name="Name">TODService</string>
+              <string name="Source">local Lighting = game:GetService('Lighting')
+
+local TODProfile = require(script.Parent.TODProfile)
+
+local TODService = {}
+TODService.__index = TODService
+
+TODService.ManagedNames = table.freeze({
+    Atmosphere = 'RunTODAtmosphere',
+    ColorGrading = 'RunTODColorGrading',
+})
+
+TODService.UpdateIntervalSeconds = 0.5
+
+local function getDisplayClockMinute(clockTime)
+    return math.floor(((clockTime or 0) % 24) * 60 + 0.5)
+end
+
+local function getDisplayRemainingSeconds(remainingSeconds)
+    return math.max(0, math.floor((remainingSeconds or 0) + 0.5))
+end
+
+local function copyProperties(instance, propertyNames)
+    local snapshot = {}
+
+    if instance == nil then
+        return snapshot
+    end
+
+    for _, propertyName in ipairs(propertyNames) do
+        local ok, value = pcall(function()
+            return instance[propertyName]
+        end)
+        if ok then
+            snapshot[propertyName] = value
+        end
+    end
+
+    return snapshot
+end
+
+local function applyProperties(instance, properties)
+    for propertyName, value in pairs(properties) do
+        pcall(function()
+            instance[propertyName] = value
+        end)
+    end
+end
+
+local function destroyIfAlive(instance)
+    if instance and instance.Parent ~= nil then
+        instance:Destroy()
+    end
+end
+
+local function isColorGradingTarget(instance)
+    return instance:IsA('ColorGradingEffect') or instance:IsA('ColorCorrectionEffect')
+end
+
+local function createManagedColorGrading(name)
+    local created, instance = pcall(Instance.new, 'ColorGradingEffect')
+    if created and instance then
+        instance.Name = name
+        return instance
+    end
+
+    instance = Instance.new('ColorCorrectionEffect')
+    instance.Name = name
+    return instance
+end
+
+local function resolveAtmosphereTarget(lightingRoot, managedName)
+    local managed = lightingRoot:FindFirstChild(managedName)
+
+    for _, child in ipairs(lightingRoot:GetChildren()) do
+        if child:IsA('Atmosphere') and child.Name ~= managedName then
+            return child, false
+        end
+    end
+
+    if managed and managed:IsA('Atmosphere') then
+        return managed, false
+    end
+
+    local created = Instance.new('Atmosphere')
+    created.Name = managedName
+    created.Parent = lightingRoot
+    return created, true
+end
+
+local function resolveColorGradingTarget(lightingRoot, managedName)
+    local namedColorGrading = lightingRoot:FindFirstChild('ColorGrading')
+    if namedColorGrading and isColorGradingTarget(namedColorGrading) then
+        return namedColorGrading, false
+    end
+
+    for _, child in ipairs(lightingRoot:GetChildren()) do
+        if child.Name ~= managedName and isColorGradingTarget(child) then
+            return child, false
+        end
+    end
+
+    local managed = lightingRoot:FindFirstChild(managedName)
+    if managed and isColorGradingTarget(managed) then
+        return managed, false
+    end
+
+    local created = createManagedColorGrading(managedName)
+    created.Parent = lightingRoot
+    return created, true
+end
+
+function TODService.new(options)
+    local runtimeOptions = options or {}
+    local self = setmetatable({}, TODService)
+
+    self.Config = runtimeOptions.Config or {}
+    self.Lighting = runtimeOptions.Lighting or Lighting
+    self.Remote = runtimeOptions.Remote
+    self.Clock = runtimeOptions.Clock or os.clock
+    self.Profile = runtimeOptions.Profile or TODProfile
+    self.UpdateIntervalSeconds = runtimeOptions.UpdateIntervalSeconds
+        or TODService.UpdateIntervalSeconds
+    self.ManagedNames = runtimeOptions.ManagedNames or TODService.ManagedNames
+    self.Initialized = false
+    self.Baseline = nil
+    self.Targets = nil
+    self.CurrentState = nil
+    self.IsRunning = false
+    self.StartedAtClock = nil
+    self.LoopThread = nil
+    self.LoopToken = 0
+    self.LastBroadcastSignature = nil
+
+    return self
+end
+
+function TODService:_ensureTargets()
+    if self.Targets ~= nil then
+        return self.Targets
+    end
+
+    local atmosphere, createdAtmosphere =
+        resolveAtmosphereTarget(self.Lighting, self.ManagedNames.Atmosphere)
+    local colorGrading, createdColorGrading =
+        resolveColorGradingTarget(self.Lighting, self.ManagedNames.ColorGrading)
+
+    self.Targets = {
+        Atmosphere = atmosphere,
+        ColorGrading = colorGrading,
+        CreatedAtmosphere = createdAtmosphere,
+        CreatedColorGrading = createdColorGrading,
+    }
+
+    return self.Targets
+end
+
+function TODService:_captureBaseline()
+    if self.Baseline ~= nil then
+        return self.Baseline
+    end
+
+    local targets = self:_ensureTargets()
+    self.Baseline = {
+        Lighting = copyProperties(self.Lighting, self.Profile.LightingPropertyNames),
+        Atmosphere = copyProperties(targets.Atmosphere, self.Profile.AtmospherePropertyNames),
+        ColorGrading = copyProperties(targets.ColorGrading, self.Profile.ColorGradingPropertyNames),
+    }
+
+    return self.Baseline
+end
+
+function TODService:_restoreTargets()
+    if self.Targets == nil or self.Baseline == nil then
+        return
+    end
+
+    local targets = self.Targets
+
+    if targets.CreatedAtmosphere then
+        destroyIfAlive(targets.Atmosphere)
+    else
+        applyProperties(targets.Atmosphere, self.Baseline.Atmosphere)
+    end
+
+    if targets.CreatedColorGrading then
+        destroyIfAlive(targets.ColorGrading)
+    else
+        applyProperties(targets.ColorGrading, self.Baseline.ColorGrading)
+    end
+end
+
+function TODService:_buildPayload(snapshot, isRunning)
+    return {
+        ClockTime = snapshot.ClockTime,
+        RoundTimeRemainingSeconds = snapshot.RoundTimeRemainingSeconds,
+        ElapsedRoundSeconds = snapshot.ElapsedRoundSeconds,
+        IsRunning = isRunning,
+    }
+end
+
+function TODService:_applySnapshot(snapshot)
+    local targets = self:_ensureTargets()
+    applyProperties(self.Lighting, snapshot.Lighting)
+    applyProperties(targets.Atmosphere, snapshot.Atmosphere)
+    applyProperties(targets.ColorGrading, snapshot.ColorGrading)
+end
+
+function TODService:_buildDisplaySignature(payload)
+    return string.format(
+        '%d:%d:%s',
+        getDisplayClockMinute(payload.ClockTime),
+        getDisplayRemainingSeconds(payload.RoundTimeRemainingSeconds),
+        tostring(payload.IsRunning == true)
+    )
+end
+
+function TODService:_emit(payload, forceBroadcast)
+    self.CurrentState = payload
+
+    local shouldBroadcast = forceBroadcast == true
+    local nextSignature = self:_buildDisplaySignature(payload)
+    if not shouldBroadcast then
+        shouldBroadcast = self.LastBroadcastSignature ~= nextSignature
+    end
+
+    if shouldBroadcast and self.Remote and type(self.Remote.FireAllClients) == 'function' then
+        self.Remote:FireAllClients(payload)
+    end
+
+    if shouldBroadcast then
+        self.LastBroadcastSignature = nextSignature
+    end
+end
+
+function TODService:sendToPlayer(player)
+    if self.CurrentState == nil then
+        return
+    end
+
+    if self.Remote and type(self.Remote.FireClient) == 'function' then
+        self.Remote:FireClient(player, self.CurrentState)
+    end
+end
+
+function TODService:prime()
+    self:_captureBaseline()
+
+    local snapshot = self.Profile.evaluate(self.Config, 0)
+    self:_applySnapshot(snapshot)
+
+    local payload = self:_buildPayload(snapshot, false)
+    self:_emit(payload, true)
+    self.Initialized = true
+
+    return payload
+end
+
+function TODService:start()
+    if self.IsRunning then
+        return self.CurrentState
+    end
+
+    if not self.Initialized then
+        self:prime()
+    end
+
+    self.IsRunning = true
+    self.StartedAtClock = self.Clock()
+    self.LoopToken += 1
+
+    local activeLoopToken = self.LoopToken
+    self:step(self.StartedAtClock)
+
+    self.LoopThread = task.spawn(function()
+        while self.IsRunning and self.LoopToken == activeLoopToken do
+            task.wait(self.UpdateIntervalSeconds)
+            self:step(self.Clock())
+        end
+    end)
+
+    return self.CurrentState
+end
+
+function TODService:step(nowSeconds)
+    if not self.Initialized then
+        self:prime()
+    end
+
+    local effectiveNow = nowSeconds or self.Clock()
+    local elapsedSeconds = 0
+    if self.StartedAtClock ~= nil then
+        elapsedSeconds = math.max(0, effectiveNow - self.StartedAtClock)
+    end
+
+    local snapshot = self.Profile.evaluate(self.Config, elapsedSeconds)
+    self:_applySnapshot(snapshot)
+
+    local durationSeconds = self.Profile.getDurationSeconds(self.Config)
+    local isStillRunning = self.IsRunning and elapsedSeconds &lt; durationSeconds
+    local payload = self:_buildPayload(snapshot, isStillRunning)
+    self:_emit(payload)
+
+    if self.IsRunning and not isStillRunning then
+        self.IsRunning = false
+        self.LoopToken += 1
+    end
+
+    return payload
+end
+
+function TODService:stop()
+    self.IsRunning = false
+    self.LoopToken += 1
+    return self.CurrentState
+end
+
+function TODService:restore()
+    self:stop()
+
+    if self.Baseline == nil then
+        return
+    end
+
+    applyProperties(self.Lighting, self.Baseline.Lighting)
+    self:_restoreTargets()
+    self.Targets = nil
+    self.CurrentState = nil
+    self.Initialized = false
+    self.StartedAtClock = nil
+    self.Baseline = nil
+    self.LastBroadcastSignature = nil
+end
+
+function TODService:destroy()
+    self:restore()
+end
+
+return TODService
+</string>
+            </Properties>
+          </Item>
+          <Item class="ModuleScript" referent="138">
             <Properties>
               <string name="Name">TeleportInventoryHydrator</string>
-              <string name="Source"><![CDATA[local TeleportInventoryHydrator = {}
+              <string name="Source">local TeleportInventoryHydrator = {}
 
 function TeleportInventoryHydrator.hydratePlayerInventory(
     inventoryService,
@@ -11354,24 +14362,32 @@ function TeleportInventoryHydrator.hydratePlayerInventory(
 end
 
 return TeleportInventoryHydrator
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="87">
+        <Item class="ModuleScript" referent="139">
           <Properties>
             <string name="Name">Session</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
     CampMazeSessionContract = require(script.CampMazeSessionContract),
     MazeEntryAvailability = require(script.MazeEntryAvailability),
+    SessionPhase = require(script.SessionPhase),
     SessionSeedPolicy = require(script.SessionSeedPolicy),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="88">
+          <Item class="ModuleScript" referent="140">
             <Properties>
               <string name="Name">CampMazeSessionContract</string>
-              <string name="Source"><![CDATA[local CampMazeSessionContract = {}
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local ItemFields = require(Packages:WaitForChild('Gameplay')).Config.ItemFields
+local SessionConfig = require(script.Parent.Parent.Config.SessionConfig)
+
+local CampMazeSessionContract = {}
+local SessionPhase = require(script.Parent.SessionPhase)
 
 local MAZE_STATUS = {
     Idle = 'idle',
@@ -11379,11 +14395,22 @@ local MAZE_STATUS = {
     Completed = 'completed',
 }
 
+local DEFAULT_MAX_ROUNDS = SessionConfig.Mission.RoundCount
+local DEFAULT_TARGET_ITEM_COUNT = SessionConfig.Mission.TargetItemCount
+
+local function cloneShallow(value)
+    if type(value) == 'table' then
+        return table.clone(value)
+    end
+
+    return value
+end
+
 local function cloneArray(list)
     local result = {}
 
     for index, entry in ipairs(list or {}) do
-        result[index] = table.clone(entry)
+        result[index] = cloneShallow(entry)
     end
 
     return result
@@ -11393,32 +14420,44 @@ local function cloneTable(input)
     return table.clone(input or {})
 end
 
-local function cloneLightConfig(lightConfig)
-    if type(lightConfig) ~= 'table' then
-        return nil
-    end
-
-    return {
-        Brightness = lightConfig.Brightness,
-        Range = lightConfig.Range,
-        Color = lightConfig.Color,
-    }
+local function cloneInventoryItem(itemEntry)
+    return ItemFields.copyItemEntry(itemEntry)
 end
 
-local function cloneInventoryItem(itemEntry)
-    if type(itemEntry) ~= 'table' then
-        return nil
+local function summarizeItems(backpackItems, heldItem)
+    local lootCount = 0
+    local clueCount = 0
+    local toolCount = 0
+    local missionCount = 0
+
+    local function addItem(itemEntry)
+        if type(itemEntry) ~= 'table' then
+            return
+        end
+
+        local itemCategory = itemEntry.ItemCategory
+        if itemCategory == 'Clue' then
+            clueCount += 1
+        elseif itemCategory == 'Tool' then
+            toolCount += 1
+        else
+            lootCount += 1
+        end
+
+        if type(itemEntry.MissionCount) == 'number' then
+            missionCount += itemEntry.MissionCount
+        elseif itemCategory == 'Loot' or itemCategory == nil then
+            missionCount += 1
+        end
     end
 
-    return {
-        InstanceId = itemEntry.InstanceId,
-        Id = itemEntry.Id,
-        Name = itemEntry.Name,
-        Weight = itemEntry.Weight,
-        Value = itemEntry.Value,
-        Color = itemEntry.Color,
-        Light = cloneLightConfig(itemEntry.Light),
-    }
+    for _, itemEntry in ipairs(backpackItems) do
+        addItem(itemEntry)
+    end
+
+    addItem(heldItem)
+
+    return lootCount, clueCount, toolCount, missionCount
 end
 
 local function cloneInventorySummary(summary)
@@ -11431,15 +14470,22 @@ local function cloneInventorySummary(summary)
         backpackItems[index] = cloneInventoryItem(itemEntry)
     end
 
+    local heldItem = cloneInventoryItem(summary.HeldItem)
+    local lootCount, clueCount, toolCount, missionCount = summarizeItems(backpackItems, heldItem)
+
     return {
         Capacity = summary.Capacity or 0,
         Weight = summary.Weight or 0,
-        Count = summary.Count or 0,
+        Count = summary.Count or (#backpackItems + (if heldItem then 1 else 0)),
         BackpackCount = summary.BackpackCount or #backpackItems,
-        HeldCount = summary.HeldCount or (summary.HeldItem and 1 or 0),
+        HeldCount = summary.HeldCount or (if heldItem then 1 else 0),
         Value = summary.Value or 0,
         BackpackItems = backpackItems,
-        HeldItem = cloneInventoryItem(summary.HeldItem),
+        HeldItem = heldItem,
+        LootCount = summary.LootCount or lootCount,
+        ClueCount = summary.ClueCount or clueCount,
+        ToolCount = summary.ToolCount or toolCount,
+        MissionCount = summary.MissionCount or missionCount,
     }
 end
 
@@ -11456,79 +14502,114 @@ local function clonePlayerInventories(playerInventories)
     end
 
     table.sort(cloned, function(left, right)
-        return left.UserId < right.UserId
+        return left.UserId &lt; right.UserId
     end)
 
     return cloned
 end
 
-local function cloneUgcRuntimeProfile(runtimeProfile)
-    if type(runtimeProfile) ~= 'table' then
-        return nil
+local function clonePosition(position)
+    if typeof(position) == 'Vector3' then
+        return {
+            X = position.X,
+            Y = position.Y,
+            Z = position.Z,
+        }
     end
 
+    if type(position) == 'table' then
+        return {
+            X = position.X or position[1] or 0,
+            Y = position.Y or position[2] or 0,
+            Z = position.Z or position[3] or 0,
+        }
+    end
+
+    return nil
+end
+
+local function cloneDropNodes(dropNodes)
+    local cloned = {}
+
+    for index, dropNode in ipairs(dropNodes or {}) do
+        if type(dropNode) == 'table' then
+            local entries = {}
+            for entryIndex, itemEntry in ipairs(dropNode.Entries or {}) do
+                entries[entryIndex] = cloneInventoryItem(itemEntry)
+            end
+
+            cloned[index] = {
+                DropNodeId = dropNode.DropNodeId,
+                Label = dropNode.Label,
+                Position = clonePosition(dropNode.Position),
+                Entries = entries,
+            }
+        end
+    end
+
+    return cloned
+end
+
+local function clonePersistentWorldState(persistentWorldState)
+    local state = persistentWorldState or {}
+
     return {
-        Id = runtimeProfile.Id,
-        Name = runtimeProfile.Name,
-        Presentation = type(runtimeProfile.Presentation) == 'table' and table.clone(
-            runtimeProfile.Presentation
-        ) or nil,
-        Speed = runtimeProfile.Speed,
-        SightRange = runtimeProfile.SightRange,
-        PatrolSpeedMultiplier = runtimeProfile.PatrolSpeedMultiplier,
-        SpawnOffset = runtimeProfile.SpawnOffset,
-        Behaviors = type(runtimeProfile.Behaviors) == 'table' and table.clone(
-            runtimeProfile.Behaviors
-        ) or {},
-        Effects = cloneArray(runtimeProfile.Effects),
+        CollectedLootRoomIds = cloneArray(state.CollectedLootRoomIds),
+        DropNodes = cloneDropNodes(state.DropNodes),
     }
 end
 
-local function cloneUgcDiagnostics(diagnostics)
-    if type(diagnostics) ~= 'table' then
+local function cloneReturnedSummary(summary)
+    if type(summary) ~= 'table' then
         return nil
     end
 
     return {
-        SkippedBehaviorIds = cloneArray(diagnostics.SkippedBehaviorIds),
-        SkippedEffectIds = cloneArray(diagnostics.SkippedEffectIds),
-        ClampedFields = cloneArray(diagnostics.ClampedFields),
+        UserId = summary.UserId,
+        Name = summary.Name,
+        ReturnReason = summary.ReturnReason,
+        Value = summary.Value or 0,
+        ItemCount = summary.ItemCount or 0,
+        Weight = summary.Weight or 0,
+        WasSettled = summary.WasSettled == true,
+        CountedInSettlement = summary.CountedInSettlement ~= false,
+        LootItemCount = summary.LootItemCount or summary.MissionCount or summary.ItemCount or 0,
+        ClueCount = summary.ClueCount or 0,
+        ToolCount = summary.ToolCount or 0,
+        MissionCount = summary.MissionCount or summary.LootItemCount or summary.ItemCount or 0,
     }
 end
 
-local function clonePendingUgcMonsterPayload(payload)
-    if type(payload) ~= 'table' then
-        return nil
+local function cloneReturnedSummaries(summaries)
+    local cloned = {}
+
+    for _, summary in ipairs(summaries or {}) do
+        local clonedSummary = cloneReturnedSummary(summary)
+        if clonedSummary ~= nil then
+            table.insert(cloned, clonedSummary)
+        end
     end
 
-    return {
-        OwnerUserId = payload.OwnerUserId,
-        MonsterId = payload.MonsterId,
-        MonsterName = payload.MonsterName,
-        Seed = payload.Seed,
-        RecipeHash = payload.RecipeHash,
-        RuntimeProfile = cloneUgcRuntimeProfile(payload.RuntimeProfile),
-        Diagnostics = cloneUgcDiagnostics(payload.Diagnostics),
-    }
+    return cloned
 end
 
 local function sortPlayers(players)
     table.sort(players, function(left, right)
         if left.UserId == right.UserId then
-            return (left.Name or '') < (right.Name or '')
+            return (left.Name or '') &lt; (right.Name or '')
         end
 
-        return left.UserId < right.UserId
+        return left.UserId &lt; right.UserId
     end)
 end
 
 local function sortSummaries(summaries)
     table.sort(summaries, function(left, right)
         if left.UserId == right.UserId then
-            return (left.ReturnReason or '') < (right.ReturnReason or '')
+            return (left.ReturnReason or '') &lt; (right.ReturnReason or '')
         end
 
-        return left.UserId < right.UserId
+        return left.UserId &lt; right.UserId
     end)
 end
 
@@ -11544,7 +14625,7 @@ local function updateMazeStatus(nextSession)
         return
     end
 
-    if nextSession.MazeAccessCode then
+    if nextSession.MazeAccessCode or #nextSession.PlayersInMaze &gt; 0 then
         nextSession.MazeStatus = MAZE_STATUS.Active
         return
     end
@@ -11556,15 +14637,37 @@ function CampMazeSessionContract.normalizeCampSession(session)
     local normalized = {
         SessionId = session and session.SessionId or 'local-debug-camp',
         CampAccessCode = session and session.CampAccessCode or 'local-debug-camp',
+        SignalScope = session and session.SignalScope or nil,
+        HostUserId = session and session.HostUserId or nil,
         GateOpen = session ~= nil and session.GateOpen == true or false,
+        RoundStarted = session ~= nil and session.RoundStarted == true or false,
+        DangerActive = session ~= nil and session.DangerActive == true or false,
+        RoundStartTime = session and session.RoundStartTime or nil,
+        RoundEndTime = session and session.RoundEndTime or nil,
+        SettlementReason = session and session.SettlementReason or nil,
+        SettlementTriggeredByUserId = session and session.SettlementTriggeredByUserId or nil,
+        SettlementTriggeredByName = session and session.SettlementTriggeredByName or nil,
         MazeStatus = session and session.MazeStatus or MAZE_STATUS.Idle,
         MazeAccessCode = session and session.MazeAccessCode or nil,
         PlayersInMaze = cloneArray(session and session.PlayersInMaze or {}),
-        ReturnedPlayerSummaries = cloneArray(session and session.ReturnedPlayerSummaries or {}),
+        ReturnedPlayerSummaries = cloneReturnedSummaries(
+            session and session.ReturnedPlayerSummaries or {}
+        ),
+        SessionClosed = session ~= nil and session.SessionClosed == true or false,
+        CurrentRound = session and session.CurrentRound or 1,
+        MaxRounds = session and session.MaxRounds or DEFAULT_MAX_ROUNDS,
+        BankedItemCount = session and session.BankedItemCount or 0,
+        TargetItemCount = session and session.TargetItemCount or DEFAULT_TARGET_ITEM_COUNT,
+        RoundOutcome = session and session.RoundOutcome or nil,
+        SessionOutcome = session and session.SessionOutcome or nil,
+        PersistentWorldState = clonePersistentWorldState(
+            session and session.PersistentWorldState or nil
+        ),
     }
 
     sortPlayers(normalized.PlayersInMaze)
     sortSummaries(normalized.ReturnedPlayerSummaries)
+    normalized.SessionPhase = SessionPhase.resolveFromCampSession(normalized)
 
     return normalized
 end
@@ -11618,9 +14721,54 @@ function CampMazeSessionContract.buildReturnSummary(params)
         Value = params.Value or 0,
         ItemCount = params.ItemCount or 0,
         Weight = params.Weight or 0,
-        WasExtracted = params.WasExtracted == true,
         WasSettled = params.WasSettled == true,
+        CountedInSettlement = params.CountedInSettlement ~= false,
+        LootItemCount = params.LootItemCount or params.MissionCount or params.ItemCount or 0,
+        ClueCount = params.ClueCount or 0,
+        ToolCount = params.ToolCount or 0,
+        MissionCount = params.MissionCount or params.LootItemCount or params.ItemCount or 0,
     }
+end
+
+function CampMazeSessionContract.assignHost(session, hostUserId)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    nextSession.HostUserId = if type(hostUserId) == 'number' then hostUserId else nil
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
+end
+
+function CampMazeSessionContract.markRoundStarted(session, params)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    local resolved = params or {}
+
+    nextSession.HostUserId = resolved.HostUserId or nextSession.HostUserId
+    nextSession.GateOpen = true
+    nextSession.RoundStarted = true
+    nextSession.DangerActive = resolved.DangerActive ~= false
+    nextSession.RoundStartTime = resolved.RoundStartTime
+    nextSession.RoundEndTime = resolved.RoundEndTime
+    nextSession.SettlementReason = nil
+    nextSession.SettlementTriggeredByUserId = nil
+    nextSession.SettlementTriggeredByName = nil
+    nextSession.RoundOutcome = nil
+    nextSession.SessionClosed = false
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
+end
+
+function CampMazeSessionContract.markSettlementTriggered(session, params)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    local resolved = params or {}
+
+    nextSession.GateOpen = false
+    nextSession.RoundStarted = false
+    nextSession.DangerActive = false
+    nextSession.SettlementReason = resolved.SettlementReason or 'settlement'
+    nextSession.SettlementTriggeredByUserId = resolved.TriggeredByUserId
+    nextSession.SettlementTriggeredByName = resolved.TriggeredByName
+    nextSession.RoundOutcome = resolved.RoundOutcome or nextSession.RoundOutcome
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
 end
 
 function CampMazeSessionContract.markPlayerEntered(session, player)
@@ -11650,6 +14798,7 @@ function CampMazeSessionContract.markPlayerEntered(session, player)
     nextSession.ReturnedPlayerSummaries = nextSummaries
 
     nextSession.MazeStatus = MAZE_STATUS.Active
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
 
     return nextSession
 end
@@ -11679,6 +14828,7 @@ function CampMazeSessionContract.prunePlayer(session, userId, options)
     sortSummaries(nextSummaries)
     nextSession.ReturnedPlayerSummaries = nextSummaries
     updateMazeStatus(nextSession)
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
 
     return nextSession
 end
@@ -11702,7 +14852,7 @@ function CampMazeSessionContract.applyReturn(session, summary, mazeCompleted)
         end
     end
 
-    table.insert(nextSummaries, table.clone(summary))
+    table.insert(nextSummaries, cloneReturnedSummary(summary))
     sortPlayers(nextPlayers)
     sortSummaries(nextSummaries)
     nextSession.ReturnedPlayerSummaries = nextSummaries
@@ -11714,6 +14864,64 @@ function CampMazeSessionContract.applyReturn(session, summary, mazeCompleted)
         updateMazeStatus(nextSession)
     end
 
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+
+    return nextSession
+end
+
+function CampMazeSessionContract.recordBankedItems(session, itemCount)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    local count = math.max(0, math.floor(tonumber(itemCount) or 0))
+    nextSession.BankedItemCount += count
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
+end
+
+function CampMazeSessionContract.setPersistentWorldState(session, persistentWorldState)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    nextSession.PersistentWorldState = clonePersistentWorldState(persistentWorldState)
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
+end
+
+function CampMazeSessionContract.markRoundOutcome(session, roundOutcome)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    nextSession.RoundOutcome = roundOutcome
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
+end
+
+function CampMazeSessionContract.markSessionOutcome(session, sessionOutcome)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    nextSession.SessionOutcome = sessionOutcome
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+    return nextSession
+end
+
+function CampMazeSessionContract.resetForNextRound(session)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+
+    nextSession.GateOpen = false
+    nextSession.RoundStarted = false
+    nextSession.DangerActive = false
+    nextSession.RoundStartTime = nil
+    nextSession.RoundEndTime = nil
+    nextSession.SettlementReason = nil
+    nextSession.SettlementTriggeredByUserId = nil
+    nextSession.SettlementTriggeredByName = nil
+    nextSession.MazeStatus = MAZE_STATUS.Idle
+    nextSession.MazeAccessCode = nil
+    nextSession.PlayersInMaze = {}
+    nextSession.ReturnedPlayerSummaries = {}
+    nextSession.RoundOutcome = nil
+    nextSession.SessionClosed = false
+
+    if nextSession.SessionOutcome == nil then
+        nextSession.CurrentRound = math.min(nextSession.CurrentRound + 1, nextSession.MaxRounds)
+    end
+
+    nextSession.SessionPhase = SessionPhase.resolveFromCampSession(nextSession)
+
     return nextSession
 end
 
@@ -11723,11 +14931,19 @@ function CampMazeSessionContract.buildLobbyToRunTeleportData(params)
         CampSession = CampMazeSessionContract.newCampSession({
             SessionId = params.SessionId,
             CampAccessCode = params.CampAccessCode,
+            SignalScope = params.SignalScope,
             GateOpen = false,
+            RoundStarted = false,
+            DangerActive = false,
             MazeStatus = MAZE_STATUS.Idle,
             MazeAccessCode = nil,
             PlayersInMaze = {},
             ReturnedPlayerSummaries = {},
+            CurrentRound = params.CurrentRound or 1,
+            MaxRounds = params.MaxRounds or DEFAULT_MAX_ROUNDS,
+            BankedItemCount = params.BankedItemCount or 0,
+            TargetItemCount = params.TargetItemCount or DEFAULT_TARGET_ITEM_COUNT,
+            PersistentWorldState = params.PersistentWorldState,
         }),
         Entry = {
             Kind = 'LobbyLaunch',
@@ -11738,6 +14954,13 @@ end
 
 function CampMazeSessionContract.buildLobbyToCampTeleportData(params)
     return CampMazeSessionContract.buildLobbyToRunTeleportData(params)
+end
+
+function CampMazeSessionContract.closeCampSession(session)
+    local nextSession = CampMazeSessionContract.normalizeCampSession(session)
+    nextSession.SessionClosed = true
+    nextSession.SessionPhase = SessionPhase.SessionClosed
+    return nextSession
 end
 
 function CampMazeSessionContract.buildRunToMazeTeleportData(params)
@@ -11761,9 +14984,6 @@ function CampMazeSessionContract.buildRunToMazeTeleportData(params)
             MazeAccessCode = params.CampSession.MazeAccessCode,
             EntryReason = params.EntryReason or 'camp_gate',
             EnteringPlayer = table.clone(params.EnteringPlayer),
-            PendingUgcMonsterPayload = clonePendingUgcMonsterPayload(
-                params.PendingUgcMonsterPayload
-            ),
         },
         PlayerInventories = clonePlayerInventories(playerInventories),
     }
@@ -11779,7 +14999,7 @@ function CampMazeSessionContract.buildMazeToRunTeleportData(params)
         CampSession = CampMazeSessionContract.normalizeCampSession(params.CampSession),
         MazeReturn = {
             MazeCompleted = params.MazeCompleted == true,
-            Summaries = cloneArray(params.Summaries),
+            Summaries = cloneReturnedSummaries(params.Summaries),
         },
         PlayerInventories = clonePlayerInventories(params.PlayerInventories),
     }
@@ -11797,7 +15017,7 @@ function CampMazeSessionContract.findReturnSummary(teleportData, userId)
 
     for _, summary in ipairs(mazeReturn.Summaries or {}) do
         if summary.UserId == userId then
-            return summary
+            return cloneReturnedSummary(summary)
         end
     end
 
@@ -11819,25 +15039,17 @@ function CampMazeSessionContract.findPlayerInventory(teleportData, userId)
     return nil
 end
 
-function CampMazeSessionContract.findPendingUgcMonsterPayload(teleportData)
-    local mazeSession = teleportData and teleportData.MazeSession
-    if type(mazeSession) ~= 'table' then
-        return nil
-    end
-
-    return clonePendingUgcMonsterPayload(mazeSession.PendingUgcMonsterPayload)
-end
-
 CampMazeSessionContract.MazeStatus = MAZE_STATUS
+CampMazeSessionContract.SessionPhase = SessionPhase
 
 return CampMazeSessionContract
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="89">
+          <Item class="ModuleScript" referent="141">
             <Properties>
               <string name="Name">MazeEntryAvailability</string>
-              <string name="Source"><![CDATA[local MazeEntryAvailability = {}
+              <string name="Source">local MazeEntryAvailability = {}
 
 MazeEntryAvailability.Mode = {
     Teleport = 'Teleport',
@@ -11856,7 +15068,7 @@ function MazeEntryAvailability.evaluate(params)
     local isStudio = params.IsStudio == true
     local placeId = type(params.PlaceId) == 'number' and params.PlaceId or 0
     local gameId = type(params.GameId) == 'number' and params.GameId or 0
-    if isStudio and (placeId <= 0 or gameId <= 0) then
+    if isStudio and (placeId &lt;= 0 or gameId &lt;= 0) then
         return {
             Mode = MazeEntryAvailability.Mode.Blocked,
             ReasonCode = MazeEntryAvailability.ReasonCode.StudioLocalFileTeleportBlocked,
@@ -11864,7 +15076,7 @@ function MazeEntryAvailability.evaluate(params)
         }
     end
 
-    if mazePlaceId <= 0 then
+    if mazePlaceId &lt;= 0 then
         return {
             Mode = MazeEntryAvailability.Mode.Blocked,
             ReasonCode = MazeEntryAvailability.ReasonCode.MazePlaceIdMissing,
@@ -11880,13 +15092,87 @@ function MazeEntryAvailability.evaluate(params)
 end
 
 return MazeEntryAvailability
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="90">
+          <Item class="ModuleScript" referent="142">
+            <Properties>
+              <string name="Name">SessionPhase</string>
+              <string name="Source">local SessionPhase = table.freeze({
+    RunPrep = 'RunPrep',
+    RunField = 'RunField',
+    MazeActive = 'MazeActive',
+    RunIntermission = 'RunIntermission',
+    FinalDebrief = 'FinalDebrief',
+    SessionClosed = 'SessionClosed',
+    Debrief = 'FinalDebrief',
+})
+
+function SessionPhase.resolveFromCampSession(session)
+    local normalizedSession = if type(session) == 'table' then session else {}
+    local mazeStatus = normalizedSession.MazeStatus
+    local gateOpen = normalizedSession.GateOpen == true
+    local roundStarted = normalizedSession.RoundStarted == true
+    local dangerActive = normalizedSession.DangerActive == true
+    local settlementReason = normalizedSession.SettlementReason
+    local roundOutcome = normalizedSession.RoundOutcome
+    local sessionOutcome = normalizedSession.SessionOutcome
+    local returnedSummaries = normalizedSession.ReturnedPlayerSummaries or {}
+    local playersInMaze = normalizedSession.PlayersInMaze or {}
+    local currentRound = normalizedSession.CurrentRound or 1
+    local maxRounds = normalizedSession.MaxRounds or currentRound
+
+    if normalizedSession.SessionClosed == true then
+        return SessionPhase.SessionClosed
+    end
+
+    if mazeStatus == 'active' or #playersInMaze &gt; 0 then
+        return SessionPhase.MazeActive
+    end
+
+    if type(sessionOutcome) == 'string' and sessionOutcome ~= '' then
+        return SessionPhase.FinalDebrief
+    end
+
+    if type(settlementReason) == 'string' and settlementReason ~= '' then
+        if currentRound &gt;= maxRounds then
+            return SessionPhase.FinalDebrief
+        end
+
+        return SessionPhase.RunIntermission
+    end
+
+    if type(roundOutcome) == 'string' and roundOutcome ~= '' then
+        if currentRound &gt;= maxRounds then
+            return SessionPhase.FinalDebrief
+        end
+
+        return SessionPhase.RunIntermission
+    end
+
+    if mazeStatus == 'completed' or #returnedSummaries &gt; 0 then
+        if currentRound &gt;= maxRounds then
+            return SessionPhase.FinalDebrief
+        end
+
+        return SessionPhase.RunIntermission
+    end
+
+    if gateOpen or roundStarted or dangerActive then
+        return SessionPhase.RunField
+    end
+
+    return SessionPhase.RunPrep
+end
+
+return SessionPhase
+</string>
+            </Properties>
+          </Item>
+          <Item class="ModuleScript" referent="143">
             <Properties>
               <string name="Name">SessionSeedPolicy</string>
-              <string name="Source"><![CDATA[local SessionSeedPolicy = {}
+              <string name="Source">local SessionSeedPolicy = {}
 
 SessionSeedPolicy.SeedMin = 100000
 SessionSeedPolicy.SeedMax = 999999
@@ -11915,23 +15201,71 @@ function SessionSeedPolicy.ensureAuthoritativeSeed(params)
 end
 
 return SessionSeedPolicy
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
-        <Item class="ModuleScript" referent="91">
+        <Item class="ModuleScript" referent="144">
           <Properties>
             <string name="Name">Util</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
+    HostPolicy = require(script.HostPolicy),
     TeleportDiagnostics = require(script.TeleportDiagnostics),
     Visibility = require(script.Visibility),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="92">
+          <Item class="ModuleScript" referent="145">
+            <Properties>
+              <string name="Name">HostPolicy</string>
+              <string name="Source">-- Deterministic host assignment for the run waiting phase.
+-- Rules:
+--  1. The first waiting player becomes host.
+--  2. If the host leaves, promote the next waiting player still present.
+--  3. An empty waiting roster has no host.
+
+local HostPolicy = {}
+
+function HostPolicy.assignHost(waitingPlayerOrderUserIds, currentHostUserId)
+    if #waitingPlayerOrderUserIds == 0 then
+        return nil
+    end
+
+    if HostPolicy.isValidHost(currentHostUserId, waitingPlayerOrderUserIds) then
+        return currentHostUserId
+    end
+
+    for _, userId in ipairs(waitingPlayerOrderUserIds) do
+        if type(userId) == 'number' then
+            return userId
+        end
+    end
+
+    return nil
+end
+
+function HostPolicy.isValidHost(hostUserId, waitingPlayerOrderUserIds)
+    if hostUserId == nil then
+        return false
+    end
+
+    for _, userId in ipairs(waitingPlayerOrderUserIds) do
+        if userId == hostUserId then
+            return true
+        end
+    end
+
+    return false
+end
+
+return HostPolicy
+</string>
+            </Properties>
+          </Item>
+          <Item class="ModuleScript" referent="146">
             <Properties>
               <string name="Name">TeleportDiagnostics</string>
-              <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+              <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local TeleportDiagnostics = {}
 
@@ -12022,13 +15356,13 @@ function TeleportDiagnostics.formatFailure(step, message, snapshot)
 end
 
 return TeleportDiagnostics
-]]></string>
+</string>
             </Properties>
           </Item>
-          <Item class="ModuleScript" referent="93">
+          <Item class="ModuleScript" referent="147">
             <Properties>
               <string name="Name">Visibility</string>
-              <string name="Source"><![CDATA[local Visibility = {}
+              <string name="Source">local Visibility = {}
 
 local function cloneArray(list)
     return table.clone(list or {})
@@ -12054,31 +15388,31 @@ function Visibility.filterRoster(rosterByUserId, recipientUserId)
 end
 
 return Visibility
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
       </Item>
-      <Item class="ModuleScript" referent="94">
+      <Item class="ModuleScript" referent="148">
         <Properties>
           <string name="Name">UI</string>
-          <string name="Source"><![CDATA[return {
+          <string name="Source">return {
     Hud = require(script.Hud),
 }
-]]></string>
+</string>
         </Properties>
-        <Item class="ModuleScript" referent="95">
+        <Item class="ModuleScript" referent="149">
           <Properties>
             <string name="Name">Hud</string>
-            <string name="Source"><![CDATA[return {
+            <string name="Source">return {
     Theme = require(script.Theme),
 }
-]]></string>
+</string>
           </Properties>
-          <Item class="ModuleScript" referent="96">
+          <Item class="ModuleScript" referent="150">
             <Properties>
               <string name="Name">Theme</string>
-              <string name="Source"><![CDATA[return {
+              <string name="Source">return {
     Font = Enum.Font.GothamMedium,
     Background = Color3.fromRGB(20, 24, 33),
     Surface = Color3.fromRGB(48, 57, 74),
@@ -12087,86 +15421,24 @@ return Visibility
     Accent = Color3.fromRGB(80, 227, 194),
     Warning = Color3.fromRGB(248, 196, 113),
 }
-]]></string>
+</string>
             </Properties>
           </Item>
         </Item>
       </Item>
     </Item>
-  </Item>
-  <Item class="ServerScriptService" referent="97">
-    <Properties>
-      <string name="Name">ServerScriptService</string>
-    </Properties>
-    <Item class="Script" referent="98">
+    <Item class="Folder" referent="151">
       <Properties>
-        <string name="Name">Bootstrap</string>
-        <token name="RunContext">0</token>
-        <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
-
-local MazeBootstrapStatus = require(script.Parent.Maze.MazeBootstrapStatus)
-
-MazeBootstrapStatus.set('BootstrapScriptLoaded', nil)
-
-task.defer(function()
-    local mazeSessionService
-    local lightingResult
-
-    local ok, err = pcall(function()
-        MazeBootstrapStatus.set('RequirePackages', nil)
-        local Packages = ReplicatedStorage:WaitForChild('Packages')
-
-        MazeBootstrapStatus.set('RequireShared', nil)
-        local Shared = require(Packages:WaitForChild('Shared'))
-
-        -- Create maze remotes before the heavier maze service require chain so
-        -- clients can still attach and read diagnostics if bootstrap fails later.
-        MazeBootstrapStatus.set('EnsureRemotes', nil)
-        Shared.Network.Remotes.ensure()
-
-        MazeBootstrapStatus.set('RequireLightingService', nil)
-        local MazeLightingService = require(script.Parent.Maze.MazeLightingService)
-
-        MazeBootstrapStatus.set('RequireSessionService', nil)
-        local MazeSessionService = require(script.Parent.Maze.MazeSessionService)
-
-        MazeBootstrapStatus.set('ConstructSessionService', nil)
-        mazeSessionService = MazeSessionService.new()
-
-        MazeBootstrapStatus.set('StartLightingService', nil)
-        lightingResult = MazeLightingService.new():start()
-
-        if lightingResult and lightingResult.SurfacePalette then
-            mazeSessionService:setSurfacePalette(lightingResult.SurfacePalette)
-        end
-
-        MazeBootstrapStatus.set('StartSessionService', nil)
-        mazeSessionService:start()
-    end)
-
-    if not ok then
-        local phase = mazeSessionService and mazeSessionService.BootPhase or 'BootstrapFailed'
-        MazeBootstrapStatus.set(phase, tostring(err))
-        warn(
-            string.format(
-                '[MazeBoot] bootstrap failed at phase=%s error=%s',
-                tostring(phase),
-                tostring(err)
-            )
-        )
-    end
-end)
-]]></string>
+        <string name="Name">PlaceModules</string>
       </Properties>
-    </Item>
-    <Item class="Folder" referent="99">
-      <Properties>
-        <string name="Name">Maze</string>
-      </Properties>
-      <Item class="ModuleScript" referent="100">
+      <Item class="Folder" referent="152">
         <Properties>
-          <string name="Name">MazeBootstrapStatus</string>
-          <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+          <string name="Name">Maze</string>
+        </Properties>
+        <Item class="ModuleScript" referent="153">
+          <Properties>
+            <string name="Name">MazeBootstrapStatus</string>
+            <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local MazeBootstrapStatus = {}
 
@@ -12181,13 +15453,28 @@ function MazeBootstrapStatus.set(phase, err)
 end
 
 return table.freeze(MazeBootstrapStatus)
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="101">
-        <Properties>
-          <string name="Name">MazeDoor</string>
-          <string name="Source"><![CDATA[local MazeDoor = {}
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="154">
+          <Properties>
+            <string name="Name">MazeChunkManifest</string>
+            <string name="Source">local MazeChunkManifest = table.freeze({
+    table.freeze({
+        ChunkId = 'maze.3dm',
+        AssetName = 'MazeChunk_maze_v1',
+        Enabled = true,
+    }),
+})
+
+return MazeChunkManifest
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="155">
+          <Properties>
+            <string name="Name">MazeDoor</string>
+            <string name="Source">local MazeDoor = {}
 MazeDoor.__index = MazeDoor
 
 function MazeDoor.new(rawDoorway)
@@ -12215,31 +15502,13 @@ function MazeDoor:bind(callback)
 end
 
 return MazeDoor
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="102">
-        <Properties>
-          <string name="Name">MazeExtractionNode</string>
-          <string name="Source"><![CDATA[local MazeExtractionNode = {}
-MazeExtractionNode.__index = MazeExtractionNode
-
-function MazeExtractionNode.new(rawNode)
-    return setmetatable(rawNode, MazeExtractionNode)
-end
-
-function MazeExtractionNode:bind(callback)
-    return self.Prompt.Triggered:Connect(callback)
-end
-
-return MazeExtractionNode
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="103">
-        <Properties>
-          <string name="Name">MazeInteractionRegistry</string>
-          <string name="Source"><![CDATA[local MazeInteractionRegistry = {}
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="156">
+          <Properties>
+            <string name="Name">MazeInteractionRegistry</string>
+            <string name="Source">local MazeInteractionRegistry = {}
 MazeInteractionRegistry.__index = MazeInteractionRegistry
 
 function MazeInteractionRegistry.new()
@@ -12258,12 +15527,6 @@ function MazeInteractionRegistry:bindScene(scene, handlers)
     self:_track(scene.ReturnHoldPad:bind(function(player)
         handlers.OnReturnHold(player)
     end))
-
-    for extractionNodeId, extractionNode in pairs(scene.ExtractionNodes) do
-        self:_track(extractionNode:bind(function(player)
-            handlers.OnExtraction(player, extractionNodeId)
-        end))
-    end
 
     for roomId, lootNode in pairs(scene.LootNodes) do
         self:_track(lootNode:bind(function(player)
@@ -12286,13 +15549,13 @@ function MazeInteractionRegistry:disconnectAll()
 end
 
 return MazeInteractionRegistry
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="104">
-        <Properties>
-          <string name="Name">MazeLightingService</string>
-          <string name="Source"><![CDATA[local Lighting = game:GetService('Lighting')
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="157">
+          <Properties>
+            <string name="Name">MazeLightingService</string>
+            <string name="Source">local Lighting = game:GetService('Lighting')
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
@@ -12334,13 +15597,13 @@ function MazeLightingService:start()
 end
 
 return MazeLightingService
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="105">
-        <Properties>
-          <string name="Name">MazeLootNode</string>
-          <string name="Source"><![CDATA[local MazeLootNode = {}
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="158">
+          <Properties>
+            <string name="Name">MazeLootNode</string>
+            <string name="Source">local MazeLootNode = {}
 MazeLootNode.__index = MazeLootNode
 
 function MazeLootNode.new(roomId, rawNode)
@@ -12363,16 +15626,18 @@ function MazeLootNode:markCollected()
     if promptPart then
         promptPart:Destroy()
     end
+
+    self.Prompt = nil
 end
 
 return MazeLootNode
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="106">
-        <Properties>
-          <string name="Name">MazeRoom</string>
-          <string name="Source"><![CDATA[local MazeRoom = {}
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="159">
+          <Properties>
+            <string name="Name">MazeRoom</string>
+            <string name="Source">local MazeRoom = {}
 MazeRoom.__index = MazeRoom
 
 function MazeRoom.new(roomData, affordance, instance)
@@ -12383,13 +15648,13 @@ function MazeRoom.new(roomData, affordance, instance)
 end
 
 return MazeRoom
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="107">
-        <Properties>
-          <string name="Name">MazeRunPortal</string>
-          <string name="Source"><![CDATA[local MazeToRunTransition = require(script.Parent.MazeToRunTransition)
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="160">
+          <Properties>
+            <string name="Name">MazeRunPortal</string>
+            <string name="Source">local MazeToRunTransition = require(script.Parent.MazeToRunTransition)
 
 local transition = MazeToRunTransition.new()
 
@@ -12400,14 +15665,13 @@ function MazeRunPortal.returnPlayers(params)
 end
 
 return MazeRunPortal
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="108">
-        <Properties>
-          <string name="Name">MazeScene</string>
-          <string name="Source"><![CDATA[local MazeDoor = require(script.Parent.MazeDoor)
-local MazeExtractionNode = require(script.Parent.MazeExtractionNode)
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="161">
+          <Properties>
+            <string name="Name">MazeScene</string>
+            <string name="Source">local MazeDoor = require(script.Parent.MazeDoor)
 local MazeInteractionRegistry = require(script.Parent.MazeInteractionRegistry)
 local MazeLootNode = require(script.Parent.MazeLootNode)
 local MazeRoom = require(script.Parent.MazeRoom)
@@ -12453,12 +15717,6 @@ function MazeScene.new(rawWorld)
         )
     end
 
-    local extractionNodes = {}
-    for extractionNodeId, extractionNode in pairs(rawWorld.ExtractionNodes or {}) do
-        extractionNodes[extractionNodeId] = MazeExtractionNode.new(extractionNode)
-    end
-    assertNonEmptyMap(extractionNodes, 'extraction nodes')
-
     local lootNodes = {}
     for roomId, lootNode in pairs(rawWorld.LootNodes or {}) do
         lootNodes[roomId] = MazeLootNode.new(roomId, lootNode)
@@ -12479,7 +15737,6 @@ function MazeScene.new(rawWorld)
     local registry = MazeSceneRegistry.new({
         RoomsById = roomsById,
         LootNodes = lootNodes,
-        ExtractionNodes = extractionNodes,
         Doorways = doorways,
     })
 
@@ -12499,7 +15756,6 @@ function MazeScene.new(rawWorld)
             rawWorld.ReturnHoldCFrame
         ),
         ReturnHoldPad = returnHoldPad,
-        ExtractionNodes = extractionNodes,
         LootNodes = lootNodes,
         Doorways = doorways,
         CanTraverseBetweenPositions = rawWorld.CanTraverseBetweenPositions,
@@ -12555,20 +15811,19 @@ function MazeScene:bindInteractions(handlers)
 end
 
 return MazeScene
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="109">
-        <Properties>
-          <string name="Name">MazeSceneRegistry</string>
-          <string name="Source"><![CDATA[local MazeSceneRegistry = {}
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="162">
+          <Properties>
+            <string name="Name">MazeSceneRegistry</string>
+            <string name="Source">local MazeSceneRegistry = {}
 MazeSceneRegistry.__index = MazeSceneRegistry
 
 function MazeSceneRegistry.new(entries)
     return setmetatable({
         RoomsById = entries.RoomsById or {},
         LootNodes = entries.LootNodes or {},
-        ExtractionNodes = entries.ExtractionNodes or {},
         Doorways = entries.Doorways or {},
     }, MazeSceneRegistry)
 end
@@ -12581,22 +15836,18 @@ function MazeSceneRegistry:getLootNode(roomId)
     return self.LootNodes[roomId]
 end
 
-function MazeSceneRegistry:getExtractionNode(extractionNodeId)
-    return self.ExtractionNodes[extractionNodeId]
-end
-
 function MazeSceneRegistry:getDoor(doorwayId)
     return self.Doorways[doorwayId]
 end
 
 return MazeSceneRegistry
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="110">
-        <Properties>
-          <string name="Name">MazeSessionService</string>
-          <string name="Source"><![CDATA[local Players = game:GetService('Players')
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="163">
+          <Properties>
+            <string name="Name">MazeSessionService</string>
+            <string name="Source">local Players = game:GetService('Players')
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 local RunService = game:GetService('RunService')
 local Workspace = game:GetService('Workspace')
@@ -12604,7 +15855,6 @@ local Workspace = game:GetService('Workspace')
 local DEFAULT_WORKSPACE_SHELL_NAMES = { 'Baseplate', 'SpawnLocation' }
 local CAMP_SESSION_LOCK_WAIT_SECONDS = 0.05
 local SNAPSHOT_INTERVAL_SECONDS = 0.25
-local UGC_MONSTER_GLOBAL_CAP = 5
 local TELEPORT_DATA_WAIT_SECONDS = 3
 local TELEPORT_DATA_WAIT_STEP_SECONDS = 0.05
 local MAZE_DIAG_PREFIX = '[MazeDiag]'
@@ -12625,6 +15875,7 @@ local SharedPackage = Packages:WaitForChild('Shared')
 
 local SessionConfig = Shared.Config.SessionConfig
 local CampMazeSessionContract = Shared.Session.CampMazeSessionContract
+local SessionPhase = Shared.Session.SessionPhase
 local SessionSeedPolicy = Shared.Session.SessionSeedPolicy
 local Remotes = Shared.Network.Remotes.ensureScope(Shared.Network.Remotes.Scope.Maze)
 local InventoryService =
@@ -12634,6 +15885,7 @@ local ControlStateService = Shared.Runtime.ControlStateService
 local FormalLocomotion = Shared.Runtime.FormalLocomotion
 local PlayerStateService = Shared.Runtime.PlayerStateService
 local PlayerService = Shared.Runtime.PlayerService
+local RoundSignalBus = Shared.Runtime.RoundSignalBus
 local TeleportInventoryHydrator = Shared.Runtime.TeleportInventoryHydrator
 
 local MazeBootstrapStatus = require(script.Parent.MazeBootstrapStatus)
@@ -12648,8 +15900,6 @@ local DAMAGE_KIND_BY_PIPS = table.freeze({
     [1] = Gameplay.PlayerState.DamageKind.Light,
     [2] = Gameplay.PlayerState.DamageKind.Heavy,
 })
-
-local MazeMonsterSpawnPolicy = Gameplay.Monsters.MazeMonsterSpawnPolicy
 
 local MazeSessionService = {}
 MazeSessionService.__index = MazeSessionService
@@ -12709,7 +15959,7 @@ local function mergeSummaries(existingSummaries, nextSummaries)
     end
 
     table.sort(merged, function(left, right)
-        return left.UserId < right.UserId
+        return left.UserId &lt; right.UserId
     end)
 
     return merged
@@ -12774,22 +16024,6 @@ local function buildMazeMonsterRuntimeProfile(monsterAuthorProfile)
     return runtimeProfileOrReason
 end
 
-local function cloneUgcPendingPayload(payload)
-    if type(payload) ~= 'table' then
-        return nil
-    end
-
-    return {
-        OwnerUserId = payload.OwnerUserId,
-        MonsterId = payload.MonsterId,
-        MonsterName = payload.MonsterName,
-        Seed = payload.Seed,
-        RecipeHash = payload.RecipeHash,
-        RuntimeProfile = table.clone(payload.RuntimeProfile or {}),
-        Diagnostics = table.clone(payload.Diagnostics or {}),
-    }
-end
-
 function MazeSessionService:_emitDiagnostic(event, fields)
     self.DiagnosticSequence += 1
     local prefix = string.format(
@@ -12806,6 +16040,236 @@ function MazeSessionService:_emitDiagnostic(event, fields)
     end
 
     print(string.format('%s | %s', prefix, fieldString))
+end
+
+function MazeSessionService:_getPersistentWorldState()
+    return self.CampSession.PersistentWorldState
+        or {
+            CollectedLootRoomIds = {},
+            DropNodes = {},
+        }
+end
+
+function MazeSessionService:_setPersistentWorldState(persistentWorldState)
+    self.CampSession =
+        CampMazeSessionContract.setPersistentWorldState(self.CampSession, persistentWorldState)
+end
+
+function MazeSessionService:_replaceDropNodeState(nextDropNodes)
+    local state = self:_getPersistentWorldState()
+    state.DropNodes = nextDropNodes
+    self:_setPersistentWorldState(state)
+end
+
+function MazeSessionService:_reserveDynamicDropNodeId()
+    local nextId = self.NextDynamicDropNodeId or 1
+    local state = self:_getPersistentWorldState()
+
+    for _, dropNodeState in ipairs(state.DropNodes or {}) do
+        local existingId =
+            tonumber(string.match(tostring(dropNodeState.DropNodeId or ''), '^DynamicDrop_(%d+)$'))
+        if existingId ~= nil and existingId &gt;= nextId then
+            nextId = existingId + 1
+        end
+    end
+
+    self.NextDynamicDropNodeId = nextId + 1
+    return string.format('DynamicDrop_%d', nextId)
+end
+
+function MazeSessionService:_markLootCollected(roomId)
+    local state = self:_getPersistentWorldState()
+    local collectedLootRoomIds = state.CollectedLootRoomIds or {}
+
+    for _, collectedRoomId in ipairs(collectedLootRoomIds) do
+        if collectedRoomId == roomId then
+            return
+        end
+    end
+
+    table.insert(collectedLootRoomIds, roomId)
+    table.sort(collectedLootRoomIds)
+    state.CollectedLootRoomIds = collectedLootRoomIds
+    self:_setPersistentWorldState(state)
+end
+
+function MazeSessionService:_destroyDynamicDropNode(dropNodeId)
+    local dynamicNode = self.DynamicDropNodesById[dropNodeId]
+    if dynamicNode == nil then
+        return
+    end
+
+    if dynamicNode.Connection and dynamicNode.Connection.Disconnect then
+        dynamicNode.Connection:Disconnect()
+    end
+    if dynamicNode.Part and dynamicNode.Part.Parent then
+        dynamicNode.Part:Destroy()
+    end
+    self.DynamicDropNodesById[dropNodeId] = nil
+end
+
+function MazeSessionService:_destroyDynamicDropNodes()
+    for dropNodeId in pairs(self.DynamicDropNodesById) do
+        self:_destroyDynamicDropNode(dropNodeId)
+    end
+end
+
+function MazeSessionService:_dropNodePositionToVector3(position)
+    if typeof(position) == 'Vector3' then
+        return position
+    end
+
+    if type(position) == 'table' then
+        return Vector3.new(
+            position.X or position[1] or 0,
+            position.Y or position[2] or 0,
+            position.Z or position[3] or 0
+        )
+    end
+
+    return self.World and self.World.ReturnHoldCFrame.Position or Vector3.zero
+end
+
+function MazeSessionService:_buildDropNodePart(dropNodeState)
+    local position = self:_dropNodePositionToVector3(dropNodeState.Position)
+    local part = Instance.new('Part')
+    part.Name = dropNodeState.DropNodeId
+    part.Anchored = true
+    part.CanCollide = false
+    part.Transparency = 0.15
+    part.Material = Enum.Material.Metal
+    part.Color = Color3.fromRGB(142, 236, 255)
+    part.Size = Vector3.new(2.5, 2.5, 2.5)
+    part.CFrame = CFrame.new(position + Vector3.new(0, 1.5, 0))
+    part.Parent = self.World.Root
+
+    local prompt = Instance.new('ProximityPrompt')
+    prompt.ActionText = 'Recover'
+    prompt.ObjectText = dropNodeState.Label or 'Dropped Pack'
+    prompt.MaxActivationDistance = 10
+    prompt.RequiresLineOfSight = false
+    prompt.Parent = part
+
+    return part, prompt
+end
+
+function MazeSessionService:_spawnDynamicDropNode(dropNodeState)
+    if not (self.World and self.World.Root) then
+        return
+    end
+
+    local part, prompt = self:_buildDropNodePart(dropNodeState)
+    local connection = prompt.Triggered:Connect(function(player)
+        self:_pickupDropNode(player, dropNodeState.DropNodeId)
+    end)
+
+    self.DynamicDropNodesById[dropNodeState.DropNodeId] = {
+        Part = part,
+        Connection = connection,
+    }
+end
+
+function MazeSessionService:_applyPersistentWorldStateToWorld()
+    local state = self:_getPersistentWorldState()
+
+    for _, roomId in ipairs(state.CollectedLootRoomIds or {}) do
+        local lootNode = self.World and self.World:getLootNode(roomId)
+        if lootNode and lootNode.Collected ~= true then
+            lootNode:markCollected()
+        end
+    end
+
+    self:_destroyDynamicDropNodes()
+    for _, dropNodeState in ipairs(state.DropNodes or {}) do
+        self:_spawnDynamicDropNode(dropNodeState)
+    end
+end
+
+function MazeSessionService:_createPersistentDropNode(entries, position, label)
+    if entries == nil or #entries == 0 then
+        return
+    end
+
+    local state = self:_getPersistentWorldState()
+    local dropNodeId = self:_reserveDynamicDropNodeId()
+    local dropNodes = state.DropNodes or {}
+    table.insert(dropNodes, {
+        DropNodeId = dropNodeId,
+        Label = label,
+        Position = {
+            X = position.X,
+            Y = position.Y,
+            Z = position.Z,
+        },
+        Entries = entries,
+    })
+    state.DropNodes = dropNodes
+    self:_setPersistentWorldState(state)
+    self:_spawnDynamicDropNode(dropNodes[#dropNodes])
+end
+
+function MazeSessionService:_pickupDropNode(player, dropNodeId)
+    if not self.RunTracker:isPlayerActive(player.UserId) then
+        return
+    end
+
+    local state = self:_getPersistentWorldState()
+    local nextDropNodes = {}
+    local pickedCount = 0
+    local pickedAny = false
+
+    for _, dropNodeState in ipairs(state.DropNodes or {}) do
+        if dropNodeState.DropNodeId == dropNodeId then
+            local remainingEntries = {}
+            for _, itemEntry in ipairs(dropNodeState.Entries or {}) do
+                local success = self.InventoryService:pickupEntry(player, itemEntry)
+                if success == true then
+                    pickedAny = true
+                    pickedCount += 1
+                else
+                    table.insert(remainingEntries, itemEntry)
+                end
+            end
+
+            if #remainingEntries &gt; 0 then
+                table.insert(nextDropNodes, {
+                    DropNodeId = dropNodeState.DropNodeId,
+                    Label = dropNodeState.Label,
+                    Position = dropNodeState.Position,
+                    Entries = remainingEntries,
+                })
+            end
+        else
+            table.insert(nextDropNodes, dropNodeState)
+        end
+    end
+
+    if not pickedAny then
+        self:_setStatus(
+            string.format(
+                '%s found a dropped pack but has no room to recover it.',
+                player.DisplayName
+            )
+        )
+        return
+    end
+
+    self:_destroyDynamicDropNode(dropNodeId)
+    self:_replaceDropNodeState(nextDropNodes)
+    for _, dropNodeState in ipairs(nextDropNodes) do
+        if dropNodeState.DropNodeId == dropNodeId then
+            self:_spawnDynamicDropNode(dropNodeState)
+            break
+        end
+    end
+
+    self:_setStatus(
+        string.format(
+            '%s recovered %d dropped item(s) from the maze floor.',
+            player.DisplayName,
+            pickedCount
+        )
+    )
 end
 
 function MazeSessionService:_getWorldBuildMetadataFields()
@@ -12862,114 +16326,23 @@ function MazeSessionService:_markAcceptedTeleportData(teleportData)
     return true
 end
 
-function MazeSessionService:_queuePendingUgcMonsterPayload(payload)
-    local clonedPayload = cloneUgcPendingPayload(payload)
-    if clonedPayload == nil then
-        return
-    end
-
-    table.insert(self.PendingUgcMonsterPayloads, clonedPayload)
-end
-
-function MazeSessionService:_destroyUgcMonsters()
-    for _, entry in ipairs(self.UgcMonsterServices) do
-        if entry.Service and entry.Service.destroy then
-            entry.Service:destroy()
-        end
-    end
-    table.clear(self.UgcMonsterServices)
-end
-
 function MazeSessionService:_buildMonsterRuntimeOptions(randomSeed)
     return {
         RandomSeed = randomSeed,
-        OnAttackHit = function(player, damagePips)
+        OnAttackHit = function(player, damagePips, hitContext)
             local damageKind = damageKindFromPips(damagePips)
             if damageKind == nil then
                 return
             end
 
             self:_applyPlayerDamage(player, damageKind)
+            if hitContext and hitContext.Effects then
+                for _, effect in ipairs(hitContext.Effects) do
+                    self.PlayerStateService:applyEffect(player, effect.Id, effect.DurationSeconds)
+                end
+            end
         end,
     }
-end
-
-function MazeSessionService:_spawnQueuedUgcMonsters()
-    if #self.PendingUgcMonsterPayloads == 0 then
-        return
-    end
-
-    local patrolPoints = self.World and self.World.PatrolPoints or {}
-    if #patrolPoints == 0 then
-        table.clear(self.PendingUgcMonsterPayloads)
-        self:_setStatus('UGC 怪物刷怪失败：迷宫缺少巡逻点。')
-        return
-    end
-
-    local queuedPayloads = table.clone(self.PendingUgcMonsterPayloads)
-    table.clear(self.PendingUgcMonsterPayloads)
-
-    for _, payload in ipairs(queuedPayloads) do
-        if #self.UgcMonsterServices >= UGC_MONSTER_GLOBAL_CAP then
-            self:_setStatus('UGC 怪物刷怪已达本局上限（5只）。')
-            break
-        end
-
-        local runtimeProfile = payload.RuntimeProfile
-        local runtimeValid, runtimeReason =
-            Gameplay.Monsters.MonsterRuntimeProfile.validate(runtimeProfile)
-        if not runtimeValid then
-            self:_setStatus(
-                string.format(
-                    'UGC 怪物运行配置无效（owner=%s, reason=%s）。',
-                    tostring(payload.OwnerUserId),
-                    tostring(runtimeReason)
-                )
-            )
-            continue
-        end
-
-        local randomSeed = if type(payload.Seed) == 'number'
-            then math.floor(payload.Seed)
-            else self.SessionData.Seed
-        if randomSeed <= 0 then
-            randomSeed = self.SessionData.Seed
-        end
-        local random = Random.new(randomSeed)
-
-        local initialPatrolIndex, spawnRoomId =
-            MazeMonsterSpawnPolicy.selectRandomEligiblePatrolIndex(
-                self.World.RoomIds,
-                self.World.RoomAffordances,
-                self.World.RoomById,
-                self.World.CampRoomId,
-                random
-            )
-        if initialPatrolIndex == nil then
-            self:_setStatus('UGC 怪物刷怪失败：没有可用的安全房间。')
-            continue
-        end
-
-        local ugcMonsterService = self.MonsterServiceFactory(runtimeProfile, function()
-            return self.RunTracker:getState() == 'Expedition'
-        end, function(player)
-            return self.RunTracker:isPlayerActive(player.UserId)
-        end, function(fromPosition, toPosition)
-            if not self.World or not self.World.CanTraverseBetweenPositions then
-                return true
-            end
-
-            return self.World.CanTraverseBetweenPositions(fromPosition, toPosition)
-        end, self:_buildMonsterRuntimeOptions(randomSeed))
-        ugcMonsterService:spawn(patrolPoints, initialPatrolIndex)
-
-        table.insert(self.UgcMonsterServices, {
-            OwnerUserId = payload.OwnerUserId,
-            SpawnRoomId = spawnRoomId,
-            Service = ugcMonsterService,
-            RuntimeProfileId = runtimeProfile.Id,
-        })
-    end
 end
 
 function MazeSessionService.new(options)
@@ -12981,13 +16354,20 @@ function MazeSessionService.new(options)
         Quota = SessionConfig.DefaultQuota,
         RunDurationSeconds = SessionConfig.DefaultRunDurationSeconds,
         InventoryCapacity = SessionConfig.InventoryCapacity,
+        Mission = {
+            RoundCount = SessionConfig.Mission.RoundCount,
+            TargetItemCount = SessionConfig.Mission.TargetItemCount,
+        },
     }
     self.Remotes = Remotes
     self.CampSession = CampMazeSessionContract.newCampSession({
+        CurrentRound = 1,
+        MaxRounds = SessionConfig.Mission.RoundCount,
+        TargetItemCount = SessionConfig.Mission.TargetItemCount,
         MazeAccessCode = 'local-debug-maze',
         MazeStatus = CampMazeSessionContract.MazeStatus.Active,
     })
-    self.Status = 'Direct boot: maze session is live. Explore, loot, and find an extraction point.'
+    self.Status = 'Direct boot: maze session is live. Explore, loot, and find a return point.'
     self.World = nil
     self.WorldInteractions = nil
     self.IsDirectBoot = true
@@ -13040,11 +16420,15 @@ function MazeSessionService.new(options)
         end,
         self:_buildMonsterRuntimeOptions(self.SessionData.Seed)
     )
-    self.UgcMonsterServices = {}
-    self.PendingUgcMonsterPayloads = {}
     self.CorpsesByUserId = {}
+    self.DeathSummaryByUserId = {}
+    self.DynamicDropNodesById = {}
+    self.NextDynamicDropNodeId = 1
     self.BootPhase = 'New'
     self.SurfacePalette = Shared.Runtime.MazeLightingProfile.SurfacePalette
+    self.RoundSignalBus = runtimeOptions.RoundSignalBus or RoundSignalBus.new()
+    self.RoundSignalConnection = nil
+    self.RoundClosureInProgress = false
 
     self:_emitDiagnostic('InitDefaultState', {
         InitialIsDirectBoot = self.IsDirectBoot,
@@ -13054,6 +16438,79 @@ function MazeSessionService.new(options)
     })
 
     return self
+end
+
+function MazeSessionService:_getServerTimeNow()
+    local ok, result = pcall(function()
+        return Workspace:GetServerTimeNow()
+    end)
+    if ok and type(result) == 'number' then
+        return result
+    end
+
+    return os.time()
+end
+
+function MazeSessionService:_isPlayerDead(player)
+    local summary = self.PlayerService:getSummary(player)
+    return summary ~= nil and summary.Health ~= nil and summary.Health.IsDead == true
+end
+
+function MazeSessionService:_getAliveActiveCount()
+    local count = 0
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        if self.RunTracker:isPlayerActive(player.UserId) and not self:_isPlayerDead(player) then
+            count += 1
+        end
+    end
+
+    return count
+end
+
+function MazeSessionService:_publishMazePresence()
+    self.RoundSignalBus:publish(self.CampSession, {
+        Kind = RoundSignalBus.MessageKind.MazePresence,
+        AliveCount = self:_getAliveActiveCount(),
+        ActiveCount = self.RunTracker:getActiveCount(),
+        IssuedAt = self:_getServerTimeNow(),
+    })
+end
+
+function MazeSessionService:_handleRoundSignal(payload)
+    if type(payload) ~= 'table' or payload.Kind ~= RoundSignalBus.MessageKind.RoundClosure then
+        return
+    end
+
+    if self.RoundClosureInProgress then
+        return
+    end
+
+    self.RoundClosureInProgress = true
+    self.CampSession = CampMazeSessionContract.markSettlementTriggered(self.CampSession, {
+        SettlementReason = payload.Reason,
+        TriggeredByUserId = payload.TriggeredByUserId,
+        TriggeredByName = payload.TriggeredByName,
+    })
+    self.CampSession.GateOpen = false
+    self.CampSession.RoundStarted = false
+    self.CampSession.RoundEndTime = payload.IssuedAt or self:_getServerTimeNow()
+    self.CampSession = CampMazeSessionContract.normalizeCampSession(self.CampSession)
+    self:_forceCloseToCamp(payload.Reason, payload.CountInventories ~= false)
+end
+
+function MazeSessionService:_subscribeToRoundSignals()
+    if self.RoundSignalConnection and self.RoundSignalConnection.Disconnect then
+        self.RoundSignalConnection:Disconnect()
+        self.RoundSignalConnection = nil
+    end
+
+    local connection, ok = self.RoundSignalBus:subscribe(self.CampSession, function(payload)
+        self:_handleRoundSignal(payload)
+    end)
+    if ok then
+        self.RoundSignalConnection = connection
+    end
 end
 
 function MazeSessionService:_setBootPhase(phase)
@@ -13092,7 +16549,6 @@ function MazeSessionService:_mergeTeleportData(teleportData, resetInventoryServi
         HadCampSession = false,
         HadTeleportData = type(teleportData) == 'table',
         Merged = false,
-        HadPendingUgcMonster = false,
         PreviousIsDirectBoot = self.IsDirectBoot,
         PreviousMazeAccessCode = self.CampSession and self.CampSession.MazeAccessCode or nil,
         PreviousSeed = self.SessionData.Seed,
@@ -13141,19 +16597,25 @@ function MazeSessionService:_mergeTeleportData(teleportData, resetInventoryServi
             self.SessionData.InventoryCapacity = incoming.InventoryCapacity
             self.InventoryService.Capacity = incoming.InventoryCapacity
         end
+        if type(incoming.Mission) == 'table' then
+            if type(incoming.Mission.RoundCount) == 'number' then
+                self.SessionData.Mission.RoundCount = incoming.Mission.RoundCount
+            end
+            if type(incoming.Mission.TargetItemCount) == 'number' then
+                self.SessionData.Mission.TargetItemCount = incoming.Mission.TargetItemCount
+                self.SessionData.Quota = incoming.Mission.TargetItemCount
+            end
+        end
     end
 
     self.CampSession = nextSession
     self.IsDirectBoot = false
-    self.Status = 'Maze session is live. Explore, loot, and find an extraction point.'
+    self.CampSession.MaxRounds = self.SessionData.Mission.RoundCount
+    self.CampSession.TargetItemCount = self.SessionData.Mission.TargetItemCount
+    self.Status = 'Maze session is live. Explore, loot, and find a return point.'
+    self:_subscribeToRoundSignals()
     result.AcceptedBeforeBuild = self:_markAcceptedTeleportData(teleportData)
     result.Merged = true
-    local pendingUgcMonsterPayload =
-        CampMazeSessionContract.findPendingUgcMonsterPayload(teleportData)
-    if pendingUgcMonsterPayload ~= nil then
-        result.HadPendingUgcMonster = true
-        self:_queuePendingUgcMonsterPayload(pendingUgcMonsterPayload)
-    end
 
     if resetInventoryService == true then
         self.InventoryService = InventoryService.new(self.SessionData.InventoryCapacity)
@@ -13164,7 +16626,7 @@ end
 
 function MazeSessionService:_awaitInitialTeleportData()
     local deadline = os.clock() + TELEPORT_DATA_WAIT_SECONDS
-    while os.clock() < deadline do
+    while os.clock() &lt; deadline do
         if self.HasAcceptedTeleportData == true then
             return true
         end
@@ -13251,7 +16713,7 @@ function MazeSessionService:_handlePlayerTeleportData(player)
         and mergeResult.PreviousSeed ~= mergeResult.ResultSeed
         and self.WorldBuildMetadata
         and self.WorldBuildMetadata.Source == WORLD_BUILD_SOURCE.JoinDataMergedAfterBuild
-        and #Players:GetPlayers() <= 1
+        and #Players:GetPlayers() &lt;= 1
     then
         self:_emitDiagnostic('LateJoinSeedRebuild', {
             PreviousSeed = mergeResult.PreviousSeed,
@@ -13264,7 +16726,6 @@ function MazeSessionService:_handlePlayerTeleportData(player)
         Accepted = mergeResult.Accepted,
         AcceptedBeforeBuild = mergeResult.AcceptedBeforeBuild,
         HadCampSession = mergeResult.HadCampSession,
-        HadPendingUgcMonster = mergeResult.HadPendingUgcMonster,
         HadTeleportData = mergeResult.HadTeleportData,
         Merged = mergeResult.Merged,
         Player = player.DisplayName,
@@ -13277,10 +16738,6 @@ function MazeSessionService:_handlePlayerTeleportData(player)
         ResultSessionId = mergeResult.ResultSessionId,
         WorldBuildSource = self.WorldBuildMetadata and self.WorldBuildMetadata.Source or nil,
     })
-
-    if self.IsLaunched then
-        self:_spawnQueuedUgcMonsters()
-    end
 end
 
 function MazeSessionService:_hydratePlayerInventory(player, teleportData)
@@ -13310,6 +16767,7 @@ function MazeSessionService:_addPlayerState(player)
     self.ControlStateService:addPlayer(player)
     self.PlayerService:addPlayer(player)
     self.PlayerStateService:addPlayer(player)
+    self:_publishMazePresence()
 end
 
 function MazeSessionService:_removePlayerState(player)
@@ -13321,6 +16779,8 @@ function MazeSessionService:_removePlayerState(player)
     self.ControlStateService:removePlayer(player)
     self.PlayerService:removePlayer(player)
     self.PlayerStateService:removePlayer(player)
+    self.DeathSummaryByUserId[player.UserId] = nil
+    self:_publishMazePresence()
 end
 
 function MazeSessionService:_getMovementSummaryFor(player)
@@ -13375,7 +16835,7 @@ function MazeSessionService:_buildRoster()
     end
 
     table.sort(roster, function(left, right)
-        return left.Name < right.Name
+        return left.Name &lt; right.Name
     end)
 
     return roster
@@ -13401,11 +16861,19 @@ function MazeSessionService:_getPlayerArea(player)
 end
 
 function MazeSessionService:_getObjectiveFor()
-    if self.RunTracker.IsCompleted then
-        return 'The maze run is complete. Review the returned summaries back in camp.'
+    if self.RoundClosureInProgress or self.CampSession.SettlementReason ~= nil then
+        return 'The round is closing. Hold position until the return to the ship completes.'
     end
 
-    return 'Collect loot, avoid the monster, and use a return marker to head back to the run maze gate.'
+    if self.CampSession.SessionOutcome == 'success' then
+        return 'Mission complete. The maze is done for this run; head back to the ship for final debrief.'
+    end
+
+    if self.CampSession.SessionOutcome == 'failure' then
+        return 'This was the last round and the crew missed the quota. Return to the ship for final debrief.'
+    end
+
+    return 'Read the room, dodge the threat, grab loot, and bring it back to the ship alive.'
 end
 
 function MazeSessionService:_broadcastSnapshot()
@@ -13419,6 +16887,27 @@ function MazeSessionService:_broadcastSnapshot()
         self.RunTracker:getReturnedSummaries()
     )
     local mazeStatus = self:_getMazeStatus()
+    local roundEndTime = self.CampSession.RoundEndTime
+    local roundTimeRemainingSeconds = nil
+    if type(roundEndTime) == 'number' then
+        roundTimeRemainingSeconds = math.max(0, roundEndTime - self:_getServerTimeNow())
+    end
+
+    local sessionPhaseInput = {
+        GateOpen = self.CampSession.GateOpen,
+        RoundStarted = self.CampSession.RoundStarted,
+        DangerActive = self.CampSession.DangerActive,
+        SettlementReason = self.CampSession.SettlementReason,
+        MazeStatus = mazeStatus,
+        PlayersInMaze = self.CampSession.PlayersInMaze,
+        ReturnedPlayerSummaries = returnedSummaries,
+        SessionClosed = self.CampSession.SessionClosed,
+        CurrentRound = self.CampSession.CurrentRound,
+        MaxRounds = self.CampSession.MaxRounds,
+        RoundOutcome = self.CampSession.RoundOutcome,
+        SessionOutcome = self.CampSession.SessionOutcome,
+    }
+    local sessionPhase = SessionPhase.resolveFromCampSession(sessionPhaseInput)
     local worldBuildFields = self:_getWorldBuildMetadataFields()
 
     for _, player in ipairs(Players:GetPlayers()) do
@@ -13428,6 +16917,18 @@ function MazeSessionService:_broadcastSnapshot()
             Area = self:_getPlayerArea(player),
             Objective = self:_getObjectiveFor(),
             State = self.RunTracker:getState(),
+            SessionPhase = sessionPhase,
+            HostUserId = self.CampSession.HostUserId,
+            RoundStarted = self.CampSession.RoundStarted == true,
+            DangerActive = self.CampSession.DangerActive == true,
+            RoundTimeRemainingSeconds = roundTimeRemainingSeconds,
+            SettlementReason = self.CampSession.SettlementReason,
+            CurrentRound = self.CampSession.CurrentRound,
+            MaxRounds = self.CampSession.MaxRounds,
+            BankedItemCount = self.CampSession.BankedItemCount,
+            TargetItemCount = self.CampSession.TargetItemCount,
+            RoundOutcome = self.CampSession.RoundOutcome,
+            SessionOutcome = self.CampSession.SessionOutcome,
             Inventory = self.InventoryService:getSummary(player),
             Movement = self:_getMovementSummaryFor(player),
             ControlState = self.ControlStateService:getSummary(player),
@@ -13463,6 +16964,7 @@ function MazeSessionService:_rebuildWorld()
     end
 
     clearDefaultWorkspaceShell()
+    self:_destroyDynamicDropNodes()
 
     if self.WorldInteractions then
         self.WorldInteractions:disconnectAll()
@@ -13471,13 +16973,11 @@ function MazeSessionService:_rebuildWorld()
 
     self.World = MazeWorldBuilder.build()
     self:_recordWorldBuildMetadata()
+    self:_applyPersistentWorldStateToWorld()
     self:_setBootPhase('BindWorldInteractions')
     self.WorldInteractions = self.World:bindInteractions({
         OnReturnHold = function(player)
-            self:_returnPlayerToRunEntrance(player, 'early_return')
-        end,
-        OnExtraction = function(player, extractionNodeId)
-            self:_returnPlayerToRunEntrance(player, 'extracted', extractionNodeId)
+            self:_returnPlayerToRunEntrance(player, 'returned')
         end,
         OnLoot = function(player, roomId)
             self:_pickupLoot(player, roomId)
@@ -13512,43 +17012,93 @@ function MazeSessionService:_toggleDoor(player, doorwayId)
     end
 end
 
-function MazeSessionService:_buildSummaryFor(player, returnReason, wasSettled)
-    local inventorySummary = self.InventoryService:getSummary(player)
+function MazeSessionService:_buildSummaryFor(
+    player,
+    returnReason,
+    wasSettled,
+    countInventory,
+    overrides
+)
+    local inventorySummary = overrides and overrides.InventorySummary
+        or self.InventoryService:getSummary(player)
+    local shouldCountInventory = countInventory ~= false
+    local lootItemCount = shouldCountInventory
+            and (overrides and overrides.LootItemCount or inventorySummary.LootCount or 0)
+        or 0
+    local clueCount = shouldCountInventory
+            and (overrides and overrides.ClueCount or inventorySummary.ClueCount or 0)
+        or 0
+    local toolCount = shouldCountInventory
+            and (overrides and overrides.ToolCount or inventorySummary.ToolCount or 0)
+        or 0
+    local missionCount = shouldCountInventory
+            and (overrides and overrides.MissionCount or inventorySummary.MissionCount or lootItemCount)
+        or 0
 
     return CampMazeSessionContract.buildReturnSummary({
         UserId = player.UserId,
         Name = player.DisplayName,
         ReturnReason = returnReason,
-        Value = inventorySummary.Value,
-        ItemCount = inventorySummary.Count,
-        Weight = inventorySummary.Weight,
-        WasExtracted = returnReason == 'extracted' or returnReason == 'settled',
+        Value = 0,
+        ItemCount = shouldCountInventory and (lootItemCount + clueCount + toolCount) or 0,
+        Weight = 0,
         WasSettled = wasSettled == true,
+        CountedInSettlement = shouldCountInventory,
+        LootItemCount = lootItemCount,
+        ClueCount = clueCount,
+        ToolCount = toolCount,
+        MissionCount = missionCount,
     })
 end
 
-function MazeSessionService:_buildPlayerInventories(players)
+function MazeSessionService:_buildPlayerInventories(players, countInventory)
     local playerInventories = {}
+    local shouldCountInventory = countInventory ~= false
 
     for _, player in ipairs(players) do
         table.insert(playerInventories, {
             UserId = player.UserId,
-            Inventory = self.InventoryService:getSummary(player),
+            Inventory = if shouldCountInventory
+                then self.InventoryService:getSummary(player)
+                else {
+                    Capacity = self.SessionData.InventoryCapacity,
+                    Weight = 0,
+                    Count = 0,
+                    BackpackCount = 0,
+                    HeldCount = 0,
+                    Value = 0,
+                    BackpackItems = {},
+                    HeldItem = nil,
+                    LootCount = 0,
+                    ClueCount = 0,
+                    ToolCount = 0,
+                    MissionCount = 0,
+                },
         })
     end
 
     table.sort(playerInventories, function(left, right)
-        return left.UserId < right.UserId
+        return left.UserId &lt; right.UserId
     end)
 
     return playerInventories
+end
+
+function MazeSessionService:_bankMissionLootForPlayer(player)
+    local inventorySummary = self.InventoryService:getSummary(player)
+    local _, bankedCount = self.InventoryService:extractMissionCargo(player)
+    if bankedCount &gt; 0 then
+        self.CampSession = CampMazeSessionContract.recordBankedItems(self.CampSession, bankedCount)
+    end
+
+    return inventorySummary, bankedCount
 end
 
 function MazeSessionService:_canReturnToCamp()
     return SessionConfig.PlaceIds.Run ~= 0 and self.CampSession.CampAccessCode ~= 'local-debug-camp'
 end
 
-function MazeSessionService:_teleportToCamp(players, summaries, mazeCompleted)
+function MazeSessionService:_teleportToCamp(players, summaries, mazeCompleted, countInventory)
     return runWithCampSessionLock(self, function()
         if not self:_canReturnToCamp() then
             self:_setStatus(
@@ -13565,7 +17115,7 @@ function MazeSessionService:_teleportToCamp(players, summaries, mazeCompleted)
             CampSession = self.CampSession,
             Summaries = mergedSummaries,
             MazeCompleted = mazeCompleted,
-            PlayerInventories = self:_buildPlayerInventories(players),
+            PlayerInventories = self:_buildPlayerInventories(players, countInventory),
         })
         if not result.Ok then
             self:_setStatus(string.format('Camp return failed: %s', tostring(result.Reason)))
@@ -13575,6 +17125,48 @@ function MazeSessionService:_teleportToCamp(players, summaries, mazeCompleted)
         self.CampSession = result.NextCampSession
         return true
     end)
+end
+
+function MazeSessionService:_forceCloseToCamp(reason, countInventories)
+    local playersToReturn = {}
+    local summaries = {}
+
+    for _, player in ipairs(Players:GetPlayers()) do
+        if self.RunTracker:isPlayerActive(player.UserId) then
+            table.insert(playersToReturn, player)
+            if self:_isPlayerDead(player) then
+                table.insert(
+                    summaries,
+                    self.DeathSummaryByUserId[player.UserId]
+                        or self:_buildSummaryFor(player, 'death', false, false)
+                )
+            else
+                local inventorySummary, bankedCount = self:_bankMissionLootForPlayer(player)
+                table.insert(
+                    summaries,
+                    self:_buildSummaryFor(player, reason or 'settled', true, countInventories, {
+                        InventorySummary = inventorySummary,
+                        LootItemCount = bankedCount,
+                        MissionCount = bankedCount,
+                    })
+                )
+            end
+        end
+    end
+
+    if #playersToReturn == 0 then
+        return
+    end
+
+    self.MonsterService:destroy()
+    self:_publishMazePresence()
+
+    if self:_teleportToCamp(playersToReturn, summaries, true, countInventories) then
+        self:_setStatus('The shared round ended from camp. Maze survivors are being returned now.')
+        return
+    end
+
+    self:_setStatus('The shared round ended, but the forced return to camp failed.')
 end
 
 function MazeSessionService:_beginFormalExpedition()
@@ -13590,8 +17182,7 @@ function MazeSessionService:_beginFormalExpedition()
     local patrolPoints, initialPatrolIndex = self.World:getPatrolPoints()
     self:_setBootPhase('SpawnMonster')
     self.MonsterService:spawn(patrolPoints, initialPatrolIndex)
-    self:_spawnQueuedUgcMonsters()
-    self:_setStatus('Maze session is live. Explore, loot, and find an extraction point.')
+    self:_setStatus('Maze session is live. Explore, loot, and find a return point.')
 end
 
 function MazeSessionService:_canManageInventory(player)
@@ -13601,6 +17192,13 @@ function MazeSessionService:_canManageInventory(player)
                 '%s already returned and cannot change inventory state.',
                 player.DisplayName
             )
+        )
+        return false
+    end
+
+    if self:_isPlayerDead(player) then
+        self:_setStatus(
+            string.format('%s is dead for this round and cannot use inventory.', player.DisplayName)
         )
         return false
     end
@@ -13678,102 +17276,20 @@ end
 
 -- === 新增：处理道具使用的逻辑（这是本次手术最核心的部位） ===
 function MazeSessionService:_handleUseTool(player)
-    if not self:_canManageInventory(player) then
-        return
-    end
-
-    local playerState = self.PlayerService:getSummary(player).PlayerState
-    if playerState.IsDead == true then
-        self:_setStatus(string.format('%s cannot use tools while dead.', player.DisplayName))
-        return
-    end
-
-    -- 1. 检查手里有没有拿东西
-    local inventorySummary = self.InventoryService:getSummary(player)
-    local heldItem = inventorySummary and inventorySummary.HeldItem
-
-    if not heldItem then
-        self:_setStatus(
-            string.format('%s tried to use a tool, but hands are empty.', player.DisplayName)
-        )
-        return
-    end
-
-    -- 2. 检查这东西有没有“状态/耐久”
-    if not heldItem.CurrentState or not heldItem.ConsumePerUse then
-        self:_setStatus(
-            string.format(
-                '%s cannot actively "use" %s (it is not a tool).',
-                player.DisplayName,
-                heldItem.Name
-            )
-        )
-        return
-    end
-
-    -- 3. 检查有没有没电/报废
-    if heldItem.CurrentState < heldItem.ConsumePerUse then
-        self:_setStatus(
-            string.format(
-                '%s tried to use %s, but it has no %s left.',
-                player.DisplayName,
-                heldItem.Name,
-                heldItem.StateModel or 'power'
-            )
-        )
-        return
-    end
-
-    -- 4. 真正“使用”它：扣除耐久并同步到实际背包状态
-    local consumeSuccess, consumeResult, cooldownRemaining =
-        self.InventoryService:consumeHeldItemState(player, os.clock())
-    if not consumeSuccess then
-        if consumeResult == 'Cooldown' then
-            self:_setStatus(
-                string.format(
-                    '%s cannot use %s yet (cooldown %.1fs remaining).',
-                    player.DisplayName,
-                    heldItem.Name,
-                    math.max(cooldownRemaining or 0, 0)
-                )
-            )
-        else
-            self:_setStatus(
-                string.format(
-                    '%s could not use %s (%s).',
-                    player.DisplayName,
-                    heldItem.Name,
-                    tostring(consumeResult)
-                )
-            )
-        end
-        return
-    end
-
-    local updatedHeldItem = consumeResult
-
-    local actionWord = 'used'
-    local effectText = 'It worked!'
-
-    if updatedHeldItem.ToolCategory == 'Flashlight' then
-        actionWord = 'flashed'
-        effectText = 'The area is illuminated.'
-    elseif updatedHeldItem.ToolCategory == 'Crowbar' then
-        actionWord = 'swung'
-        effectText = 'A satisfying swoosh cuts the air!'
-    end
-
-    self:_setStatus(
-        string.format(
-            '%s %s the %s. %s (%s remaining: %d)',
-            player.DisplayName,
-            actionWord,
-            updatedHeldItem.Name,
-            effectText,
-            updatedHeldItem.StateModel or 'state',
-            updatedHeldItem.CurrentState
-        )
-    )
+    Gameplay.HeldToolUseRequest.apply(player, {
+        canManageInventory = function(p)
+            return self:_canManageInventory(p)
+        end,
+        inventoryService = self.InventoryService,
+        monsterService = self.MonsterService,
+        playerService = self.PlayerService,
+        setStatus = function(message)
+            self:_setStatus(message)
+        end,
+        shouldConsumeCrowbarOnUse = function(_p)
+            return self.RunTracker:getState() == 'Expedition'
+        end,
+    })
 end
 -- =======================================================
 
@@ -13809,46 +17325,33 @@ function MazeSessionService:_completeExpeditionIfNoActivePlayers()
     end
 
     self.MonsterService:destroy()
-    self:_destroyUgcMonsters()
-    table.clear(self.PendingUgcMonsterPayloads)
     return true
 end
 
 function MazeSessionService:_handlePlayerDeath(player, damageKind)
     self:_spawnCorpseForPlayer(player)
-    self:_syncPlayerMovement(player)
+    self:_clearPlayerMovement(player)
 
-    local summary = self:_buildSummaryFor(player, 'death', false)
-    local recorded = self.RunTracker:recordReturn(summary)
-    if not recorded then
-        return
-    end
-
-    local mazeCompleted, completionReason = self:_completeExpeditionIfNoActivePlayers()
-    if mazeCompleted == nil then
-        self:_setStatus(string.format('Maze completion failed: %s', tostring(completionReason)))
-        return
-    end
-
-    if self:_teleportToCamp({ player }, { summary }, mazeCompleted) then
-        self:_setStatus(
-            string.format(
-                '%s took %s damage and was returned to camp.',
-                player.DisplayName,
-                string.lower(damageKind)
-            )
-        )
-        return
-    end
-
+    local droppedEntries = self.InventoryService:dropAllItems(player)
     local character = player.Character
+    local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+    local dropPosition = rootPart and rootPart.Position or self.World.ReturnHoldCFrame.Position
+    self:_createPersistentDropNode(
+        droppedEntries,
+        dropPosition,
+        string.format('%s Pack', player.DisplayName)
+    )
+
+    self.DeathSummaryByUserId[player.UserId] = self:_buildSummaryFor(player, 'death', false, false)
+    self:_publishMazePresence()
+
     if character and character.Parent and self.World then
         character:PivotTo(self.World.ReturnHoldCFrame)
     end
 
     self:_setStatus(
         string.format(
-            '%s took %s damage and died, leaving a corpse behind.',
+            '%s took %s damage and died, dropping their pack in the maze.',
             player.DisplayName,
             string.lower(damageKind)
         )
@@ -13927,19 +17430,20 @@ function MazeSessionService:_pickupLoot(player, roomId)
     end
 
     lootEntry:markCollected()
+    self:_markLootCollected(roomId)
 
     local inventorySummary = self.InventoryService:getSummary(player)
     self:_setStatus(
         string.format(
-            '%s collected %s. Inventory value now %d.',
+            '%s collected %s. They are now carrying %d loot item(s).',
             player.DisplayName,
             lootEntry.ItemDef.Name,
-            inventorySummary.Value
+            inventorySummary.LootCount or 0
         )
     )
 end
 
-function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason, _interactionId)
+function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason)
     if self.RunTracker:getState() ~= 'Expedition' then
         self:_setStatus('Return markers are only available during the expedition phase.')
         return
@@ -13947,17 +17451,29 @@ function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason, _in
 
     if not self.RunTracker:isPlayerActive(player.UserId) then
         self:_setStatus(
-            string.format('%s already returned to the run maze gate.', player.DisplayName)
+            string.format('%s already returned to the run return point.', player.DisplayName)
         )
         return
     end
 
-    local summary = self:_buildSummaryFor(player, returnReason, false)
+    if self:_isPlayerDead(player) then
+        self:_setStatus(
+            string.format('%s is dead and must wait for the round to end.', player.DisplayName)
+        )
+        return
+    end
+
+    local inventorySummary, bankedCount = self:_bankMissionLootForPlayer(player)
+    local summary = self:_buildSummaryFor(player, returnReason, false, true, {
+        InventorySummary = inventorySummary,
+        LootItemCount = bankedCount,
+        MissionCount = bankedCount,
+    })
     local recorded, reason = self.RunTracker:recordReturn(summary)
     if not recorded then
         if reason == 'MissingActivePlayer' then
             self:_setStatus(
-                string.format('%s already returned to the run maze gate.', player.DisplayName)
+                string.format('%s already returned to the run return point.', player.DisplayName)
             )
         end
         return
@@ -13971,12 +17487,14 @@ function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason, _in
 
     self:_clearPlayerMovement(player)
 
-    if self:_teleportToCamp({ player }, { summary }, mazeCompleted) then
+    self:_publishMazePresence()
+
+    if self:_teleportToCamp({ player }, { summary }, mazeCompleted, true) then
         self:_setStatus(
             string.format(
-                '%s returned to the run maze gate with %d value (%s).',
+                '%s returned to run with %d banked loot item(s) (%s).',
                 player.DisplayName,
-                summary.Value,
+                bankedCount,
                 summary.ReturnReason
             )
         )
@@ -13990,9 +17508,9 @@ function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason, _in
 
     self:_setStatus(
         string.format(
-            '%s reached a return marker with %d value, but the handoff back to run failed.',
+            '%s reached the return point with %d banked loot item(s), but the handoff back to run failed.',
             player.DisplayName,
-            summary.Value
+            bankedCount
         )
     )
 end
@@ -14016,6 +17534,7 @@ function MazeSessionService:_launchMaze()
 
     self:_rebuildWorld()
     self:_emitDiagnostic('LaunchMazePostBuild', self:_getWorldBuildMetadataFields())
+    self:_subscribeToRoundSignals()
 
     self:_setBootPhase('LoadCharacters')
     for _, player in ipairs(Players:GetPlayers()) do
@@ -14062,6 +17581,26 @@ function MazeSessionService:_startSnapshotLoop()
                     local context = self:_getPlayerUpdateContext(player)
                     self.PlayerService:update(player, dt, context)
                     self:_syncPlayerMovement(player)
+                end
+
+                if not self.RoundClosureInProgress then
+                    local roundEndTime = self.CampSession.RoundEndTime
+                    if
+                        type(roundEndTime) == 'number'
+                        and roundEndTime &gt; 0
+                        and self:_getServerTimeNow() &gt;= roundEndTime
+                    then
+                        self.RoundClosureInProgress = true
+                        self.CampSession =
+                            CampMazeSessionContract.markSettlementTriggered(self.CampSession, {
+                                SettlementReason = 'timeout',
+                            })
+                        self.CampSession.GateOpen = false
+                        self.CampSession.RoundStarted = false
+                        self.CampSession =
+                            CampMazeSessionContract.normalizeCampSession(self.CampSession)
+                        self:_forceCloseToCamp('timeout', true)
+                    end
                 end
 
                 self:_broadcastSnapshot()
@@ -14159,13 +17698,13 @@ function MazeSessionService:start()
 end
 
 return MazeSessionService
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="111">
-        <Properties>
-          <string name="Name">MazeSpawnPoint</string>
-          <string name="Source"><![CDATA[local MazeSpawnPoint = {}
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="164">
+          <Properties>
+            <string name="Name">MazeSpawnPoint</string>
+            <string name="Source">local MazeSpawnPoint = {}
 MazeSpawnPoint.__index = MazeSpawnPoint
 
 MazeSpawnPoint.Kind = table.freeze({
@@ -14185,13 +17724,305 @@ function MazeSpawnPoint:getCFrame()
 end
 
 return MazeSpawnPoint
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="112">
-        <Properties>
-          <string name="Name">MazeToRunTransition</string>
-          <string name="Source"><![CDATA[local ReplicatedStorage = game:GetService('ReplicatedStorage')
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="165">
+          <Properties>
+            <string name="Name">MazeStaticWorldAssembler</string>
+            <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local Workspace = game:GetService('Workspace')
+
+local MazeChunkManifest = require(script.Parent.MazeChunkManifest)
+local MazeStaticWorldContract = require(script.Parent.MazeStaticWorldContract)
+local MazeStaticWorldOverlayManifest = require(script.Parent.MazeStaticWorldOverlayManifest)
+
+local MazeStaticWorldAssembler = {}
+
+local function requireFolder(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not child:IsA('Folder') then
+        error(string.format('%s is missing required Folder "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function requireAsset(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not (child:IsA('Folder') or child:IsA('Model')) then
+        error(string.format('%s is missing required asset "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function requireBasePart(parent, name, contextLabel)
+    local child = parent:FindFirstChild(name)
+    if child == nil or not child:IsA('BasePart') then
+        error(string.format('%s is missing required part "%s".', contextLabel, name), 0)
+    end
+
+    return child
+end
+
+local function requirePrompt(part, contextLabel)
+    local prompt = part:FindFirstChildOfClass('ProximityPrompt')
+    if prompt == nil then
+        error(
+            string.format('%s part "%s" is missing a ProximityPrompt.', contextLabel, part.Name),
+            0
+        )
+    end
+
+    return prompt
+end
+
+local function getMazeAssets()
+    local assetsRoot = requireFolder(
+        ReplicatedStorage,
+        MazeStaticWorldContract.AssetsRootName,
+        'ReplicatedStorage'
+    )
+    local mazeAssets = requireFolder(
+        assetsRoot,
+        MazeStaticWorldContract.MazeAssetsFolderName,
+        'ReplicatedStorage.Assets'
+    )
+    local chunkAssets = requireFolder(
+        mazeAssets,
+        MazeStaticWorldContract.ChunksFolderName,
+        'ReplicatedStorage.Assets.Maze'
+    )
+    local overlayAssets = requireFolder(
+        mazeAssets,
+        MazeStaticWorldContract.OverlaysFolderName,
+        'ReplicatedStorage.Assets.Maze'
+    )
+
+    return chunkAssets, overlayAssets
+end
+
+local function createRoot()
+    local existing = Workspace:FindFirstChild(MazeStaticWorldContract.RootName)
+    if existing ~= nil then
+        existing:Destroy()
+    end
+
+    local root = Instance.new('Folder')
+    root.Name = MazeStaticWorldContract.RootName
+    root.Parent = Workspace
+    root:SetAttribute('BuildFingerprint', MazeStaticWorldContract.BuildFingerprint)
+
+    local sceneryRoot = Instance.new('Folder')
+    sceneryRoot.Name = MazeStaticWorldContract.SceneryFolderName
+    sceneryRoot.Parent = root
+
+    return root, sceneryRoot
+end
+
+local function stabilizeChunkGeometry(chunkModel)
+    for _, descendant in ipairs(chunkModel:GetDescendants()) do
+        if descendant:IsA('BasePart') then
+            descendant.Anchored = true
+            descendant.CanTouch = false
+            descendant.CanQuery = true
+            descendant:SetAttribute('IsScenery', true)
+        end
+    end
+end
+
+local function cloneChunkAsset(chunkAsset, chunkDefinition, sceneryRoot)
+    if not chunkAsset:IsA('Model') then
+        error(
+            string.format(
+                'Maze chunk asset "%s" must be authored as a Model.',
+                chunkDefinition.AssetName
+            ),
+            0
+        )
+    end
+
+    local clone = chunkAsset:Clone()
+    clone.Name = chunkDefinition.ChunkId
+    clone.Parent = sceneryRoot
+    stabilizeChunkGeometry(clone)
+    if chunkDefinition.Transform ~= nil then
+        clone:PivotTo(chunkDefinition.Transform)
+    end
+end
+
+local function applyRoomAttributes(room, definition)
+    for attributeName, attributeValue in pairs(definition) do
+        room:SetAttribute(attributeName, attributeValue)
+    end
+end
+
+local function cloneOverlayAsset(overlayAsset, root)
+    for _, child in ipairs(overlayAsset:GetChildren()) do
+        local clone = child:Clone()
+        clone.Parent = root
+    end
+
+    for _, partName in ipairs(MazeStaticWorldOverlayManifest.RootParts) do
+        requireBasePart(root, partName, 'Maze static world overlay')
+    end
+
+    requirePrompt(
+        requireBasePart(root, 'ReturnHoldPad', 'Maze static world overlay'),
+        'Maze static world overlay'
+    )
+
+    for roomName, definition in pairs(MazeStaticWorldOverlayManifest.Rooms) do
+        local room = root:FindFirstChild(roomName)
+        if room == nil or not room:IsA('Model') then
+            error(
+                string.format(
+                    'Maze static world overlay is missing required room model "%s".',
+                    roomName
+                ),
+                0
+            )
+        end
+
+        applyRoomAttributes(room, definition)
+    end
+
+    local lootRoom = root:FindFirstChild('Room_Loot')
+    if lootRoom == nil then
+        error('Maze static world overlay must define Room_Loot.', 0)
+    end
+
+    for _, nodeName in ipairs(MazeStaticWorldOverlayManifest.RequiredInteractionNodes) do
+        local node = root:FindFirstChild(nodeName, true)
+        if node == nil then
+            error(
+                string.format(
+                    'Maze static world overlay is missing required interaction node "%s".',
+                    nodeName
+                ),
+                0
+            )
+        end
+    end
+
+    -- MazeWorldScanner only binds gameplay nodes that are direct room children,
+    -- so the overlay authoring contract keeps these prompt parts at that level.
+    requirePrompt(
+        requireBasePart(lootRoom, 'LootPrompt', 'Maze static world overlay'),
+        'Maze static world overlay'
+    )
+    requirePrompt(
+        requireBasePart(lootRoom, 'Doorway_East', 'Maze static world overlay'),
+        'Maze static world overlay'
+    )
+end
+
+function MazeStaticWorldAssembler.assemble()
+    local chunkAssets, overlayAssets = getMazeAssets()
+    local root, sceneryRoot = createRoot()
+
+    local overlayAsset = requireAsset(
+        overlayAssets,
+        MazeStaticWorldContract.OverlayAssetName,
+        'ReplicatedStorage.Assets.Maze.Overlays'
+    )
+    cloneOverlayAsset(overlayAsset, root)
+
+    local enabledChunkCount = 0
+    for _, chunkDefinition in ipairs(MazeChunkManifest) do
+        if chunkDefinition.Enabled ~= false then
+            local chunkAsset = requireAsset(
+                chunkAssets,
+                chunkDefinition.AssetName,
+                'ReplicatedStorage.Assets.Maze.Chunks'
+            )
+            cloneChunkAsset(chunkAsset, chunkDefinition, sceneryRoot)
+            enabledChunkCount += 1
+        end
+    end
+
+    if enabledChunkCount == 0 then
+        error('Maze chunk manifest must enable at least one geometry chunk.', 0)
+    end
+
+    return root
+end
+
+return MazeStaticWorldAssembler
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="166">
+          <Properties>
+            <string name="Name">MazeStaticWorldContract</string>
+            <string name="Source">local MazeStaticWorldContract = table.freeze({
+    RootName = 'MazeStaticWorld',
+    AssetsRootName = 'Assets',
+    MazeAssetsFolderName = 'Maze',
+    ChunksFolderName = 'Chunks',
+    OverlaysFolderName = 'Overlays',
+    SceneryFolderName = 'Scenery',
+    OverlayAssetName = 'MazeStaticWorldOverlay_Default',
+    BuildFingerprint = 'maze-static-chunk-v1',
+})
+
+return MazeStaticWorldContract
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="167">
+          <Properties>
+            <string name="Name">MazeStaticWorldOverlayManifest</string>
+            <string name="Source">local function freezeRoomDefinition(definition)
+    return table.freeze({
+        RoomType = definition.RoomType,
+        IsCamp = definition.IsCamp or false,
+        DifficultyTier = definition.DifficultyTier or 1,
+        MonsterBudget = definition.MonsterBudget or 0,
+        LootBudget = definition.LootBudget or 0,
+        RoomTemplateId = definition.RoomTemplateId or definition.RoomType,
+        RoomCategory = definition.RoomCategory or definition.RoomType,
+    })
+end
+
+local MazeStaticWorldOverlayManifest = table.freeze({
+    RootParts = table.freeze({
+        'SpawnMarker',
+        'ReturnHoldPad',
+    }),
+    Rooms = table.freeze({
+        Room_Camp = freezeRoomDefinition({
+            RoomType = 'OpenHub',
+            IsCamp = true,
+            DifficultyTier = 0,
+            RoomTemplateId = 'CampHub',
+            RoomCategory = 'CampHub',
+        }),
+        Room_Loot = freezeRoomDefinition({
+            RoomType = 'DeadEnd',
+            DifficultyTier = 2,
+            MonsterBudget = 2,
+            LootBudget = 1,
+            RoomTemplateId = 'SearchCluster',
+            RoomCategory = 'SearchCluster',
+        }),
+    }),
+    RequiredInteractionNodes = table.freeze({
+        'LootPrompt',
+        'LootSocket_1',
+        'Doorway_East',
+    }),
+})
+
+return MazeStaticWorldOverlayManifest
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="168">
+          <Properties>
+            <string name="Name">MazeToRunTransition</string>
+            <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 local TeleportService = game:GetService('TeleportService')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
@@ -14262,29 +18093,24 @@ function MazeToRunTransition:returnPlayers(params)
 end
 
 return MazeToRunTransition
-]]></string>
-        </Properties>
-      </Item>
-      <Item class="ModuleScript" referent="113">
-        <Properties>
-          <string name="Name">MazeWorldBuilder</string>
-          <string name="Source"><![CDATA[local Workspace = game:GetService('Workspace')
-
-local ReplicatedStorage = game:GetService('ReplicatedStorage')
+</string>
+          </Properties>
+        </Item>
+        <Item class="ModuleScript" referent="169">
+          <Properties>
+            <string name="Name">MazeWorldBuilder</string>
+            <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
 local Shared = require(Packages:WaitForChild('Shared'))
 
 local MazeScene = require(script.Parent.MazeScene)
+local MazeStaticWorldAssembler = require(script.Parent.MazeStaticWorldAssembler)
 
 local MazeWorldBuilder = {}
-local STATIC_WORLD_ROOT_NAME = 'MazeStaticWorld'
 
 function MazeWorldBuilder.build()
-    local staticWorldRoot = Workspace:FindFirstChild(STATIC_WORLD_ROOT_NAME)
-    if staticWorldRoot == nil then
-        error('Workspace is missing required authored root "MazeStaticWorld".', 0)
-    end
+    local staticWorldRoot = MazeStaticWorldAssembler.assemble()
 
     if not (staticWorldRoot:IsA('Folder') or staticWorldRoot:IsA('Model')) then
         error('MazeStaticWorld must be a Folder or Model.', 0)
@@ -14294,12 +18120,1963 @@ function MazeWorldBuilder.build()
 end
 
 return MazeWorldBuilder
-]]></string>
-        </Properties>
+</string>
+          </Properties>
+        </Item>
       </Item>
     </Item>
   </Item>
-  <Item class="StarterPlayer" referent="114">
+  <Item class="ServerScriptService" referent="170">
+    <Properties>
+      <string name="Name">ServerScriptService</string>
+    </Properties>
+    <Item class="Script" referent="171">
+      <Properties>
+        <string name="Name">Bootstrap</string>
+        <token name="RunContext">0</token>
+        <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+local PlaceModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+
+local MazeBootstrapStatus = require(PlaceModules:WaitForChild('MazeBootstrapStatus'))
+local Remotes =
+    require(Packages:WaitForChild('Shared'):WaitForChild('Network'):WaitForChild('Remotes'))
+local MazeContentHarnessService = require(script.Parent:WaitForChild('MazeContentHarnessService'))
+local MazeContentLightingService = require(script.Parent:WaitForChild('MazeContentLightingService'))
+
+MazeBootstrapStatus.set('BootstrapScriptLoaded', nil)
+
+task.defer(function()
+    local mazeService
+
+    local ok, err = pcall(function()
+        MazeBootstrapStatus.set('RequirePackages', nil)
+        MazeBootstrapStatus.set('EnsureRemotes', nil)
+        Remotes.ensureScope(Remotes.Scope.Maze)
+
+        MazeBootstrapStatus.set('RequireLightingService', nil)
+        local lightingService = MazeContentLightingService.new()
+
+        MazeBootstrapStatus.set('RequireSessionService', nil)
+        mazeService = MazeContentHarnessService.new()
+
+        MazeBootstrapStatus.set('StartLightingService', nil)
+        local lightingResult = lightingService:start()
+        if lightingResult and lightingResult.SurfacePalette then
+            mazeService:setSurfacePalette(lightingResult.SurfacePalette)
+        end
+
+        MazeBootstrapStatus.set('StartSessionService', nil)
+        mazeService:start()
+    end)
+
+    if not ok then
+        local phase = mazeService and mazeService.BootPhase or 'BootstrapFailed'
+        MazeBootstrapStatus.set(phase, tostring(err))
+        warn(
+            string.format(
+                '[MazeBoot] bootstrap failed at phase=%s error=%s',
+                tostring(phase),
+                tostring(err)
+            )
+        )
+    end
+end)
+</string>
+      </Properties>
+    </Item>
+    <Item class="ModuleScript" referent="172">
+      <Properties>
+        <string name="Name">MazeContentHarnessService</string>
+        <string name="Source">local Players = game:GetService('Players')
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local RunService = game:GetService('RunService')
+local Workspace = game:GetService('Workspace')
+
+local DEFAULT_WORKSPACE_SHELL_NAMES = { 'Baseplate', 'SpawnLocation' }
+local SNAPSHOT_INTERVAL_SECONDS = 0.25
+local CORPSE_COLOR = Color3.fromRGB(92, 92, 92)
+local CORPSE_MATERIAL = Enum.Material.Slate
+local CORPSE_SIZE = Vector3.new(4, 1.2, 2)
+local CORPSE_VERTICAL_OFFSET = -2.4
+local MAZE_DIAG_PREFIX = '[MazeDiag]'
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local PlaceModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
+local SharedPackage = Packages:WaitForChild('Shared')
+local GameplayPackage = Packages:WaitForChild('Gameplay')
+
+local SessionConfig = require(SharedPackage:WaitForChild('Config'):WaitForChild('SessionConfig'))
+local Remotes = require(SharedPackage:WaitForChild('Network'):WaitForChild('Remotes'))
+local InventoryService =
+    require(SharedPackage:WaitForChild('Runtime'):WaitForChild('InventoryService'))
+local MonsterService = require(SharedPackage:WaitForChild('Runtime'):WaitForChild('MonsterService'))
+local ControlStateService =
+    require(SharedPackage:WaitForChild('Runtime'):WaitForChild('ControlStateService'))
+local FormalLocomotion =
+    require(SharedPackage:WaitForChild('Runtime'):WaitForChild('FormalLocomotion'))
+local HeldFlashlightHeadlight =
+    require(SharedPackage:WaitForChild('Runtime'):WaitForChild('HeldFlashlightHeadlight'))
+local MazeLightingProfile =
+    require(SharedPackage:WaitForChild('Runtime'):WaitForChild('MazeLightingProfile'))
+local PlayerService = require(SharedPackage:WaitForChild('Runtime'):WaitForChild('PlayerService'))
+local PlayerStateService =
+    require(SharedPackage:WaitForChild('Runtime'):WaitForChild('PlayerStateService'))
+
+local PlayerState = require(GameplayPackage:WaitForChild('PlayerState'))
+local MonstersConfig = require(GameplayPackage:WaitForChild('Config'):WaitForChild('Monsters'))
+local ToolItems = require(GameplayPackage:WaitForChild('Config'):WaitForChild('ToolItems'))
+local MonsterCompiler =
+    require(GameplayPackage:WaitForChild('Monsters'):WaitForChild('MonsterCompiler'))
+
+local MazeBootstrapStatus = require(PlaceModules:WaitForChild('MazeBootstrapStatus'))
+
+local MazeContentSessionState = require(script.Parent:WaitForChild('MazeContentSessionState'))
+local MazeContentWorldBuilder = require(script.Parent:WaitForChild('MazeContentWorldBuilder'))
+
+local DEBUG_DAMAGE_BY_ACTION = {
+    RequestDebugLightDamage = PlayerState.DamageKind.Light,
+    RequestDebugHeavyDamage = PlayerState.DamageKind.Heavy,
+}
+local DAMAGE_KIND_BY_PIPS = table.freeze({
+    [1] = PlayerState.DamageKind.Light,
+    [2] = PlayerState.DamageKind.Heavy,
+})
+
+local MazeContentHarnessService = {}
+MazeContentHarnessService.__index = MazeContentHarnessService
+MazeContentHarnessService.BootstrapPhaseAttribute = MazeBootstrapStatus.PhaseAttribute
+MazeContentHarnessService.BootstrapErrorAttribute = MazeBootstrapStatus.ErrorAttribute
+MazeContentHarnessService.BootstrapFailedAttribute = MazeBootstrapStatus.FailedAttribute
+
+local function clearDefaultWorkspaceShell()
+    for _, instanceName in ipairs(DEFAULT_WORKSPACE_SHELL_NAMES) do
+        local instance = Workspace:FindFirstChild(instanceName)
+        if instance then
+            instance:Destroy()
+        end
+    end
+end
+
+local function buildMazeMonsterRuntimeProfile(monsterAuthorProfile)
+    local compiledOk, runtimeProfileOrReason =
+        MonsterCompiler.compileMonsterForMaze(monsterAuthorProfile)
+    if not compiledOk then
+        error(
+            string.format(
+                'Failed to compile maze monster %s: %s',
+                tostring(monsterAuthorProfile and monsterAuthorProfile.Id),
+                tostring(runtimeProfileOrReason)
+            ),
+            0
+        )
+    end
+
+    return runtimeProfileOrReason
+end
+
+local function crowbarMeleeMissText(reason)
+    local code = if type(reason) == 'string' then reason else nil
+    if code == 'ExpeditionInactive' then
+        return '现在还没进入狩猎状态 - 迷宫主循环还没开始。'
+    elseif code == 'NoMonster' then
+        return '现在场上没有可命中的怪物。'
+    elseif code == 'MissingMonsterPosition' then
+        return '怪物位置还没稳定，稍后再试。'
+    elseif code == 'OutOfRange' then
+        return '这一下挥空了，靠近一点再试。'
+    elseif code == 'OutOfSwingArc' then
+        return '你得朝着怪物挥，才会命中。'
+    elseif code == 'PathBlocked' then
+        return '有障碍物挡住了这次挥击。'
+    elseif code == 'BlockedLineOfSight' then
+        return '你得看得到怪物，才能打中。'
+    elseif code == 'InvalidFacing' then
+        return '你当前朝向不对，没法挥击。'
+    elseif code == 'NoCharacter' or code == 'MissingHumanoidRoot' then
+        return '角色还没准备好，不能挥击。'
+    elseif code == 'MonsterCombatStateMissing' then
+        return '怪物现在还不能吃伤害。'
+    elseif code == 'InvalidPlayer' then
+        return '这次挥击没有成功生效。'
+    end
+
+    return string.format('撬棍挥空了（%s）。', tostring(reason))
+end
+
+local function formatDiagnosticValue(value)
+    if value == nil then
+        return 'nil'
+    end
+
+    return tostring(value)
+end
+
+local function buildDiagnosticFieldString(fields)
+    local keys = {}
+    for key in pairs(fields) do
+        table.insert(keys, key)
+    end
+    table.sort(keys)
+
+    local segments = {}
+    for _, key in ipairs(keys) do
+        table.insert(segments, string.format('%s=%s', key, formatDiagnosticValue(fields[key])))
+    end
+
+    return table.concat(segments, ' | ')
+end
+
+local function damageKindFromPips(damagePips)
+    return DAMAGE_KIND_BY_PIPS[damagePips]
+end
+
+local function localizeDamageKind(damageKind)
+    local labels = {
+        Light = '轻伤',
+        Heavy = '重伤',
+    }
+    return labels[damageKind] or tostring(damageKind)
+end
+
+local function localizeReturnReason(reason)
+    local labels = {
+        returned = '已返回',
+        death = '死亡',
+        settled = '强制结算',
+        timeout = '超时',
+    }
+    return labels[reason] or tostring(reason)
+end
+
+function MazeContentHarnessService.new(options)
+    local runtimeOptions = options or {}
+    local self = setmetatable({}, MazeContentHarnessService)
+
+    self.Seed = runtimeOptions.Seed or SessionConfig.DefaultSeed
+    self.SessionState = runtimeOptions.SessionState or MazeContentSessionState.new(self.Seed)
+    self.Remotes = runtimeOptions.Remotes or Remotes.ensureScope(Remotes.Scope.Maze)
+    self.InventoryService = runtimeOptions.InventoryService
+        or InventoryService.new(SessionConfig.InventoryCapacity)
+    self.ControlStateService = runtimeOptions.ControlStateService or ControlStateService.new()
+    self.PlayerService = runtimeOptions.PlayerService or PlayerService.new()
+    self.PlayerStateService = runtimeOptions.PlayerStateService or PlayerStateService.new()
+    self.WorldBuilder = runtimeOptions.WorldBuilder or MazeContentWorldBuilder
+    self.GetPlayers = runtimeOptions.GetPlayers
+        or function()
+            return Players:GetPlayers()
+        end
+    self.LoadCharacter = runtimeOptions.LoadCharacter
+        or function(player)
+            player:LoadCharacter()
+        end
+    self.Status = self.SessionState.Status
+    self.World = nil
+    self.WorldInteractions = nil
+    self.SurfacePalette = runtimeOptions.SurfacePalette or MazeLightingProfile.SurfacePalette
+    self.SnapshotThread = nil
+    self.IsLaunched = false
+    self.DiagnosticSequence = 0
+    self.DynamicDropNodesById = {}
+    self.NextDynamicDropNodeId = 1
+    self.CorpsesByUserId = {}
+    self.WorldBuildMetadata = nil
+    self.BootPhase = 'New'
+    self.MonsterServiceFactory = runtimeOptions.MonsterServiceFactory
+        or function(
+            monsterRuntimeProfile,
+            isExpeditionActive,
+            canTargetPlayer,
+            canTraverse,
+            monsterOptions
+        )
+            return MonsterService.new(
+                monsterRuntimeProfile,
+                isExpeditionActive,
+                canTargetPlayer,
+                canTraverse,
+                monsterOptions
+            )
+        end
+
+    local monsterAuthorProfile = runtimeOptions.MonsterAuthorProfile or MonstersConfig[1]
+    if type(monsterAuthorProfile) ~= 'table' then
+        error('迷宫内容测试场需要一个默认怪物配置。', 0)
+    end
+
+    self.MonsterService = self.MonsterServiceFactory(
+        buildMazeMonsterRuntimeProfile(monsterAuthorProfile),
+        function()
+            return self.SessionState.LoopState == 'Expedition'
+        end,
+        function(player)
+            return self.SessionState:isPlayerActive(player.UserId)
+        end,
+        function(fromPosition, toPosition)
+            if not self.World or not self.World.CanTraverseBetweenPositions then
+                return true
+            end
+
+            return self.World.CanTraverseBetweenPositions(fromPosition, toPosition)
+        end,
+        self:_buildMonsterRuntimeOptions(self.Seed)
+    )
+
+    self:_emitDiagnostic('InitDefaultState', {
+        InitialIsDirectBoot = self.SessionState.IsDirectBoot,
+        InitialMazeAccessCode = self.SessionState.MazeAccessCode,
+        InitialSeed = self.Seed,
+        InitialSessionId = self.SessionState.SessionId,
+    })
+
+    return self
+end
+
+function MazeContentHarnessService:_emitDiagnostic(event, fields)
+    self.DiagnosticSequence += 1
+    local prefix = string.format(
+        '%s #%03d t=%.3f event=%s',
+        MAZE_DIAG_PREFIX,
+        self.DiagnosticSequence,
+        os.clock(),
+        event
+    )
+    local fieldString = buildDiagnosticFieldString(fields or {})
+    if fieldString == '' then
+        print(prefix)
+        return
+    end
+
+    print(string.format('%s | %s', prefix, fieldString))
+end
+
+function MazeContentHarnessService:_setBootPhase(phase)
+    self.BootPhase = phase
+    MazeBootstrapStatus.set(phase, nil)
+    print(string.format('[MazeBoot] phase=%s', phase))
+end
+
+function MazeContentHarnessService:_setBootFailure(err)
+    MazeBootstrapStatus.set(self.BootPhase, tostring(err))
+    warn(
+        string.format(
+            '[MazeBoot] failure at phase=%s error=%s',
+            tostring(self.BootPhase),
+            tostring(err)
+        )
+    )
+end
+
+function MazeContentHarnessService:setSurfacePalette(surfacePalette)
+    if type(surfacePalette) ~= 'table' then
+        return
+    end
+
+    self.SurfacePalette = surfacePalette
+end
+
+function MazeContentHarnessService:_buildMonsterRuntimeOptions(randomSeed)
+    return {
+        RandomSeed = randomSeed,
+        OnAttackHit = function(player, damagePips, hitContext)
+            local damageKind = damageKindFromPips(damagePips)
+            if damageKind == nil then
+                return
+            end
+
+            self:_applyPlayerDamage(player, damageKind)
+            if hitContext and hitContext.Effects then
+                for _, effect in ipairs(hitContext.Effects) do
+                    self.PlayerStateService:applyEffect(player, effect.Id, effect.DurationSeconds)
+                end
+            end
+        end,
+    }
+end
+
+function MazeContentHarnessService:_getPersistentWorldState()
+    return self.SessionState:getPersistentWorldState()
+end
+
+function MazeContentHarnessService:_setPersistentWorldState(state)
+    self.SessionState:setPersistentWorldState(state)
+end
+
+function MazeContentHarnessService:_replaceDropNodeState(nextDropNodes)
+    local state = self:_getPersistentWorldState()
+    state.DropNodes = nextDropNodes
+    self:_setPersistentWorldState(state)
+end
+
+function MazeContentHarnessService:_markLootCollected(roomId)
+    local state = self:_getPersistentWorldState()
+    local collectedLootRoomIds = state.CollectedLootRoomIds or {}
+
+    for _, collectedRoomId in ipairs(collectedLootRoomIds) do
+        if collectedRoomId == roomId then
+            return
+        end
+    end
+
+    table.insert(collectedLootRoomIds, roomId)
+    table.sort(collectedLootRoomIds)
+    state.CollectedLootRoomIds = collectedLootRoomIds
+    self:_setPersistentWorldState(state)
+end
+
+function MazeContentHarnessService:_reserveDynamicDropNodeId()
+    local nextId = self.NextDynamicDropNodeId or 1
+    local state = self:_getPersistentWorldState()
+
+    for _, dropNodeState in ipairs(state.DropNodes or {}) do
+        local existingId =
+            tonumber(string.match(tostring(dropNodeState.DropNodeId or ''), '^DynamicDrop_(%d+)$'))
+        if existingId ~= nil and existingId &gt;= nextId then
+            nextId = existingId + 1
+        end
+    end
+
+    self.NextDynamicDropNodeId = nextId + 1
+    return string.format('DynamicDrop_%d', nextId)
+end
+
+function MazeContentHarnessService:_destroyDynamicDropNode(dropNodeId)
+    local dynamicNode = self.DynamicDropNodesById[dropNodeId]
+    if dynamicNode == nil then
+        return
+    end
+
+    if dynamicNode.Connection and dynamicNode.Connection.Disconnect then
+        dynamicNode.Connection:Disconnect()
+    end
+    if dynamicNode.Part and dynamicNode.Part.Parent then
+        dynamicNode.Part:Destroy()
+    end
+    self.DynamicDropNodesById[dropNodeId] = nil
+end
+
+function MazeContentHarnessService:_destroyDynamicDropNodes()
+    for dropNodeId in pairs(self.DynamicDropNodesById) do
+        self:_destroyDynamicDropNode(dropNodeId)
+    end
+end
+
+function MazeContentHarnessService:_dropNodePositionToVector3(position)
+    if typeof(position) == 'Vector3' then
+        return position
+    end
+
+    if type(position) == 'table' then
+        return Vector3.new(
+            position.X or position[1] or 0,
+            position.Y or position[2] or 0,
+            position.Z or position[3] or 0
+        )
+    end
+
+    return self.World and self.World.ReturnHoldCFrame.Position or Vector3.zero
+end
+
+function MazeContentHarnessService:_buildDropNodePart(dropNodeState)
+    local position = self:_dropNodePositionToVector3(dropNodeState.Position)
+    local part = Instance.new('Part')
+    part.Name = dropNodeState.DropNodeId
+    part.Anchored = true
+    part.CanCollide = false
+    part.Transparency = 0.15
+    part.Material = Enum.Material.Metal
+    part.Color = Color3.fromRGB(142, 236, 255)
+    part.Size = Vector3.new(2.5, 2.5, 2.5)
+    part.CFrame = CFrame.new(position + Vector3.new(0, 1.5, 0))
+    part.Parent = self.World.Root
+
+    local prompt = Instance.new('ProximityPrompt')
+    prompt.ActionText = 'Recover'
+    prompt.ObjectText = dropNodeState.Label or 'Dropped Pack'
+    prompt.MaxActivationDistance = 10
+    prompt.RequiresLineOfSight = false
+    prompt.Parent = part
+
+    return part, prompt
+end
+
+function MazeContentHarnessService:_spawnDynamicDropNode(dropNodeState)
+    if not (self.World and self.World.Root) then
+        return
+    end
+
+    local part, prompt = self:_buildDropNodePart(dropNodeState)
+    local connection = prompt.Triggered:Connect(function(player)
+        self:_pickupDropNode(player, dropNodeState.DropNodeId)
+    end)
+
+    self.DynamicDropNodesById[dropNodeState.DropNodeId] = {
+        Part = part,
+        Connection = connection,
+    }
+end
+
+function MazeContentHarnessService:_applyPersistentWorldStateToWorld()
+    local state = self:_getPersistentWorldState()
+
+    for _, roomId in ipairs(state.CollectedLootRoomIds or {}) do
+        local lootNode = self.World and self.World:getLootNode(roomId)
+        if lootNode and lootNode.Collected ~= true then
+            lootNode:markCollected()
+        end
+    end
+
+    self:_destroyDynamicDropNodes()
+    for _, dropNodeState in ipairs(state.DropNodes or {}) do
+        self:_spawnDynamicDropNode(dropNodeState)
+    end
+end
+
+function MazeContentHarnessService:_createPersistentDropNode(entries, position, label)
+    if entries == nil or #entries == 0 then
+        return
+    end
+
+    local state = self:_getPersistentWorldState()
+    local dropNodeId = self:_reserveDynamicDropNodeId()
+    local dropNodes = state.DropNodes or {}
+    table.insert(dropNodes, {
+        DropNodeId = dropNodeId,
+        Label = label,
+        Position = {
+            X = position.X,
+            Y = position.Y,
+            Z = position.Z,
+        },
+        Entries = entries,
+    })
+    state.DropNodes = dropNodes
+    self:_setPersistentWorldState(state)
+    self:_spawnDynamicDropNode(dropNodes[#dropNodes])
+end
+
+function MazeContentHarnessService:_pickupDropNode(player, dropNodeId)
+    if not self.SessionState:isPlayerActive(player.UserId) then
+        return
+    end
+
+    local state = self:_getPersistentWorldState()
+    local nextDropNodes = {}
+    local pickedCount = 0
+    local pickedAny = false
+
+    for _, dropNodeState in ipairs(state.DropNodes or {}) do
+        if dropNodeState.DropNodeId == dropNodeId then
+            local remainingEntries = {}
+            for _, itemEntry in ipairs(dropNodeState.Entries or {}) do
+                local success = self.InventoryService:pickupEntry(player, itemEntry)
+                if success == true then
+                    pickedAny = true
+                    pickedCount += 1
+                else
+                    table.insert(remainingEntries, itemEntry)
+                end
+            end
+
+            if #remainingEntries &gt; 0 then
+                table.insert(nextDropNodes, {
+                    DropNodeId = dropNodeState.DropNodeId,
+                    Label = dropNodeState.Label,
+                    Position = dropNodeState.Position,
+                    Entries = remainingEntries,
+                })
+            end
+        else
+            table.insert(nextDropNodes, dropNodeState)
+        end
+    end
+
+    if not pickedAny then
+        self:_setStatus(
+            string.format(
+                '%s found a dropped pack but has no room to recover it.',
+                player.DisplayName
+            )
+        )
+        return
+    end
+
+    self:_destroyDynamicDropNode(dropNodeId)
+    self:_replaceDropNodeState(nextDropNodes)
+    for _, dropNodeState in ipairs(nextDropNodes) do
+        if dropNodeState.DropNodeId == dropNodeId then
+            self:_spawnDynamicDropNode(dropNodeState)
+            break
+        end
+    end
+
+    self:_setStatus(
+        string.format('%s 从地上捡回了 %d 件掉落物。', player.DisplayName, pickedCount)
+    )
+end
+
+function MazeContentHarnessService:_getWorldBuildMetadataFields()
+    local metadata = self.WorldBuildMetadata or {}
+    return {
+        WorldBuildIsDirectBoot = metadata.IsDirectBoot,
+        WorldBuildMazeAccessCode = metadata.MazeAccessCode,
+        WorldBuildSeed = metadata.Seed,
+        WorldBuildSessionId = metadata.SessionId,
+        WorldBuildSource = metadata.Source,
+    }
+end
+
+function MazeContentHarnessService:_applyWorldBuildMetadataToRoot()
+    if not (self.World and self.World.Root and self.WorldBuildMetadata) then
+        return
+    end
+
+    self.World.Root:SetAttribute('WorldBuildSeed', self.WorldBuildMetadata.Seed)
+    self.World.Root:SetAttribute('WorldBuildSessionId', self.WorldBuildMetadata.SessionId or 'nil')
+    self.World.Root:SetAttribute(
+        'WorldBuildMazeAccessCode',
+        self.WorldBuildMetadata.MazeAccessCode or 'nil'
+    )
+    self.World.Root:SetAttribute('WorldBuildIsDirectBoot', self.WorldBuildMetadata.IsDirectBoot)
+    self.World.Root:SetAttribute('WorldBuildSource', self.WorldBuildMetadata.Source)
+end
+
+function MazeContentHarnessService:_recordWorldBuildMetadata()
+    self.WorldBuildMetadata = {
+        IsDirectBoot = self.SessionState.IsDirectBoot == true,
+        MazeAccessCode = self.SessionState.MazeAccessCode,
+        Seed = self.Seed,
+        SessionId = self.SessionState.SessionId,
+        Source = self.SessionState.WorldBuildSource,
+    }
+    self:_applyWorldBuildMetadataToRoot()
+end
+
+function MazeContentHarnessService:_getServerTimeNow()
+    local ok, result = pcall(function()
+        return Workspace:GetServerTimeNow()
+    end)
+    if ok and type(result) == 'number' then
+        return result
+    end
+
+    return os.time()
+end
+
+function MazeContentHarnessService:_syncHeldItemEffects(player)
+    local inventory = self.InventoryService:getSummary(player)
+    HeldFlashlightHeadlight.syncHeldItem(player, inventory.HeldItem)
+end
+
+function MazeContentHarnessService:_seedDefaultTools(player)
+    local inventorySummary = self.InventoryService:getSummary(player)
+    if inventorySummary.Count &gt; 0 then
+        return
+    end
+
+    for _, itemId in ipairs({ 'tool-flashlight', 'tool-crowbar', 'tool-potion' }) do
+        local itemDef = ToolItems[itemId]
+        if itemDef then
+            local success, reason = self.InventoryService:pickup(player, itemDef)
+            if not success then
+                error(
+                    string.format(
+                        '把 %s 塞进内容测试背包失败（%s）。',
+                        itemId,
+                        tostring(reason)
+                    ),
+                    0
+                )
+            end
+        end
+    end
+end
+
+function MazeContentHarnessService:_addPlayerState(player)
+    self.SessionState:addPlayer({
+        UserId = player.UserId,
+        Name = player.DisplayName,
+    })
+    self.InventoryService:addPlayer(player)
+    self:_seedDefaultTools(player)
+    self.ControlStateService:addPlayer(player)
+    self.PlayerService:addPlayer(player)
+    self.PlayerStateService:addPlayer(player)
+end
+
+function MazeContentHarnessService:_removePlayerState(player)
+    self.SessionState:removePlayer(player.UserId)
+    self.InventoryService:removePlayer(player)
+    self.ControlStateService:removePlayer(player)
+    self.PlayerService:removePlayer(player)
+    self.PlayerStateService:removePlayer(player)
+    HeldFlashlightHeadlight.clear(player)
+end
+
+function MazeContentHarnessService:_getMovementSummaryFor(player)
+    local playerState = self.PlayerService:getSummary(player)
+    local controlState = self.ControlStateService:getSummary(player)
+    return FormalLocomotion.summarize(playerState, controlState)
+end
+
+function MazeContentHarnessService:_applyMovementMode(player)
+    local character = player.Character
+    local humanoid = character and character:FindFirstChildOfClass('Humanoid')
+    if not humanoid then
+        return
+    end
+
+    FormalLocomotion.applyToHumanoid(humanoid, self:_getMovementSummaryFor(player))
+end
+
+function MazeContentHarnessService:_syncPlayerMovement(player)
+    local playerState = self.PlayerService:getSummary(player)
+    local ok, controlState = self.ControlStateService:syncPlayerState(player, playerState)
+    if ok and controlState then
+        self.PlayerService:setSprinting(player, controlState.Mode == FormalLocomotion.Mode.Sprint)
+    end
+
+    self:_applyMovementMode(player)
+end
+
+function MazeContentHarnessService:_clearPlayerMovement(player)
+    self.ControlStateService:requestSprintStop(player)
+    self.PlayerService:setSprinting(player, false)
+    self:_applyMovementMode(player)
+end
+
+function MazeContentHarnessService:_bindCharacterTeleport(player)
+    player.CharacterAdded:Connect(function(character)
+        task.wait()
+        if not self.World or not character.Parent then
+            return
+        end
+
+        local targetCFrame = self.World.SpawnCFrame
+        if not self.SessionState:isPlayerActive(player.UserId) then
+            targetCFrame = self.World.ReturnHoldCFrame
+        end
+
+        character:PivotTo(targetCFrame)
+        self:_applyMovementMode(player)
+        self:_syncHeldItemEffects(player)
+    end)
+end
+
+function MazeContentHarnessService:_getPlayerUpdateContext(player)
+    local character = player.Character
+    local humanoid = character and character:FindFirstChildOfClass('Humanoid')
+    local rootPart = humanoid and humanoid.RootPart
+    local currentPosition = rootPart and rootPart.Position or Vector3.zero
+
+    return {
+        CurrentPosition = currentPosition,
+        InputState = {},
+    }
+end
+
+function MazeContentHarnessService:_isPlayerDead(player)
+    local summary = self.PlayerService:getSummary(player)
+    return summary ~= nil and summary.Health ~= nil and summary.Health.IsDead == true
+end
+
+function MazeContentHarnessService:_buildRoster()
+    local roster = {}
+
+    for _, player in ipairs(self.GetPlayers()) do
+        table.insert(roster, {
+            Name = player.DisplayName,
+            UserId = player.UserId,
+            InMaze = self.SessionState:isPlayerActive(player.UserId),
+        })
+    end
+
+    table.sort(roster, function(left, right)
+        return left.Name &lt; right.Name
+    end)
+
+    return roster
+end
+
+function MazeContentHarnessService:_getPlayerArea(player)
+    if not self.IsLaunched or not self.World then
+        return 'Maze Staging'
+    end
+
+    local character = player.Character
+    local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+    if not rootPart then
+        return 'Maze Staging'
+    end
+
+    local room = self.World:findRoomByPosition(rootPart.Position)
+    if not room then
+        return 'Maze Staging'
+    end
+
+    return string.format('%s Room', room.Kind)
+end
+
+function MazeContentHarnessService:_getObjectiveFor()
+    if self.SessionState.LoopState == 'Completed' then
+        return '这一轮内容测试已经完成。你可以先观察现场，再重新 Play 进行下一轮。'
+    end
+
+    return self.SessionState.Objective
+end
+
+function MazeContentHarnessService:_buildSnapshotFor(player)
+    local worldBuildFields = self:_getWorldBuildMetadataFields()
+    local inventory = self.InventoryService:getSummary(player)
+    local playerSummary = self.PlayerService:getSummary(player)
+
+    return {
+        IsLaunched = true,
+        Status = self.Status,
+        Area = self:_getPlayerArea(player),
+        Objective = self:_getObjectiveFor(),
+        State = self.SessionState.LoopState,
+        SessionPhase = self.SessionState.SessionPhase,
+        HostUserId = nil,
+        RoundStarted = self.SessionState.LoopState ~= 'Staging',
+        DangerActive = self.SessionState.LoopState == 'Expedition',
+        RoundTimeRemainingSeconds = nil,
+        SettlementReason = nil,
+        CurrentRound = self.SessionState.CurrentRound,
+        MaxRounds = self.SessionState.MaxRounds,
+        BankedItemCount = self.SessionState.BankedItemCount,
+        TargetItemCount = self.SessionState.TargetItemCount,
+        RoundOutcome = nil,
+        SessionOutcome = if self.SessionState.LoopState == 'Completed' then 'content-test' else nil,
+        Inventory = inventory,
+        Movement = self:_getMovementSummaryFor(player),
+        ControlState = self.ControlStateService:getSummary(player),
+        PlayerState = playerSummary and playerSummary.PlayerState or nil,
+        Roster = self:_buildRoster(),
+        SessionId = self.SessionState.SessionId,
+        MazeAccessCode = self.SessionState.MazeAccessCode,
+        MazeStatus = self.SessionState.MazeStatus,
+        ReturnedPlayerSummaries = self.SessionState:getReturnedSummaries(),
+        IsDirectBoot = self.SessionState.IsDirectBoot,
+        WorldBuildSeed = worldBuildFields.WorldBuildSeed,
+        WorldBuildSessionId = worldBuildFields.WorldBuildSessionId,
+        WorldBuildMazeAccessCode = worldBuildFields.WorldBuildMazeAccessCode,
+        WorldBuildIsDirectBoot = worldBuildFields.WorldBuildIsDirectBoot,
+        WorldBuildSource = worldBuildFields.WorldBuildSource,
+    }
+end
+
+function MazeContentHarnessService:_broadcastSnapshot()
+    if not self.IsLaunched then
+        return
+    end
+
+    for _, player in ipairs(self.GetPlayers()) do
+        self.Remotes.MazeState:FireClient(player, self:_buildSnapshotFor(player))
+        self.Remotes.MazePrivateState:FireClient(player, nil)
+    end
+end
+
+function MazeContentHarnessService:_setStatus(status)
+    self.Status = status
+    self.SessionState:setStatus(status)
+    print(string.format('[Maze] %s', status))
+    self:_broadcastSnapshot()
+end
+
+function MazeContentHarnessService:_rebuildWorld()
+    self:_setBootPhase('RebuildWorld')
+    if self.SessionState.LoopState == 'Expedition' then
+        self.MonsterService:destroy()
+    end
+
+    clearDefaultWorkspaceShell()
+    self:_destroyDynamicDropNodes()
+
+    if self.WorldInteractions then
+        self.WorldInteractions:disconnectAll()
+        self.WorldInteractions = nil
+    end
+
+    self.World = self.WorldBuilder.build()
+    self:_recordWorldBuildMetadata()
+    self:_applyPersistentWorldStateToWorld()
+    self:_setBootPhase('BindWorldInteractions')
+    self.WorldInteractions = self.World:bindInteractions({
+        OnReturnHold = function(player)
+            self:_returnPlayerLocally(player, 'returned')
+        end,
+        OnLoot = function(player, roomId)
+            self:_pickupLoot(player, roomId)
+        end,
+        OnDoor = function(player, doorwayId)
+            self:_toggleDoor(player, doorwayId)
+        end,
+    })
+end
+
+function MazeContentHarnessService:_toggleDoor(player, doorwayId)
+    if not self.World then
+        return
+    end
+
+    local toggled = self.World:toggleDoor(doorwayId)
+    if not toggled then
+        return
+    end
+
+    local doorway = self.World:getDoor(doorwayId)
+    if doorway then
+        local stateText = doorway.IsOpen and 'opened' or 'closed'
+        self:_setStatus(
+            string.format('%s %s a concrete double door.', player.DisplayName, stateText)
+        )
+    end
+end
+
+function MazeContentHarnessService:_buildSummaryFor(player, returnReason, countInventory, overrides)
+    local inventorySummary = overrides and overrides.InventorySummary
+        or self.InventoryService:getSummary(player)
+    local shouldCountInventory = countInventory ~= false
+    local lootItemCount = shouldCountInventory
+            and (overrides and overrides.LootItemCount or inventorySummary.LootCount or 0)
+        or 0
+    local clueCount = shouldCountInventory
+            and (overrides and overrides.ClueCount or inventorySummary.ClueCount or 0)
+        or 0
+    local toolCount = shouldCountInventory
+            and (overrides and overrides.ToolCount or inventorySummary.ToolCount or 0)
+        or 0
+    local missionCount = shouldCountInventory
+            and (overrides and overrides.MissionCount or inventorySummary.MissionCount or lootItemCount)
+        or 0
+
+    return {
+        UserId = player.UserId,
+        Name = player.DisplayName,
+        ReturnReason = returnReason,
+        Value = 0,
+        ItemCount = shouldCountInventory and (lootItemCount + clueCount + toolCount) or 0,
+        Weight = 0,
+        WasSettled = false,
+        CountedInSettlement = shouldCountInventory,
+        LootItemCount = lootItemCount,
+        ClueCount = clueCount,
+        ToolCount = toolCount,
+        MissionCount = missionCount,
+    }
+end
+
+function MazeContentHarnessService:_spawnCorpseForPlayer(player)
+    if self.CorpsesByUserId[player.UserId] or not self.World or not self.World.Root then
+        return
+    end
+
+    local character = player.Character
+    local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+    local corpsePosition = rootPart and rootPart.Position or self.World.ReturnHoldCFrame.Position
+
+    local corpse = Instance.new('Part')
+    corpse.Name = string.format('Corpse_%d', player.UserId)
+    corpse.Anchored = true
+    corpse.Size = CORPSE_SIZE
+    corpse.CFrame = CFrame.new(corpsePosition + Vector3.new(0, CORPSE_VERTICAL_OFFSET, 0))
+    corpse.Color = CORPSE_COLOR
+    corpse.Material = CORPSE_MATERIAL
+    corpse.Parent = self.World.Root
+
+    self.CorpsesByUserId[player.UserId] = corpse
+end
+
+function MazeContentHarnessService:_completeLoopIfNoActivePlayers()
+    if self.SessionState:getActiveCount() ~= 0 then
+        return false
+    end
+
+    local completed, reason = self.SessionState:completeExpedition()
+    if not completed then
+        return nil, reason
+    end
+
+    self.MonsterService:destroy()
+    self.SessionState:setObjective(
+        '内容循环已完成。你可以先检查当前迷宫现场，再重新 Play 开下一轮。'
+    )
+    return true
+end
+
+function MazeContentHarnessService:_applyDeathReturn(player)
+    local summary = self:_buildSummaryFor(player, 'death', false)
+    local recorded = self.SessionState:recordReturn(summary)
+    if not recorded then
+        return
+    end
+
+    local completed, reason = self:_completeLoopIfNoActivePlayers()
+    if completed == nil then
+        self:_setStatus(string.format('迷宫结算失败：%s', tostring(reason)))
+        return
+    end
+end
+
+function MazeContentHarnessService:_handlePlayerDeath(player, damageKind)
+    self:_spawnCorpseForPlayer(player)
+    self:_clearPlayerMovement(player)
+
+    local droppedEntries = self.InventoryService:dropAllItems(player)
+    local character = player.Character
+    local rootPart = character and character:FindFirstChild('HumanoidRootPart')
+    local dropPosition = rootPart and rootPart.Position or self.World.ReturnHoldCFrame.Position
+    self:_createPersistentDropNode(
+        droppedEntries,
+        dropPosition,
+        string.format('%s Pack', player.DisplayName)
+    )
+
+    self:_applyDeathReturn(player)
+    HeldFlashlightHeadlight.clear(player)
+
+    if character and character.Parent and self.World then
+        character:PivotTo(self.World.ReturnHoldCFrame)
+    end
+
+    self:_setStatus(
+        string.format(
+            '%s 受到了 %s 伤害并死亡，背包掉在了迷宫里。',
+            player.DisplayName,
+            localizeDamageKind(damageKind)
+        )
+    )
+end
+
+function MazeContentHarnessService:_applyPlayerDamage(player, damageKind)
+    if not self.SessionState:isPlayerActive(player.UserId) then
+        return
+    end
+
+    local success, result = self.PlayerService:applyDamage(player, damageKind)
+    if not success then
+        self:_setStatus(
+            string.format('%s 无法受伤（%s）。', player.DisplayName, tostring(result))
+        )
+        return
+    end
+
+    local summary = self.PlayerService:getSummary(player)
+    if not summary then
+        self:_setStatus(string.format('%s 受伤后状态摘要不可用。', player.DisplayName))
+        return
+    end
+
+    if summary.Health.IsDead then
+        self:_handlePlayerDeath(player, damageKind)
+        return
+    end
+
+    self:_syncPlayerMovement(player)
+
+    self:_setStatus(
+        string.format(
+            '%s 受到了 %s 伤害，现在生命是 %d/%d。',
+            player.DisplayName,
+            localizeDamageKind(damageKind),
+            summary.Health.CurrentHealthPips,
+            summary.Health.MaxHealthPips
+        )
+    )
+end
+
+function MazeContentHarnessService:_pickupLoot(player, roomId)
+    if self.SessionState.LoopState ~= 'Expedition' then
+        self:_setStatus('只有在探索阶段才能拾取战利品。')
+        return
+    end
+
+    if not self.SessionState:isPlayerActive(player.UserId) then
+        self:_setStatus(
+            string.format('%s 已经返回，不能再继续捡东西了。', player.DisplayName)
+        )
+        return
+    end
+
+    local lootEntry = self.World:getLootNode(roomId)
+    if not lootEntry or lootEntry.Collected then
+        return
+    end
+
+    local success, reason = self.InventoryService:pickup(player, lootEntry.ItemDef)
+    if not success then
+        self:_setStatus(
+            string.format(
+                '%s 拿不起 %s（%s）。',
+                player.DisplayName,
+                lootEntry.ItemDef.Name,
+                tostring(reason)
+            )
+        )
+        return
+    end
+
+    lootEntry:markCollected()
+    self:_markLootCollected(roomId)
+
+    local inventorySummary = self.InventoryService:getSummary(player)
+    self:_setStatus(
+        string.format(
+            '%s 拿到了 %s，现在身上有 %d 件战利品。',
+            player.DisplayName,
+            lootEntry.ItemDef.Name,
+            inventorySummary.LootCount or 0
+        )
+    )
+end
+
+function MazeContentHarnessService:_canManageInventory(player)
+    if not self.SessionState:isPlayerActive(player.UserId) then
+        self:_setStatus(
+            string.format('%s 已经返回，不能再改背包状态了。', player.DisplayName)
+        )
+        return false
+    end
+
+    if self:_isPlayerDead(player) then
+        self:_setStatus(
+            string.format('%s 这一轮已经死亡，不能再操作背包。', player.DisplayName)
+        )
+        return false
+    end
+
+    return true
+end
+
+function MazeContentHarnessService:_equipItem(player, itemInstanceId)
+    if not self:_canManageInventory(player) then
+        return
+    end
+
+    local success, result = self.InventoryService:equip(player, itemInstanceId)
+    if not success then
+        self:_setStatus(
+            string.format(
+                '%s 装备这个物品失败（%s）。',
+                player.DisplayName,
+                tostring(result)
+            )
+        )
+        return
+    end
+
+    self:_syncHeldItemEffects(player)
+    self:_setStatus(string.format('%s 装备了 %s。', player.DisplayName, result.Name))
+end
+
+function MazeContentHarnessService:_unequipItem(player)
+    if not self:_canManageInventory(player) then
+        return
+    end
+
+    local success, result = self.InventoryService:unequip(player)
+    if not success then
+        self:_setStatus(
+            string.format(
+                '%s 收起当前手持失败（%s）。',
+                player.DisplayName,
+                tostring(result)
+            )
+        )
+        return
+    end
+
+    self:_syncHeldItemEffects(player)
+    self:_setStatus(string.format('%s 把 %s 收回了背包。', player.DisplayName, result.Name))
+end
+
+function MazeContentHarnessService:_handleUseTool(player)
+    if not self:_canManageInventory(player) then
+        return
+    end
+
+    local summary = self.PlayerService:getSummary(player)
+    local playerState = summary and summary.PlayerState
+    if playerState and playerState.IsDead == true then
+        self:_setStatus(
+            string.format('%s 已经死亡，不能再使用工具。', player.DisplayName)
+        )
+        return
+    end
+
+    local inventorySummary = self.InventoryService:getSummary(player)
+    local heldItem = inventorySummary and inventorySummary.HeldItem
+
+    if not heldItem then
+        self:_setStatus(
+            string.format('%s 想使用工具，但手上是空的。', player.DisplayName)
+        )
+        return
+    end
+
+    if type(heldItem.CurrentState) ~= 'number' or type(heldItem.ConsumePerUse) ~= 'number' then
+        self:_setStatus(
+            string.format(
+                '%s 不能主动使用 %s（它不是工具）。',
+                player.DisplayName,
+                heldItem.Name
+            )
+        )
+        return
+    end
+
+    if heldItem.ConsumePerUse &gt; 0 and heldItem.CurrentState &lt; heldItem.ConsumePerUse then
+        self:_setStatus(
+            string.format(
+                '%s 想使用 %s，但它已经没有 %s 了。',
+                player.DisplayName,
+                heldItem.Name,
+                heldItem.StateModel or 'power'
+            )
+        )
+        return
+    end
+
+    local consumeSuccess, consumeResult, cooldownRemaining =
+        self.InventoryService:consumeHeldItemState(player, os.clock())
+    if not consumeSuccess then
+        if consumeResult == 'Cooldown' then
+            self:_setStatus(
+                string.format(
+                    '%s 现在还不能用 %s（还剩 %.1f 秒冷却）。',
+                    player.DisplayName,
+                    heldItem.Name,
+                    math.max(cooldownRemaining or 0, 0)
+                )
+            )
+        else
+            self:_setStatus(
+                string.format(
+                    '%s 使用 %s 失败（%s）。',
+                    player.DisplayName,
+                    heldItem.Name,
+                    tostring(consumeResult)
+                )
+            )
+        end
+        return
+    end
+
+    local updatedHeldItem = consumeResult
+    local effectText = '使用成功。'
+
+    if updatedHeldItem.ToolCategory == 'Flashlight' then
+        local enabled = HeldFlashlightHeadlight.toggle(player)
+        if enabled == nil then
+            effectText = '头灯切换失败（角色没有头部）。'
+        elseif enabled then
+            effectText = '头灯已打开。'
+        else
+            effectText = '头灯已关闭。'
+        end
+    elseif updatedHeldItem.ToolCategory == 'Crowbar' then
+        effectText = '空气中划过一声很扎实的挥击声。'
+
+        local damagePips = 1
+        if type(updatedHeldItem.MeleeDamage) == 'number' and updatedHeldItem.MeleeDamage &gt;= 1 then
+            damagePips = math.floor(updatedHeldItem.MeleeDamage)
+        end
+
+        local meleeOk, meleeResult = self.MonsterService:tryApplyPlayerMeleeHit(player, {
+            DamagePips = damagePips,
+            SwingArcDegrees = updatedHeldItem.SwingArcDegrees,
+            SwingRange = updatedHeldItem.SwingRange,
+        })
+        if meleeOk then
+            if meleeResult and meleeResult.Killed then
+                effectText = '撬棍命中了，怪物倒下了！'
+            elseif meleeResult and type(meleeResult.RemainingHitPoints) == 'number' then
+                effectText = string.format(
+                    '撬棍命中了！怪物剩余血量约 %d。',
+                    meleeResult.RemainingHitPoints
+                )
+            end
+        else
+            effectText = crowbarMeleeMissText(meleeResult)
+        end
+    elseif updatedHeldItem.ToolCategory == 'Potion' then
+        local healPips = 1
+        if
+            type(updatedHeldItem.HealHealthPips) == 'number'
+            and updatedHeldItem.HealHealthPips &gt;= 1
+        then
+            healPips = math.floor(updatedHeldItem.HealHealthPips)
+        end
+        local healOk, healResult = self.PlayerService:healHealthPips(player, healPips)
+        if healOk then
+            effectText = string.format('药水生效了，当前生命为 %d。', healResult)
+        else
+            effectText = string.format('药水没有生效（%s）。', tostring(healResult))
+        end
+    end
+
+    self:_setStatus(
+        string.format(
+            '%s 使用了 %s。%s（%s 剩余：%d）',
+            player.DisplayName,
+            updatedHeldItem.Name,
+            effectText,
+            updatedHeldItem.StateModel or '状态',
+            updatedHeldItem.CurrentState
+        )
+    )
+end
+
+function MazeContentHarnessService:_returnPlayerLocally(player, returnReason)
+    if self.SessionState.LoopState ~= 'Expedition' then
+        self:_setStatus('只有在探索阶段才能使用返回点。')
+        return
+    end
+
+    if not self.SessionState:isPlayerActive(player.UserId) then
+        self:_setStatus(
+            string.format('%s 这一轮本地迷宫已经完成了。', player.DisplayName)
+        )
+        return
+    end
+
+    if self:_isPlayerDead(player) then
+        self:_setStatus(
+            string.format('%s 已经死亡，只能先待在等待区。', player.DisplayName)
+        )
+        return
+    end
+
+    local inventorySummary, bankedCount = self.InventoryService:extractMissionCargo(player)
+    self.SessionState:addBankedItems(bankedCount)
+
+    local summary = self:_buildSummaryFor(player, returnReason, true, {
+        InventorySummary = inventorySummary,
+        LootItemCount = bankedCount,
+        MissionCount = bankedCount,
+    })
+    local recorded, reason = self.SessionState:recordReturn(summary)
+    if not recorded then
+        if reason == 'MissingActivePlayer' then
+            self:_setStatus(
+                string.format('%s 这一轮本地迷宫已经完成了。', player.DisplayName)
+            )
+        end
+        return
+    end
+
+    self:_clearPlayerMovement(player)
+    HeldFlashlightHeadlight.clear(player)
+
+    local character = player.Character
+    if character and character.Parent and self.World then
+        character:PivotTo(self.World.ReturnHoldCFrame)
+    end
+
+    local completed, completionReason = self:_completeLoopIfNoActivePlayers()
+    if completed == nil then
+        self:_setStatus(string.format('迷宫完成结算失败：%s', tostring(completionReason)))
+        return
+    end
+
+    if completed then
+        self:_setStatus(
+            string.format(
+                '%s 完成了这一轮本地迷宫测试，入账了 %d 件战利品（%s）。',
+                player.DisplayName,
+                bankedCount,
+                localizeReturnReason(summary.ReturnReason)
+            )
+        )
+        return
+    end
+
+    self:_setStatus(
+        string.format(
+            '%s 到达了返回点，入账了 %d 件战利品（%s）。',
+            player.DisplayName,
+            bankedCount,
+            localizeReturnReason(summary.ReturnReason)
+        )
+    )
+end
+
+function MazeContentHarnessService:_beginFormalExpedition()
+    self:_setBootPhase('BeginFormalExpedition')
+    local started, reason = self.SessionState:beginExpedition()
+    if not started then
+        if reason ~= 'InvalidState' then
+            self:_setStatus(string.format('迷宫流程启动失败：%s', tostring(reason)))
+        end
+        return
+    end
+
+    local patrolPoints, initialPatrolIndex = self.World:getPatrolPoints()
+    if #patrolPoints == 0 then
+        error('迷宫内容测试场要求 authored 世界里存在 MonsterSpawns 巡逻点。', 0)
+    end
+
+    self:_setBootPhase('SpawnMonster')
+    self.MonsterService:spawn(patrolPoints, initialPatrolIndex)
+    self:_setStatus(
+        '迷宫内容测试场已启动。开始探索、拿战利品，并找到返回点。'
+    )
+end
+
+function MazeContentHarnessService:_loadExistingPlayers()
+    self:_setBootPhase('BindExistingPlayers')
+    for _, player in ipairs(self.GetPlayers()) do
+        self:_bindCharacterTeleport(player)
+        self:_addPlayerState(player)
+
+        if player.Character then
+            player.Character:Destroy()
+        end
+    end
+end
+
+function MazeContentHarnessService:_launchMaze()
+    if self.IsLaunched then
+        return
+    end
+
+    self:_setBootPhase('LaunchMaze')
+    self:_rebuildWorld()
+
+    self:_setBootPhase('LoadCharacters')
+    for _, player in ipairs(self.GetPlayers()) do
+        self.LoadCharacter(player)
+    end
+
+    self.IsLaunched = true
+    self:_beginFormalExpedition()
+    self:_setBootPhase('StartSnapshotLoop')
+    self:_startSnapshotLoop()
+    self:_setBootPhase('FirstSnapshot')
+    self:_broadcastSnapshot()
+    self:_setBootPhase('Launched')
+end
+
+function MazeContentHarnessService:_startSnapshotLoop()
+    if self.SnapshotThread then
+        return
+    end
+
+    self.SnapshotThread = task.spawn(function()
+        local previousTick = os.clock()
+
+        while true do
+            task.wait(SNAPSHOT_INTERVAL_SECONDS)
+
+            if self.IsLaunched then
+                local currentTick = os.clock()
+                local dt = currentTick - previousTick
+                previousTick = currentTick
+
+                self.PlayerStateService:step(dt)
+
+                for _, player in ipairs(self.GetPlayers()) do
+                    local context = self:_getPlayerUpdateContext(player)
+                    self.PlayerService:update(player, dt, context)
+                    self:_syncPlayerMovement(player)
+                end
+
+                self:_broadcastSnapshot()
+            else
+                previousTick = os.clock()
+            end
+        end
+    end)
+end
+
+function MazeContentHarnessService:start()
+    self:_setBootPhase('Start')
+    Players.CharacterAutoLoads = false
+
+    self:_loadExistingPlayers()
+
+    self:_setBootPhase('BindPlayerSignals')
+    Players.PlayerAdded:Connect(function(player)
+        self:_bindCharacterTeleport(player)
+        self:_addPlayerState(player)
+
+        if self.IsLaunched then
+            self.LoadCharacter(player)
+            self:_setStatus(
+                string.format('%s 已加入本地迷宫内容测试。', player.DisplayName)
+            )
+            return
+        end
+
+        self:_broadcastSnapshot()
+    end)
+
+    Players.PlayerRemoving:Connect(function(player)
+        self:_removePlayerState(player)
+        self:_broadcastSnapshot()
+    end)
+
+    self:_setBootPhase('BindMazeActionRemote')
+    self.Remotes.MazeAction.OnServerEvent:Connect(function(player, payload)
+        if type(payload) ~= 'table' then
+            return
+        end
+
+        if payload.Type == 'RequestEquipItem' then
+            self:_equipItem(player, payload.ItemInstanceId)
+        elseif payload.Type == 'RequestUnequipItem' then
+            self:_unequipItem(player)
+        elseif payload.Type == 'RequestSprintStart' then
+            self:_setPlayerSprinting(player, true)
+        elseif payload.Type == 'RequestSprintStop' then
+            self:_setPlayerSprinting(player, false)
+        elseif payload.Type == 'RequestUseTool' then
+            self:_handleUseTool(player)
+        elseif RunService:IsStudio() and DEBUG_DAMAGE_BY_ACTION[payload.Type] then
+            self:_applyPlayerDamage(player, DEBUG_DAMAGE_BY_ACTION[payload.Type])
+        end
+    end)
+
+    self:_setBootPhase('BeforeLaunchMaze')
+    task.defer(function()
+        local ok, err = pcall(function()
+            self:_launchMaze()
+        end)
+
+        if not ok then
+            self:_setBootFailure(err)
+        end
+    end)
+end
+
+function MazeContentHarnessService:_setPlayerSprinting(player, isSprinting)
+    if not self.SessionState:isPlayerActive(player.UserId) then
+        return
+    end
+
+    local playerState = self.PlayerService:getSummary(player)
+    local success, result
+    if isSprinting then
+        success, result = self.ControlStateService:requestSprintStart(player, playerState)
+    else
+        success, result = self.ControlStateService:requestSprintStop(player)
+    end
+
+    if not success then
+        if result == 'StaminaDepleted' then
+            self:_setStatus(
+                string.format('%s 太累了，暂时不能冲刺。', player.DisplayName)
+            )
+        elseif result == 'Dead' then
+            self:_setStatus(string.format('%s 已经死亡，不能冲刺。', player.DisplayName))
+        end
+        self:_syncPlayerMovement(player)
+        return
+    end
+
+    self:_syncPlayerMovement(player)
+end
+
+return MazeContentHarnessService
+</string>
+      </Properties>
+    </Item>
+    <Item class="ModuleScript" referent="173">
+      <Properties>
+        <string name="Name">MazeContentLightingService</string>
+        <string name="Source">local Lighting = game:GetService('Lighting')
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local MazeLightingProfile = require(
+    Packages:WaitForChild('Shared'):WaitForChild('Runtime'):WaitForChild('MazeLightingProfile')
+)
+
+local MazeContentLightingService = {}
+MazeContentLightingService.__index = MazeContentLightingService
+
+function MazeContentLightingService.new()
+    return setmetatable({}, MazeContentLightingService)
+end
+
+function MazeContentLightingService:start()
+    local created = MazeLightingProfile.apply(Lighting)
+    local skippedProperties = created.SkippedProperties or {}
+
+    for propertyName, err in pairs(skippedProperties) do
+        warn(
+            string.format(
+                '[MazeLighting] skipped %s update: %s',
+                tostring(propertyName),
+                tostring(err)
+            )
+        )
+    end
+
+    if created.TechnologyApplied then
+        print('[MazeLightingDiag] applied Future lighting profile')
+    else
+        warn(
+            string.format(
+                '[MazeLightingDiag] applied fallback readable profile: %s',
+                tostring(created.TechnologyError or 'Technology unavailable')
+            )
+        )
+    end
+
+    return created
+end
+
+return MazeContentLightingService
+</string>
+      </Properties>
+    </Item>
+    <Item class="ModuleScript" referent="174">
+      <Properties>
+        <string name="Name">MazeContentSessionState</string>
+        <string name="Source">local MazeContentSessionState = {}
+MazeContentSessionState.__index = MazeContentSessionState
+
+local function cloneSummary(summary)
+    return {
+        UserId = summary.UserId,
+        Name = summary.Name,
+        ReturnReason = summary.ReturnReason,
+        Value = summary.Value or 0,
+        ItemCount = summary.ItemCount or 0,
+        Weight = summary.Weight or 0,
+        WasSettled = summary.WasSettled == true,
+        CountedInSettlement = summary.CountedInSettlement ~= false,
+        LootItemCount = summary.LootItemCount or summary.MissionCount or summary.ItemCount or 0,
+        ClueCount = summary.ClueCount or 0,
+        ToolCount = summary.ToolCount or 0,
+        MissionCount = summary.MissionCount or summary.LootItemCount or summary.ItemCount or 0,
+    }
+end
+
+local function cloneArray(list)
+    return table.clone(list or {})
+end
+
+local function cloneDropNode(dropNode)
+    local entries = {}
+    for index, entry in ipairs(dropNode.Entries or {}) do
+        entries[index] = table.clone(entry)
+    end
+
+    local position = dropNode.Position
+    local clonedPosition
+    if type(position) == 'table' then
+        clonedPosition = table.clone(position)
+    else
+        clonedPosition = position
+    end
+
+    return {
+        DropNodeId = dropNode.DropNodeId,
+        Label = dropNode.Label,
+        Position = clonedPosition,
+        Entries = entries,
+    }
+end
+
+local function clonePersistentWorldState(state)
+    local dropNodes = {}
+    for index, dropNode in ipairs(state.DropNodes or {}) do
+        dropNodes[index] = cloneDropNode(dropNode)
+    end
+
+    return {
+        CollectedLootRoomIds = cloneArray(state.CollectedLootRoomIds or {}),
+        DropNodes = dropNodes,
+    }
+end
+
+function MazeContentSessionState.new(seed)
+    return setmetatable({
+        Seed = seed,
+        SessionId = 'local-content-harness',
+        MazeAccessCode = 'local-content-harness',
+        IsDirectBoot = true,
+        CurrentRound = 1,
+        MaxRounds = 1,
+        Status = '本地直启：迷宫内容测试场已启动。开始探索、拿 loot、验证玩法。',
+        Objective = '观察房间、躲开威胁、拿到战利品，然后活着走到返回点。',
+        MazeStatus = 'active',
+        SessionPhase = 'MazeActive',
+        WorldBuildSource = 'ContentHarness',
+        BankedItemCount = 0,
+        TargetItemCount = 0,
+        LoopState = 'Staging',
+        ActivePlayersByUserId = {},
+        ReturnedPlayerSummaries = {},
+        PersistentWorldState = {
+            CollectedLootRoomIds = {},
+            DropNodes = {},
+        },
+    }, MazeContentSessionState)
+end
+
+function MazeContentSessionState:addPlayer(playerInfo)
+    self.ActivePlayersByUserId[playerInfo.UserId] = {
+        UserId = playerInfo.UserId,
+        Name = playerInfo.Name,
+    }
+end
+
+function MazeContentSessionState:removePlayer(userId)
+    self.ActivePlayersByUserId[userId] = nil
+end
+
+function MazeContentSessionState:isPlayerActive(userId)
+    return self.ActivePlayersByUserId[userId] ~= nil
+end
+
+function MazeContentSessionState:getActiveCount()
+    local count = 0
+    for _ in pairs(self.ActivePlayersByUserId) do
+        count += 1
+    end
+    return count
+end
+
+function MazeContentSessionState:getReturnedSummaries()
+    local summaries = {}
+    for index, summary in ipairs(self.ReturnedPlayerSummaries) do
+        summaries[index] = cloneSummary(summary)
+    end
+    return summaries
+end
+
+function MazeContentSessionState:recordReturn(summary)
+    if not self:isPlayerActive(summary.UserId) then
+        return false, 'MissingActivePlayer'
+    end
+
+    self.ActivePlayersByUserId[summary.UserId] = nil
+    table.insert(self.ReturnedPlayerSummaries, cloneSummary(summary))
+    return true
+end
+
+function MazeContentSessionState:beginExpedition()
+    if self.LoopState ~= 'Staging' then
+        return false, 'InvalidState'
+    end
+
+    self.LoopState = 'Expedition'
+    self.MazeStatus = 'active'
+    self.SessionPhase = 'MazeActive'
+    return true
+end
+
+function MazeContentSessionState:completeExpedition()
+    if self.LoopState ~= 'Expedition' then
+        return false, 'InvalidState'
+    end
+
+    if self:getActiveCount() ~= 0 then
+        return false, 'ActivePlayersRemaining'
+    end
+
+    self.LoopState = 'Completed'
+    self.MazeStatus = 'completed'
+    self.SessionPhase = 'RunIntermission'
+    return true
+end
+
+function MazeContentSessionState:setStatus(status)
+    self.Status = status
+end
+
+function MazeContentSessionState:setObjective(objective)
+    self.Objective = objective
+end
+
+function MazeContentSessionState:addBankedItems(amount)
+    if type(amount) == 'number' and amount &gt; 0 then
+        self.BankedItemCount += amount
+    end
+end
+
+function MazeContentSessionState:getPersistentWorldState()
+    return clonePersistentWorldState(self.PersistentWorldState)
+end
+
+function MazeContentSessionState:setPersistentWorldState(state)
+    self.PersistentWorldState = clonePersistentWorldState(state)
+end
+
+function MazeContentSessionState:markLootCollected(roomId)
+    local collectedLootRoomIds = self.PersistentWorldState.CollectedLootRoomIds
+
+    for _, collectedRoomId in ipairs(collectedLootRoomIds) do
+        if collectedRoomId == roomId then
+            return
+        end
+    end
+
+    table.insert(collectedLootRoomIds, roomId)
+    table.sort(collectedLootRoomIds)
+end
+
+return MazeContentSessionState
+</string>
+      </Properties>
+    </Item>
+    <Item class="ModuleScript" referent="175">
+      <Properties>
+        <string name="Name">MazeContentWorldBuilder</string>
+        <string name="Source">local ReplicatedStorage = game:GetService('ReplicatedStorage')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local PlaceModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
+
+local MazeWorldScanner = require(
+    Packages:WaitForChild('Shared'):WaitForChild('Runtime'):WaitForChild('MazeWorldScanner')
+)
+local MazeScene = require(PlaceModules:WaitForChild('MazeScene'))
+local MazeStaticWorldAssembler = require(PlaceModules:WaitForChild('MazeStaticWorldAssembler'))
+
+local MazeContentWorldBuilder = {}
+
+local function placePartAt(part, targetPosition)
+    if not (part and part:IsA('BasePart')) then
+        return
+    end
+
+    part.CFrame = CFrame.new(targetPosition) * part.CFrame.Rotation
+end
+
+local function placeModelAt(model, targetPosition)
+    if not (model and model:IsA('Model')) then
+        return
+    end
+
+    model:PivotTo(CFrame.new(targetPosition) * model:GetPivot().Rotation)
+end
+
+local function findDescendant(root, name)
+    if root == nil then
+        return nil
+    end
+
+    return root:FindFirstChild(name, true)
+end
+
+local function styleAcceptancePart(part, style)
+    if not (part and part:IsA('BasePart')) then
+        return
+    end
+
+    local config = style or {}
+    part.Transparency = config.Transparency or 0.15
+    part.Material = config.Material or Enum.Material.Neon
+    part.Color = config.Color or Color3.fromRGB(111, 255, 233)
+
+    if typeof(config.Size) == 'Vector3' then
+        part.Size = config.Size
+    end
+
+    if config.Shape ~= nil then
+        part.Shape = config.Shape
+    end
+end
+
+local function placeSpawnFolderAt(folder, targetPosition)
+    if not (folder and folder:IsA('Folder')) then
+        return
+    end
+
+    for _, child in ipairs(folder:GetChildren()) do
+        if child:IsA('BasePart') then
+            placePartAt(child, targetPosition)
+        end
+    end
+end
+
+local function applyAcceptanceLayout(staticWorldRoot)
+    local spawnMarker = staticWorldRoot:FindFirstChild('SpawnMarker')
+    if not (spawnMarker and spawnMarker:IsA('BasePart')) then
+        return
+    end
+
+    local spawnPosition = spawnMarker.Position
+
+    local lootRoom = staticWorldRoot:FindFirstChild('Room_Loot')
+    local campRoom = staticWorldRoot:FindFirstChild('Room_Camp')
+    placeModelAt(campRoom, spawnPosition + Vector3.new(-22, 0, -10))
+    placeModelAt(lootRoom, spawnPosition + Vector3.new(28, 0, -6))
+
+    -- Keep the authored shell mostly intact, but pull the acceptance interaction points
+    -- into a short walk around spawn so content verification is fast and obvious.
+    placePartAt(
+        staticWorldRoot:FindFirstChild('ReturnHoldPad'),
+        spawnPosition + Vector3.new(-8, 0, 8)
+    )
+    placePartAt(
+        findDescendant(staticWorldRoot, 'LootPrompt'),
+        spawnPosition + Vector3.new(10, 0, 2)
+    )
+    placePartAt(
+        findDescendant(staticWorldRoot, 'LootSocket_1'),
+        spawnPosition + Vector3.new(12, 0, 2)
+    )
+    placePartAt(
+        findDescendant(staticWorldRoot, 'Doorway_East'),
+        spawnPosition + Vector3.new(20, 0, 2)
+    )
+    local monsterSpawns = lootRoom and lootRoom:FindFirstChild('MonsterSpawns')
+    placeSpawnFolderAt(monsterSpawns, spawnPosition + Vector3.new(72, 0, -24))
+
+    styleAcceptancePart(staticWorldRoot:FindFirstChild('ReturnHoldPad'), {
+        Color = Color3.fromRGB(79, 181, 255),
+        Material = Enum.Material.ForceField,
+        Size = Vector3.new(5, 0.5, 5),
+        Transparency = 0.2,
+    })
+    styleAcceptancePart(findDescendant(staticWorldRoot, 'LootPrompt'), {
+        Color = Color3.fromRGB(255, 205, 84),
+        Material = Enum.Material.Neon,
+        Size = Vector3.new(2.5, 2.5, 2.5),
+        Shape = Enum.PartType.Ball,
+        Transparency = 0.05,
+    })
+    styleAcceptancePart(findDescendant(staticWorldRoot, 'LootSocket_1'), {
+        Color = Color3.fromRGB(255, 245, 181),
+        Material = Enum.Material.Neon,
+        Size = Vector3.new(1.5, 1.5, 1.5),
+        Shape = Enum.PartType.Ball,
+        Transparency = 0.15,
+    })
+    styleAcceptancePart(findDescendant(staticWorldRoot, 'Doorway_East'), {
+        Color = Color3.fromRGB(255, 129, 76),
+        Material = Enum.Material.ForceField,
+        Transparency = 0.3,
+    })
+end
+
+function MazeContentWorldBuilder.build()
+    local staticWorldRoot = MazeStaticWorldAssembler.assemble()
+
+    if not (staticWorldRoot:IsA('Folder') or staticWorldRoot:IsA('Model')) then
+        error('MazeStaticWorld must be a Folder or Model.', 0)
+    end
+
+    -- Keep authored interactions clustered around spawn in the content harness so
+    -- loot, doors, and return are easy to validate in one short pass.
+    applyAcceptanceLayout(staticWorldRoot)
+
+    return MazeScene.new(MazeWorldScanner.BuildStaticWorld(staticWorldRoot))
+end
+
+return MazeContentWorldBuilder
+</string>
+      </Properties>
+    </Item>
+  </Item>
+  <Item class="StarterPlayer" referent="176">
     <Properties>
       <string name="Name">StarterPlayer</string>
       <float name="CameraMaxZoomDistance">0.5</float>
@@ -14307,14 +20084,14 @@ return MazeWorldBuilder
       <token name="CameraMode">1</token>
       <bool name="EnableMouseLockOption">false</bool>
     </Properties>
-    <Item class="StarterPlayerScripts" referent="115">
+    <Item class="StarterPlayerScripts" referent="177">
       <Properties>
         <string name="Name">StarterPlayerScripts</string>
       </Properties>
-      <Item class="LocalScript" referent="116">
+      <Item class="LocalScript" referent="178">
         <Properties>
           <string name="Name">MazeClient</string>
-          <string name="Source"><![CDATA[local Players = game:GetService('Players')
+          <string name="Source">local Players = game:GetService('Players')
 local ReplicatedStorage = game:GetService('ReplicatedStorage')
 local RunService = game:GetService('RunService')
 local UserInputService = game:GetService('UserInputService')
@@ -14323,19 +20100,29 @@ local localPlayer = Players.LocalPlayer
 local playerGui = localPlayer:WaitForChild('PlayerGui')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
-local Shared = require(Packages:WaitForChild('Shared'))
-local UI = require(Packages:WaitForChild('UI'))
+local GameplayPackage = Packages:WaitForChild('Gameplay')
+local SharedPackage = Packages:WaitForChild('Shared')
+local UIPackage = Packages:WaitForChild('UI')
 
-local FormalLocomotion = Shared.Runtime.FormalLocomotion
-local heldItemController = Shared.Client.HeldItemController.new(localPlayer)
-local Theme = UI.Hud.Theme
+local ItemPresentation =
+    require(GameplayPackage:WaitForChild('Config'):WaitForChild('ItemPresentation'))
+local FormalLocomotion =
+    require(SharedPackage:WaitForChild('Runtime'):WaitForChild('FormalLocomotion'))
+local HeldToolVisual = require(SharedPackage:WaitForChild('Client'):WaitForChild('HeldToolVisual'))
+local HeldItemController =
+    require(SharedPackage:WaitForChild('Client'):WaitForChild('HeldItemController'))
+local FirstPersonController =
+    require(SharedPackage:WaitForChild('Client'):WaitForChild('FirstPersonController'))
+local RemotesModule = require(SharedPackage:WaitForChild('Network'):WaitForChild('Remotes'))
+local Theme = require(UIPackage:WaitForChild('Hud'):WaitForChild('Theme'))
+local heldItemController = HeldItemController.new(localPlayer)
 local REMOTE_WAIT_TIMEOUT_SECONDS = 10
-local WAITING_STATUS_TEXT = 'Waiting for maze snapshot...'
-local INITIAL_DIAGNOSTIC_TEXT = 'Diagnostic: waiting for bootstrap signal...'
+local WAITING_STATUS_TEXT = '正在等待迷宫状态同步...'
+local INITIAL_DIAGNOSTIC_TEXT = '诊断信息：正在等待启动信号...'
 local REMOTE_WAIT_TIMEOUT_TEXT =
-    'Still waiting for the server snapshot. Remotes may be late or the maze server bootstrap may have failed.'
+    '仍在等待服务端快照。可能是 remote 还没准备好，或者迷宫启动失败了。'
 
-Shared.Client.FirstPersonController.start(localPlayer)
+FirstPersonController.start(localPlayer)
 
 local Remotes
 local actionInputConnection
@@ -14344,6 +20131,90 @@ local visibleBackpackItems = {}
 local didReceiveInitialSnapshot = false
 local lastToolUseRequestAt = -math.huge
 local heldToolCooldownSeconds = 0.2
+local mazeInventoryForSwing: { [string]: any }? = nil
+
+local function presentationIconSuffix(itemEntry: { [string]: any }?)
+    if type(itemEntry) ~= 'table' then
+        return ''
+    end
+    local uri = ItemPresentation.formatIconContentId(itemEntry.IconAssetId)
+    if uri ~= '' then
+        return ' | 2D 图标'
+    end
+    return ''
+end
+
+local function localizeSessionPhase(sessionPhase)
+    local labels = {
+        MazeActive = '迷宫进行中',
+        RunIntermission = '本轮完成',
+        FinalDebrief = '最终结算',
+        SessionClosed = '会话关闭',
+        RunPrep = '准备阶段',
+        RunField = '外场阶段',
+    }
+    return labels[sessionPhase] or tostring(sessionPhase or '迷宫进行中')
+end
+
+local function localizeLoopState(state)
+    local labels = {
+        Staging = '准备中',
+        Expedition = '探索中',
+        Extraction = '撤离中',
+        Settlement = '结算中',
+        Completed = '已完成',
+        Camp = '营地',
+    }
+    return labels[state] or tostring(state or '探索中')
+end
+
+local function localizeMazeStatus(mazeStatus)
+    local labels = {
+        active = '进行中',
+        completed = '已完成',
+        idle = '未开始',
+    }
+    return labels[mazeStatus] or tostring(mazeStatus or '进行中')
+end
+
+local function localizeBuildSource(source)
+    local labels = {
+        ContentHarness = '内容测试场',
+        DirectBootDefault = '本地直启',
+        JoinDataMergedBeforeBuild = '进场前合并',
+        JoinDataMergedAfterBuild = '进场后合并',
+    }
+    return labels[source] or tostring(source or '内容测试场')
+end
+
+local function localizeReturnReason(reason)
+    local labels = {
+        returned = '已返回',
+        death = '死亡',
+        settled = '强制结算',
+        timeout = '超时',
+    }
+    return labels[reason] or tostring(reason or '未知')
+end
+
+local function localizeRoomArea(areaText)
+    local labels = {
+        ['Maze Staging'] = '迷宫准备区',
+        ['Loot Room'] = '战利品房',
+        ['Camp Room'] = '营地区',
+        ['Monster Room'] = '怪物房',
+    }
+    return labels[areaText] or tostring(areaText or '未知区域')
+end
+
+local function localizeMovementStatus(status)
+    local labels = {
+        Disabled = '不可行动',
+        Ready = '可冲刺',
+        Recovering = '恢复中',
+    }
+    return labels[status] or tostring(status or '未知')
+end
 
 local function readBootstrapDiagnostic()
     local failed = ReplicatedStorage:GetAttribute('MazeBootstrapFailed')
@@ -14355,10 +20226,10 @@ local function readBootstrapDiagnostic()
 
     local lines = {}
     if phase ~= nil then
-        table.insert(lines, string.format('Phase: %s', tostring(phase)))
+        table.insert(lines, string.format('阶段：%s', tostring(phase)))
     end
     if err ~= nil then
-        table.insert(lines, string.format('Error: %s', tostring(err)))
+        table.insert(lines, string.format('错误：%s', tostring(err)))
     end
 
     if #lines == 0 then
@@ -14374,6 +20245,116 @@ screenGui.IgnoreGuiInset = true
 screenGui.ResetOnSpawn = false
 screenGui.Parent = playerGui
 
+-- Watch HUD: shows game time and remaining round time
+local watchFrame = Instance.new('Frame')
+watchFrame.Name = 'WatchHud'
+watchFrame.AnchorPoint = Vector2.new(1, 0)
+watchFrame.Position = UDim2.new(1, -16, 0, 16)
+watchFrame.Size = UDim2.fromOffset(130, 58)
+watchFrame.BackgroundColor3 = Color3.fromRGB(12, 10, 8)
+watchFrame.BackgroundTransparency = 0.15
+watchFrame.BorderSizePixel = 0
+watchFrame.Visible = false
+watchFrame.Parent = screenGui
+local watchCorner = Instance.new('UICorner')
+watchCorner.CornerRadius = UDim.new(0, 10)
+watchCorner.Parent = watchFrame
+local watchStroke = Instance.new('UIStroke')
+watchStroke.Color = Theme.Text
+watchStroke.Transparency = 0.7
+watchStroke.Thickness = 1
+watchStroke.Parent = watchFrame
+
+local watchClockIcon = Instance.new('TextLabel')
+watchClockIcon.Name = 'ClockIcon'
+watchClockIcon.Size = UDim2.fromOffset(16, 16)
+watchClockIcon.Position = UDim2.fromOffset(10, 10)
+watchClockIcon.BackgroundTransparency = 1
+watchClockIcon.Font = Enum.Font.GothamBold
+watchClockIcon.TextColor3 = Theme.Accent
+watchClockIcon.TextSize = 14
+watchClockIcon.Text = '\u{1F551}'
+watchClockIcon.Parent = watchFrame
+
+local watchTimeLabel = Instance.new('TextLabel')
+watchTimeLabel.Name = 'GameTime'
+watchTimeLabel.Size = UDim2.new(1, -36, 0, 22)
+watchTimeLabel.Position = UDim2.fromOffset(30, 6)
+watchTimeLabel.BackgroundTransparency = 1
+watchTimeLabel.Font = Enum.Font.GothamBold
+watchTimeLabel.TextColor3 = Theme.Text
+watchTimeLabel.TextSize = 18
+watchTimeLabel.TextXAlignment = Enum.TextXAlignment.Left
+watchTimeLabel.TextYAlignment = Enum.TextYAlignment.Center
+watchTimeLabel.Text = '07:00'
+watchTimeLabel.Parent = watchFrame
+
+local watchRemainLabel = Instance.new('TextLabel')
+watchRemainLabel.Name = 'Remaining'
+watchRemainLabel.Size = UDim2.new(1, -20, 0, 18)
+watchRemainLabel.Position = UDim2.fromOffset(10, 34)
+watchRemainLabel.BackgroundTransparency = 1
+watchRemainLabel.Font = Theme.Font
+watchRemainLabel.TextColor3 = Theme.SubtleText
+watchRemainLabel.TextSize = 13
+watchRemainLabel.TextXAlignment = Enum.TextXAlignment.Left
+watchRemainLabel.TextYAlignment = Enum.TextYAlignment.Center
+watchRemainLabel.Text = '\u{21BB} 15:00'
+watchRemainLabel.Parent = watchFrame
+
+local function formatGameTimeMaze(gameHour)
+    local totalMinutes = math.floor(gameHour * 60)
+    local h = math.floor(totalMinutes / 60)
+    local m = totalMinutes % 60
+    return string.format('%02d:%02d', h, m)
+end
+
+local function formatRemainingMaze(seconds)
+    local m = math.floor(seconds / 60)
+    local s = math.floor(seconds % 60)
+    return string.format('\u{21BB} %02d:%02d', m, s)
+end
+
+local _todConnectionMaze = nil
+local lastTodStateMaze = nil
+
+local function updateWatchMaze(todState)
+    if not todState then
+        watchFrame.Visible = false
+        return
+    end
+    local gameHour = todState.GameHour or 7
+    local remaining = todState.RoundTimeRemaining or 0
+    watchTimeLabel.Text = formatGameTimeMaze(gameHour)
+    watchRemainLabel.Text = formatRemainingMaze(remaining)
+    watchFrame.Visible = true
+    if remaining &lt; 180 then
+        watchTimeLabel.TextColor3 = Color3.fromRGB(220, 80, 80)
+        watchRemainLabel.TextColor3 = Color3.fromRGB(220, 80, 80)
+    else
+        watchTimeLabel.TextColor3 = Theme.Text
+        watchRemainLabel.TextColor3 = Theme.SubtleText
+    end
+end
+
+task.spawn(function()
+    local remoteFolder = ReplicatedStorage:WaitForChild('Remotes', 5)
+    if not remoteFolder then
+        return
+    end
+    local todRemote = remoteFolder:WaitForChild('TODState', 3)
+    if not todRemote then
+        return
+    end
+    _todConnectionMaze = todRemote.OnClientEvent:Connect(function(todState)
+        lastTodStateMaze = todState
+        updateWatchMaze(todState)
+    end)
+    if lastTodStateMaze then
+        updateWatchMaze(lastTodStateMaze)
+    end
+end)
+
 local function makeTextLabel(parent, size, color, textSize, bold)
     local label = Instance.new('TextLabel')
     label.Size = size
@@ -14388,42 +20369,227 @@ local function makeTextLabel(parent, size, color, textSize, bold)
     return label
 end
 
-local panel = Instance.new('Frame')
-panel.Name = 'MazePanel'
-panel.AnchorPoint = Vector2.new(0, 0)
-panel.Position = UDim2.fromScale(0.03, 0.05)
-panel.Size = UDim2.fromOffset(440, 560)
-panel.BackgroundColor3 = Theme.Background
-panel.BorderSizePixel = 0
-panel.Parent = screenGui
+local function applyPanelStyle(frame, cornerRadius, backgroundTransparency)
+    frame.BackgroundColor3 = Theme.Background
+    frame.BackgroundTransparency = backgroundTransparency or 0.18
+    frame.BorderSizePixel = 0
 
-local panelCorner = Instance.new('UICorner')
-panelCorner.CornerRadius = UDim.new(0, 16)
-panelCorner.Parent = panel
+    local corner = Instance.new('UICorner')
+    corner.CornerRadius = UDim.new(0, cornerRadius or 14)
+    corner.Parent = frame
+
+    local stroke = Instance.new('UIStroke')
+    stroke.Color = Theme.Text
+    stroke.Transparency = 0.72
+    stroke.Thickness = 1
+    stroke.Parent = frame
+end
+
+local function makePanel(parent, name, position, size, anchorPoint, transparency)
+    local frame = Instance.new('Frame')
+    frame.Name = name
+    frame.AnchorPoint = anchorPoint or Vector2.zero
+    frame.Position = position
+    frame.Size = size
+    frame.Parent = parent
+    applyPanelStyle(frame, 14, transparency)
+    return frame
+end
+
+local function makeSectionTitle(parent, text)
+    local label = makeTextLabel(parent, UDim2.new(1, 0, 0, 18), Theme.SubtleText, 12, true)
+    label.TextYAlignment = Enum.TextYAlignment.Center
+    label.Text = text
+    return label
+end
+
+local function makeDivider(parent)
+    local divider = Instance.new('Frame')
+    divider.Size = UDim2.new(1, 0, 0, 1)
+    divider.BackgroundColor3 = Theme.Text
+    divider.BackgroundTransparency = 0.82
+    divider.BorderSizePixel = 0
+    divider.Parent = parent
+    return divider
+end
+
+local function buildQuickSlotGlyph(itemEntry)
+    if type(itemEntry) ~= 'table' then
+        return ''
+    end
+
+    local toolCategory = itemEntry.ToolCategory
+    if toolCategory == 'Flashlight' then
+        return '灯'
+    elseif toolCategory == 'Crowbar' then
+        return '撬'
+    elseif toolCategory == 'Potion' then
+        return '药'
+    end
+
+    local itemCategory = itemEntry.ItemCategory
+    if itemCategory == 'Loot' then
+        return '资'
+    elseif itemCategory == 'Clue' then
+        return '线'
+    elseif itemCategory == 'Tool' then
+        return '工'
+    end
+
+    return '包'
+end
+
+local function truncateText(text, maxLength)
+    local value = tostring(text or '')
+    if #value &lt;= maxLength then
+        return value
+    end
+
+    return string.sub(value, 1, math.max(0, maxLength - 1)) .. '…'
+end
+
+local topHudFrame = Instance.new('Frame')
+topHudFrame.Name = 'TopHud'
+topHudFrame.AnchorPoint = Vector2.zero
+topHudFrame.Position = UDim2.new(0, 16, 0, 16)
+topHudFrame.Size = UDim2.fromOffset(380, 190)
+topHudFrame.BackgroundTransparency = 1
+topHudFrame.Parent = screenGui
+
+local healthPanel = makePanel(
+    topHudFrame,
+    'HealthPanel',
+    UDim2.fromOffset(0, 0),
+    UDim2.fromOffset(130, 76),
+    Vector2.zero,
+    0.16
+)
+local healthTitle = makeSectionTitle(healthPanel, '生命')
+healthTitle.Position = UDim2.fromOffset(12, 8)
+local healthValueLabel =
+    makeTextLabel(healthPanel, UDim2.new(1, -24, 0, 18), Theme.SubtleText, 13, false)
+healthValueLabel.Position = UDim2.fromOffset(12, 52)
+healthValueLabel.Text = '等待同步'
+
+local healthHearts = {}
+for index = 1, 4 do
+    local heart = makeTextLabel(healthPanel, UDim2.fromOffset(22, 26), Theme.Warning, 24, true)
+    heart.Position = UDim2.fromOffset(12 + (index - 1) * 24, 22)
+    heart.TextXAlignment = Enum.TextXAlignment.Center
+    heart.TextYAlignment = Enum.TextYAlignment.Center
+    heart.Text = '♥'
+    heart.Visible = false
+    healthHearts[index] = heart
+end
+
+local staminaPanel = makePanel(
+    topHudFrame,
+    'StaminaPanel',
+    UDim2.fromOffset(142, 0),
+    UDim2.fromOffset(238, 76),
+    Vector2.zero,
+    0.16
+)
+local staminaTitle = makeSectionTitle(staminaPanel, '体力 / 冲刺')
+staminaTitle.Position = UDim2.fromOffset(12, 8)
+local staminaValueLabel =
+    makeTextLabel(staminaPanel, UDim2.new(1, -24, 0, 18), Theme.Text, 16, true)
+staminaValueLabel.Position = UDim2.fromOffset(12, 24)
+staminaValueLabel.Text = '-- / --'
+
+local staminaTrack = Instance.new('Frame')
+staminaTrack.Name = 'StaminaTrack'
+staminaTrack.Size = UDim2.new(1, -24, 0, 12)
+staminaTrack.Position = UDim2.fromOffset(12, 48)
+staminaTrack.BackgroundColor3 = Theme.Surface
+staminaTrack.BackgroundTransparency = 0.25
+staminaTrack.BorderSizePixel = 0
+staminaTrack.Parent = staminaPanel
+local staminaTrackCorner = Instance.new('UICorner')
+staminaTrackCorner.CornerRadius = UDim.new(0, 6)
+staminaTrackCorner.Parent = staminaTrack
+
+local staminaFill = Instance.new('Frame')
+staminaFill.Name = 'StaminaFill'
+staminaFill.Size = UDim2.new(0, 0, 1, 0)
+staminaFill.BackgroundColor3 = Theme.Accent
+staminaFill.BorderSizePixel = 0
+staminaFill.Parent = staminaTrack
+local staminaFillCorner = Instance.new('UICorner')
+staminaFillCorner.CornerRadius = UDim.new(0, 6)
+staminaFillCorner.Parent = staminaFill
+
+local staminaStatusLabel =
+    makeTextLabel(staminaPanel, UDim2.new(1, -24, 0, 16), Theme.SubtleText, 13, false)
+staminaStatusLabel.Position = UDim2.fromOffset(12, 62)
+staminaStatusLabel.Text = '等待同步'
+
+local statusPanel = makePanel(
+    topHudFrame,
+    'StatusPanel',
+    UDim2.fromOffset(0, 88),
+    UDim2.fromOffset(380, 102),
+    Vector2.zero,
+    0.16
+)
+local statusAreaLabel =
+    makeTextLabel(statusPanel, UDim2.new(1, -24, 0, 18), Theme.SubtleText, 13, true)
+statusAreaLabel.Position = UDim2.fromOffset(12, 10)
+statusAreaLabel.Text = '区域：等待同步'
+
+local statusSummaryLabel =
+    makeTextLabel(statusPanel, UDim2.new(1, -24, 0, 24), Theme.Text, 20, true)
+statusSummaryLabel.Position = UDim2.fromOffset(12, 28)
+statusSummaryLabel.Text = WAITING_STATUS_TEXT
+statusSummaryLabel.TextYAlignment = Enum.TextYAlignment.Center
+
+local objectiveSummaryLabel =
+    makeTextLabel(statusPanel, UDim2.new(1, -24, 0, 18), Theme.Accent, 15, false)
+objectiveSummaryLabel.Position = UDim2.fromOffset(12, 58)
+objectiveSummaryLabel.Text = '目标：--'
+
+local heldStatusLabel =
+    makeTextLabel(statusPanel, UDim2.new(1, -24, 0, 16), Theme.SubtleText, 13, false)
+heldStatusLabel.Position = UDim2.fromOffset(12, 78)
+heldStatusLabel.Text = '当前手持：空手'
+
+local panel = makePanel(
+    screenGui,
+    'MazePanel',
+    UDim2.new(0, 16, 0, 220),
+    UDim2.fromOffset(360, 382),
+    Vector2.zero,
+    0.1
+)
 
 local panelPadding = Instance.new('UIPadding')
-panelPadding.PaddingTop = UDim.new(0, 18)
-panelPadding.PaddingLeft = UDim.new(0, 18)
-panelPadding.PaddingRight = UDim.new(0, 18)
-panelPadding.PaddingBottom = UDim.new(0, 18)
+panelPadding.PaddingTop = UDim.new(0, 16)
+panelPadding.PaddingLeft = UDim.new(0, 16)
+panelPadding.PaddingRight = UDim.new(0, 16)
+panelPadding.PaddingBottom = UDim.new(0, 16)
 panelPadding.Parent = panel
 
 local list = Instance.new('UIListLayout')
 list.Padding = UDim.new(0, 10)
 list.Parent = panel
 
-local title = makeTextLabel(panel, UDim2.new(1, 0, 0, 36), Theme.Text, 28, true)
-title.Text = 'Maze Status'
+local title = makeTextLabel(panel, UDim2.new(1, 0, 0, 24), Theme.Text, 22, true)
+title.Text = '详细信息'
+title.TextYAlignment = Enum.TextYAlignment.Center
 
-local statusLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 78), Theme.SubtleText, 18, false)
+local statusLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 56), Theme.SubtleText, 16, false)
 statusLabel.Text = WAITING_STATUS_TEXT
 
-local diagnosticLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 88), Theme.Warning, 16, false)
+local diagnosticLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 64), Theme.Warning, 15, false)
 diagnosticLabel.Text = INITIAL_DIAGNOSTIC_TEXT
 
 local function showSnapshotTimeout(fallbackDiagnosticText)
     local diagnostic = readBootstrapDiagnostic()
     statusLabel.Text = string.format('%s\n%s', WAITING_STATUS_TEXT, REMOTE_WAIT_TIMEOUT_TEXT)
+    statusSummaryLabel.Text = '迷宫还没准备好'
+    statusAreaLabel.Text = '区域：等待同步'
+    objectiveSummaryLabel.Text = '目标：等待服务端状态'
+    heldStatusLabel.Text = '当前手持：空手'
     diagnosticLabel.Text = diagnostic or fallbackDiagnosticText
 end
 
@@ -14433,40 +20599,167 @@ task.delay(REMOTE_WAIT_TIMEOUT_SECONDS, function()
         return
     end
 
-    showSnapshotTimeout('Diagnostic: no maze bootstrap attributes reached the client.')
+    showSnapshotTimeout('诊断信息：客户端还没有收到任何迷宫启动属性。')
 end)
 
-local objectiveLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 66), Theme.Accent, 18, false)
-objectiveLabel.Text = 'Objective: --'
+makeDivider(panel)
 
-local promptLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 86), Theme.Text, 16, false)
--- === 修改：加上了按 F 键使用道具的提示 ===
+local objectiveLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 50), Theme.Accent, 16, false)
+objectiveLabel.Text = '目标：--'
+
+local promptLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 72), Theme.Text, 14, false)
 promptLabel.Text =
-    'In-world prompts:\n- Loot pickups\n- Blue/Gold return markers -> Run Entrance\n- Double Door controls\nKeyboard: Hold LeftShift to sprint\nKeyboard: Press F to use held tool'
+    '交互：拾取战利品 / 开关门 / 返回\n按键：1-3 装备 | F 使用 | X 收起 | Shift 冲刺'
 
 if RunService:IsStudio() then
-    promptLabel.Text ..= '\nStudio debug: H light damage | J heavy damage'
+    promptLabel.Text ..= '\nStudio 调试：H 轻伤 | J 重伤'
 end
 
-local inventoryLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 44), Theme.Warning, 16, false)
-inventoryLabel.Text = 'Inventory: --'
+makeDivider(panel)
 
-local inventoryDetailLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 126), Theme.Text, 15, false)
+local inventoryLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 40), Theme.Warning, 15, false)
+inventoryLabel.Text = '背包：--'
+
+local inventoryDetailLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 102), Theme.Text, 14, false)
 inventoryDetailLabel.Text = ''
 
-local playerStateLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 86), Theme.Warning, 16, false)
-playerStateLabel.Text = 'Health: --\nStamina: --\nState: --\nMovement: --'
+makeDivider(panel)
 
-local rosterLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 94), Theme.SubtleText, 16, false)
+local playerStateLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 72), Theme.Warning, 15, false)
+playerStateLabel.Text = '生命：--\n体力：--\n状态：--\n移动：--'
+
+local rosterLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 78), Theme.SubtleText, 14, false)
 rosterLabel.Text = ''
 
-local returnedLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 104), Theme.SubtleText, 16, false)
+local returnedLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 86), Theme.SubtleText, 14, false)
 returnedLabel.Text = ''
+
+local quickbarPanel = makePanel(
+    screenGui,
+    'QuickbarPanel',
+    UDim2.new(1, -18, 0.5, -84),
+    UDim2.fromOffset(94, 244),
+    Vector2.new(1, 0.5),
+    0.08
+)
+local quickbarPadding = Instance.new('UIPadding')
+quickbarPadding.PaddingTop = UDim.new(0, 10)
+quickbarPadding.PaddingLeft = UDim.new(0, 10)
+quickbarPadding.PaddingRight = UDim.new(0, 10)
+quickbarPadding.PaddingBottom = UDim.new(0, 10)
+quickbarPadding.Parent = quickbarPanel
+local quickbarTitle = makeSectionTitle(quickbarPanel, '快捷栏')
+quickbarTitle.Position = UDim2.fromOffset(0, 0)
+
+local quickbarSlots = {}
+for slotIndex = 1, 3 do
+    local slotFrame = makePanel(
+        quickbarPanel,
+        string.format('QuickSlot_%d', slotIndex),
+        UDim2.fromOffset(0, 24 + (slotIndex - 1) * 68),
+        UDim2.fromOffset(74, 58),
+        Vector2.zero,
+        0.02
+    )
+    slotFrame.BackgroundTransparency = 0.02
+
+    local keyLabel = makeTextLabel(slotFrame, UDim2.fromOffset(18, 16), Theme.SubtleText, 12, true)
+    keyLabel.Position = UDim2.fromOffset(8, 6)
+    keyLabel.Text = tostring(slotIndex)
+    keyLabel.TextXAlignment = Enum.TextXAlignment.Center
+    keyLabel.TextYAlignment = Enum.TextYAlignment.Center
+
+    local glyphLabel = makeTextLabel(slotFrame, UDim2.fromOffset(54, 24), Theme.Accent, 24, true)
+    glyphLabel.Position = UDim2.fromOffset(10, 18)
+    glyphLabel.Text = '—'
+    glyphLabel.TextXAlignment = Enum.TextXAlignment.Center
+    glyphLabel.TextYAlignment = Enum.TextYAlignment.Center
+
+    local nameLabel = makeTextLabel(slotFrame, UDim2.new(1, -16, 0, 16), Theme.Text, 12, false)
+    nameLabel.Position = UDim2.fromOffset(8, 40)
+    nameLabel.TextXAlignment = Enum.TextXAlignment.Center
+    nameLabel.TextYAlignment = Enum.TextYAlignment.Center
+    nameLabel.Text = '空'
+
+    quickbarSlots[slotIndex] = {
+        Frame = slotFrame,
+        Glyph = glyphLabel,
+        Name = nameLabel,
+    }
+end
+
+local hintsPanel = makePanel(
+    screenGui,
+    'HintsPanel',
+    UDim2.new(0.5, 0, 1, -16),
+    UDim2.fromOffset(426, 70),
+    Vector2.new(0.5, 1),
+    0.08
+)
+local hintsTitle = makeSectionTitle(hintsPanel, '常用按键')
+hintsTitle.Position = UDim2.fromOffset(14, 8)
+
+local hintsLabel = makeTextLabel(hintsPanel, UDim2.new(1, -28, 0, 36), Theme.Text, 14, false)
+hintsLabel.Position = UDim2.fromOffset(14, 26)
+hintsLabel.Text = 'Shift 冲刺   F 使用工具   X 收起手持   1-3 快速装备'
+hintsLabel.TextYAlignment = Enum.TextYAlignment.Center
+
+local function updateHealthDisplay(currentHealthPips, maxHealthPips)
+    local maxPips = math.clamp(math.floor(tonumber(maxHealthPips) or 0), 0, #healthHearts)
+    local currentPips = math.clamp(math.floor(tonumber(currentHealthPips) or 0), 0, maxPips)
+
+    for index, heart in ipairs(healthHearts) do
+        heart.Visible = index &lt;= math.max(maxPips, 1)
+        heart.TextColor3 = if index &lt;= currentPips then Theme.Warning else Theme.SubtleText
+        heart.TextTransparency = if index &lt;= currentPips then 0 else 0.35
+    end
+
+    healthValueLabel.Text = string.format('%d / %d 格', currentPips, math.max(maxPips, 1))
+end
+
+local function updateStaminaDisplay(currentStamina, maxStamina, movementStatus, isSprinting)
+    local currentValue = math.max(0, tonumber(currentStamina) or 0)
+    local maxValue = math.max(1, tonumber(maxStamina) or 1)
+    local ratio = math.clamp(currentValue / maxValue, 0, 1)
+
+    staminaValueLabel.Text =
+        string.format('%d / %d', math.floor(currentValue + 0.5), math.floor(maxValue + 0.5))
+    staminaFill.Size = UDim2.new(ratio, 0, 1, 0)
+    if ratio &gt;= 0.6 then
+        staminaFill.BackgroundColor3 = Theme.Accent
+    elseif ratio &gt;= 0.25 then
+        staminaFill.BackgroundColor3 = Theme.Warning
+    else
+        staminaFill.BackgroundColor3 = Color3.fromRGB(220, 80, 80)
+    end
+
+    staminaStatusLabel.Text =
+        string.format('%s%s', movementStatus, isSprinting and ' | 正在冲刺' or '')
+end
+
+local function updateQuickbarDisplay(inventory)
+    local backpackItems = if type(inventory) == 'table' then inventory.BackpackItems or {} else {}
+    for slotIndex, slot in ipairs(quickbarSlots) do
+        local itemEntry = backpackItems[slotIndex]
+        if itemEntry then
+            slot.Glyph.Text = buildQuickSlotGlyph(itemEntry)
+            slot.Glyph.TextColor3 = Theme.Accent
+            slot.Name.Text = truncateText(itemEntry.Name or itemEntry.ItemCategory or '物品', 5)
+            slot.Name.TextColor3 = Theme.Text
+        else
+            slot.Glyph.Text = '—'
+            slot.Glyph.TextColor3 = Theme.SubtleText
+            slot.Name.Text = '空'
+            slot.Name.TextColor3 = Theme.SubtleText
+        end
+    end
+end
 
 actionInputConnection = UserInputService.InputBegan:Connect(function(input, gameProcessedEvent)
     if gameProcessedEvent or input.UserInputType ~= Enum.UserInputType.Keyboard then
         return
     end
+
     if Remotes == nil then
         return
     end
@@ -14481,11 +20774,15 @@ actionInputConnection = UserInputService.InputBegan:Connect(function(input, game
     -- === 新增：监听 F 键并发送 RequestUseTool ===
     if input.KeyCode == Enum.KeyCode.F then
         local now = os.clock()
-        if now - lastToolUseRequestAt < heldToolCooldownSeconds then
+        if now - lastToolUseRequestAt &lt; heldToolCooldownSeconds then
             return
         end
 
         lastToolUseRequestAt = now
+        local heldForSwing = mazeInventoryForSwing and mazeInventoryForSwing.HeldItem
+        if heldForSwing and heldForSwing.ToolCategory == 'Crowbar' then
+            HeldToolVisual.playCrowbarSwingFeedback(localPlayer.Character)
+        end
         Remotes.MazeAction:FireServer({
             Type = 'RequestUseTool',
         })
@@ -14561,6 +20858,10 @@ script.Destroying:Connect(function()
         sprintInputEndedConnection:Disconnect()
         sprintInputEndedConnection = nil
     end
+    if _todConnectionMaze then
+        _todConnectionMaze:Disconnect()
+        _todConnectionMaze = nil
+    end
 
     heldItemController:destroy()
 end)
@@ -14579,33 +20880,44 @@ local function connectMazeRemotes(remotes)
         diagnosticLabel.Text = ''
         local diagnosticSeed = snapshot.WorldBuildSeed ~= nil and tostring(snapshot.WorldBuildSeed)
             or '--'
-        local diagnosticDirect = snapshot.WorldBuildIsDirectBoot == true and 'true' or 'false'
-        local diagnosticSource = snapshot.WorldBuildSource or 'Pending'
+        local diagnosticDirect = snapshot.WorldBuildIsDirectBoot == true and '是' or '否'
+        local diagnosticSource = localizeBuildSource(snapshot.WorldBuildSource)
+        local localizedArea = localizeRoomArea(snapshot.Area)
+        local localizedLoopState = localizeLoopState(snapshot.State)
+        local localizedSessionPhase = localizeSessionPhase(snapshot.SessionPhase)
+        local localizedMazeStatus = localizeMazeStatus(snapshot.MazeStatus)
         statusLabel.Text = string.format(
-            '%s\nArea: %s | Phase: %s | Maze: %s%s\nBuild: %s | Seed: %s | Direct: %s',
-            snapshot.Status or 'Maze ready.',
-            snapshot.Area or 'Unknown',
-            snapshot.State or 'Camp',
-            snapshot.MazeStatus or 'active',
-            snapshot.IsDirectBoot and ' | Direct Boot' or '',
+            '%s\n区域：%s | 流程：%s | 会话：%s | 迷宫：%s%s\n构建来源：%s | 种子：%s | 直启：%s',
+            snapshot.Status or '迷宫已准备就绪。',
+            localizedArea,
+            localizedLoopState,
+            localizedSessionPhase,
+            localizedMazeStatus,
+            snapshot.IsDirectBoot and ' | 本地直启' or '',
             diagnosticSource,
             diagnosticSeed,
             diagnosticDirect
         )
+        statusAreaLabel.Text = string.format('区域：%s', localizedArea)
+        statusSummaryLabel.Text =
+            string.format('%s | %s', localizedLoopState, localizedSessionPhase)
+        objectiveSummaryLabel.Text = string.format('目标：%s', snapshot.Objective or '--')
 
-        objectiveLabel.Text = string.format('Objective: %s', snapshot.Objective or '--')
+        objectiveLabel.Text = string.format('目标：%s', snapshot.Objective or '--')
 
         local inventory = snapshot.Inventory or {}
+        mazeInventoryForSwing = inventory
         visibleBackpackItems = inventory.BackpackItems or {}
         heldItemController:applyInventory(inventory)
+        updateQuickbarDisplay(inventory)
         inventoryLabel.Text = string.format(
-            'Inventory: %d total | %d backpack | %d held | %d/%d KG | %d value',
+            '背包：共 %d 件 | 战利品 %d | 线索 %d | 工具 %d | 槽位 %d/%d',
             inventory.Count or 0,
-            inventory.BackpackCount or 0,
-            inventory.HeldCount or 0,
-            inventory.Weight or 0,
-            inventory.Capacity or 0,
-            inventory.Value or 0
+            inventory.LootCount or 0,
+            inventory.ClueCount or 0,
+            inventory.ToolCount or 0,
+            inventory.Count or 0,
+            inventory.Capacity or 0
         )
 
         local heldItem = inventory.HeldItem
@@ -14614,57 +20926,73 @@ local function connectMazeRemotes(remotes)
         else
             heldToolCooldownSeconds = 0.2
         end
+        heldStatusLabel.Text = heldItem
+                and string.format(
+                    '当前手持：%s%s',
+                    heldItem.Name,
+                    heldItem.Light and ' | 发光中' or ''
+                )
+            or '当前手持：空手'
 
         local detailLines = {
             heldItem and string.format(
-                'Held: %s | %d KG | %d value%s',
+                '当前手持：%s | %s%s%s',
                 heldItem.Name,
-                heldItem.Weight,
-                heldItem.Value,
-                heldItem.Light and ' | Glow active' or ''
-            ) or 'Held: Empty hands',
-            'Backpack:',
+                heldItem.ItemCategory or '战利品',
+                heldItem.Light and ' | 发光中' or '',
+                presentationIconSuffix(heldItem)
+            ) or '当前手持：空手',
+            '背包内容：',
         }
 
         if #visibleBackpackItems == 0 then
-            table.insert(detailLines, '- Empty')
+            table.insert(detailLines, '- 空')
         else
             for itemIndex = 1, math.min(#visibleBackpackItems, 3) do
                 local itemEntry = visibleBackpackItems[itemIndex]
                 table.insert(
                     detailLines,
                     string.format(
-                        '- [%d] %s | %d KG | %d value',
+                        '- [%d] %s | %s%s',
                         itemIndex,
                         itemEntry.Name,
-                        itemEntry.Weight,
-                        itemEntry.Value
+                        itemEntry.ItemCategory or '战利品',
+                        presentationIconSuffix(itemEntry)
                     )
                 )
             end
         end
 
         table.insert(detailLines, '')
-        table.insert(detailLines, 'Keys: 1-3 equip listed item | X unequip held item')
+        table.insert(detailLines, '按键：1-3 装备列表物品 | X 收起当前手持')
         inventoryDetailLabel.Text = table.concat(detailLines, '\n')
 
         local playerState = snapshot.PlayerState or {}
         local movement = snapshot.Movement or {}
+        local movementStatus =
+            localizeMovementStatus(FormalLocomotion.formatStatus(playerState, movement))
+        updateHealthDisplay(playerState.HealthPips or 0, playerState.MaxHealthPips or 0)
+        updateStaminaDisplay(
+            playerState.CurrentStamina or 0,
+            playerState.MaxStamina or 0,
+            movementStatus,
+            movement.Mode == 'Sprint'
+        )
         playerStateLabel.Text = string.format(
-            'Health: %d/%d pips\nStamina: %d/%d\nState: %s\nMovement: %s | Sprint: %s',
+            '生命：%d/%d 格\n体力：%d/%d\n状态：%s\n移动：%s | 冲刺：%s',
             playerState.HealthPips or 0,
             playerState.MaxHealthPips or 0,
             math.floor((playerState.CurrentStamina or 0) + 0.5),
             math.floor((playerState.MaxStamina or 0) + 0.5),
-            playerState.IsDead and 'Dead' or 'Alive',
-            movement.Mode or 'Walk',
-            FormalLocomotion.formatStatus(playerState, movement)
+            playerState.IsDead and '已死亡' or '存活',
+            movement.Mode == 'Sprint' and '冲刺' or '行走',
+            movementStatus
         )
 
-        local rosterLines = { 'Crew:' }
+        local rosterLines = { '队伍：' }
         for _, rosterEntry in ipairs(snapshot.Roster or {}) do
-            local youMarker = rosterEntry.UserId == localPlayer.UserId and ' (You)' or ''
-            local stateMarker = rosterEntry.InMaze == false and ' - Returned' or ' - Active'
+            local youMarker = rosterEntry.UserId == localPlayer.UserId and ' (你)' or ''
+            local stateMarker = rosterEntry.InMaze == false and ' - 已返回' or ' - 仍在迷宫'
             table.insert(
                 rosterLines,
                 string.format('- %s%s%s', rosterEntry.Name, youMarker, stateMarker)
@@ -14672,19 +21000,19 @@ local function connectMazeRemotes(remotes)
         end
         rosterLabel.Text = table.concat(rosterLines, '\n')
 
-        local returnedLines = { 'Returned summaries:' }
+        local returnedLines = { '返回记录：' }
         local returned = snapshot.ReturnedPlayerSummaries or {}
         if #returned == 0 then
-            table.insert(returnedLines, '- No one has returned yet.')
+            table.insert(returnedLines, '- 还没有人返回。')
         else
             for _, entry in ipairs(returned) do
                 table.insert(
                     returnedLines,
                     string.format(
-                        '- %s: %d value (%s)',
+                        '- %s：%d 件战利品（%s）',
                         entry.Name,
-                        entry.Value or 0,
-                        entry.ReturnReason or 'unknown'
+                        entry.LootItemCount or entry.MissionCount or 0,
+                        localizeReturnReason(entry.ReturnReason)
                     )
                 )
             end
@@ -14695,141 +21023,650 @@ end
 
 task.spawn(function()
     local ok, resolvedRemotes = pcall(function()
-        return Shared.Network.Remotes.waitForScope(
-            Shared.Network.Remotes.Scope.Maze,
-            REMOTE_WAIT_TIMEOUT_SECONDS
-        )
+        return RemotesModule.waitForScope(RemotesModule.Scope.Maze, REMOTE_WAIT_TIMEOUT_SECONDS)
     end)
 
     if not ok then
         showSnapshotTimeout(
-            'Diagnostic: remotes did not appear before timeout; waiting indefinitely now.'
+            '诊断信息：超时前没有等到 remotes，接下来会继续无限等待。'
         )
-        resolvedRemotes = Shared.Network.Remotes.waitForScope(Shared.Network.Remotes.Scope.Maze)
+        resolvedRemotes = RemotesModule.waitForScope(RemotesModule.Scope.Maze)
     end
 
     Remotes = resolvedRemotes
     connectMazeRemotes(Remotes)
 end)
-]]></string>
+</string>
         </Properties>
       </Item>
     </Item>
   </Item>
-  <Item class="Workspace" referent="117">
+  <Item class="Workspace" referent="180">
     <Properties>
       <string name="Name">Workspace</string>
       <bool name="NeedsPivotMigration">false</bool>
     </Properties>
-    <Item class="Folder" referent="118">
+    <Item class="Folder">
       <Properties>
         <string name="Name">MazeStaticWorld</string>
       </Properties>
-      <Item class="Part" referent="119">
+      <Item class="Part" referent="181">
+        <Properties>
+          <string name="Name">SpawnMarker</string>
+          <bool name="Anchored">true</bool>
+          <bool name="CanCollide">false</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <float name="Transparency">1</float>
+          <Vector3 name="Size">
+            <X>4</X>
+            <Y>1</Y>
+            <Z>4</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>-52</X>
+            <Y>4</Y>
+            <Z>-48</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
+        </Properties>
+      </Item>
+      <Item class="Part" referent="182">
         <Properties>
           <string name="Name">ReturnHoldPad</string>
           <bool name="Anchored">true</bool>
+          <bool name="CanCollide">false</bool>
+          <bool name="CanTouch">false</bool>
+          <bool name="CanQuery">true</bool>
+          <float name="Transparency">1</float>
+          <Vector3 name="Size">
+            <X>8</X>
+            <Y>1</Y>
+            <Z>8</Z>
+          </Vector3>
+          <CoordinateFrame name="CFrame">
+            <X>-56</X>
+            <Y>0.5</Y>
+            <Z>-56</Z>
+            <R00>1</R00>
+            <R01>0</R01>
+            <R02>0</R02>
+            <R10>0</R10>
+            <R11>1</R11>
+            <R12>0</R12>
+            <R20>0</R20>
+            <R21>0</R21>
+            <R22>1</R22>
+          </CoordinateFrame>
         </Properties>
-        <Item class="ProximityPrompt" referent="120">
+        <Item class="ProximityPrompt" referent="183">
           <Properties>
             <string name="Name">Prompt</string>
           </Properties>
         </Item>
       </Item>
-      <Item class="Model" referent="121">
+      <Item class="Model" referent="184">
         <Properties>
           <string name="Name">Room_Camp</string>
-          <BinaryString name="AttributesSerialize">AwAAAA4AAABEaWZmaWN1bHR5VGllcgYAAAAAAAAAAAYAAABJc0NhbXADAQgAAABSb29tVHlwZQIHAAAAT3Blbkh1Yg==</BinaryString>
-          <bool name="NeedsPivotMigration">false</bool>
         </Properties>
-        <Item class="Part" referent="122">
+        <Item class="Part" referent="185">
           <Properties>
             <string name="Name">Shell</string>
             <bool name="Anchored">true</bool>
+            <bool name="CanCollide">false</bool>
+            <bool name="CanTouch">false</bool>
+            <bool name="CanQuery">true</bool>
+            <float name="Transparency">1</float>
+            <Vector3 name="Size">
+              <X>28</X>
+              <Y>12</Y>
+              <Z>28</Z>
+            </Vector3>
+            <CoordinateFrame name="CFrame">
+              <X>-44</X>
+              <Y>6</Y>
+              <Z>-36</Z>
+              <R00>1</R00>
+              <R01>0</R01>
+              <R02>0</R02>
+              <R10>0</R10>
+              <R11>1</R11>
+              <R12>0</R12>
+              <R20>0</R20>
+              <R21>0</R21>
+              <R22>1</R22>
+            </CoordinateFrame>
           </Properties>
         </Item>
       </Item>
-      <Item class="Model" referent="123">
-        <Properties>
-          <string name="Name">Room_Extraction</string>
-          <BinaryString name="AttributesSerialize">AgAAAAwAAABJc0V4dHJhY3Rpb24DAQgAAABSb29tVHlwZQIIAAAAU3RyYWlnaHQ=</BinaryString>
-          <bool name="NeedsPivotMigration">false</bool>
-        </Properties>
-        <Item class="Part" referent="124">
-          <Properties>
-            <string name="Name">ExtractionMarker</string>
-            <bool name="Anchored">true</bool>
-          </Properties>
-          <Item class="ProximityPrompt" referent="125">
-            <Properties>
-              <string name="Name">Prompt</string>
-            </Properties>
-          </Item>
-        </Item>
-        <Item class="Part" referent="126">
-          <Properties>
-            <string name="Name">Shell</string>
-            <bool name="Anchored">true</bool>
-          </Properties>
-        </Item>
-      </Item>
-      <Item class="Model" referent="127">
+      <Item class="Model" referent="186">
         <Properties>
           <string name="Name">Room_Loot</string>
-          <BinaryString name="AttributesSerialize">BAAAAA4AAABEaWZmaWN1bHR5VGllcgYAAAAAAAAAQBEAAABIYXNNb25zdGVyU3Bhd25lcgMBDQAAAE1vbnN0ZXJCdWRnZXQGAAAAAAAAAEAIAAAAUm9vbVR5cGUCBwAAAERlYWRFbmQ=</BinaryString>
-          <bool name="NeedsPivotMigration">false</bool>
         </Properties>
-        <Item class="Part" referent="128">
-          <Properties>
-            <string name="Name">Doorway_East</string>
-            <bool name="Anchored">true</bool>
-          </Properties>
-          <Item class="ProximityPrompt" referent="129">
-            <Properties>
-              <string name="Name">Prompt</string>
-            </Properties>
-          </Item>
-        </Item>
-        <Item class="Part" referent="130">
-          <Properties>
-            <string name="Name">LootPrompt</string>
-            <bool name="Anchored">true</bool>
-          </Properties>
-          <Item class="ProximityPrompt" referent="131">
-            <Properties>
-              <string name="Name">Prompt</string>
-            </Properties>
-          </Item>
-        </Item>
-        <Item class="Part" referent="132">
-          <Properties>
-            <string name="Name">LootSocket_1</string>
-            <bool name="Anchored">true</bool>
-          </Properties>
-        </Item>
-        <Item class="Part" referent="133">
+        <Item class="Part" referent="187">
           <Properties>
             <string name="Name">Shell</string>
             <bool name="Anchored">true</bool>
+            <bool name="CanCollide">false</bool>
+            <bool name="CanTouch">false</bool>
+            <bool name="CanQuery">true</bool>
+            <float name="Transparency">1</float>
+            <Vector3 name="Size">
+              <X>34</X>
+              <Y>12</Y>
+              <Z>34</Z>
+            </Vector3>
+            <CoordinateFrame name="CFrame">
+              <X>6</X>
+              <Y>6</Y>
+              <Z>-2</Z>
+              <R00>1</R00>
+              <R01>0</R01>
+              <R02>0</R02>
+              <R10>0</R10>
+              <R11>1</R11>
+              <R12>0</R12>
+              <R20>0</R20>
+              <R21>0</R21>
+              <R22>1</R22>
+            </CoordinateFrame>
           </Properties>
         </Item>
-        <Item class="Folder" referent="136">
+        <Item class="Folder" referent="188">
           <Properties>
             <string name="Name">MonsterSpawns</string>
           </Properties>
-          <Item class="Part" referent="134">
+          <Item class="Part" referent="189">
             <Properties>
               <string name="Name">SpawnPoint_1</string>
               <bool name="Anchored">true</bool>
+              <bool name="CanCollide">false</bool>
+              <bool name="CanTouch">false</bool>
+              <bool name="CanQuery">true</bool>
+              <float name="Transparency">1</float>
+              <Vector3 name="Size">
+                <X>2</X>
+                <Y>1</Y>
+                <Z>2</Z>
+              </Vector3>
+              <CoordinateFrame name="CFrame">
+                <X>0</X>
+                <Y>2</Y>
+                <Z>-2</Z>
+                <R00>1</R00>
+                <R01>0</R01>
+                <R02>0</R02>
+                <R10>0</R10>
+                <R11>1</R11>
+                <R12>0</R12>
+                <R20>0</R20>
+                <R21>0</R21>
+                <R22>1</R22>
+              </CoordinateFrame>
+            </Properties>
+          </Item>
+        </Item>
+        <Item class="Part" referent="190">
+          <Properties>
+            <string name="Name">LootSocket_1</string>
+            <bool name="Anchored">true</bool>
+            <bool name="CanCollide">false</bool>
+            <bool name="CanTouch">false</bool>
+            <bool name="CanQuery">true</bool>
+            <float name="Transparency">1</float>
+            <Vector3 name="Size">
+              <X>2</X>
+              <Y>1</Y>
+              <Z>2</Z>
+            </Vector3>
+            <CoordinateFrame name="CFrame">
+              <X>12</X>
+              <Y>2</Y>
+              <Z>-4</Z>
+              <R00>1</R00>
+              <R01>0</R01>
+              <R02>0</R02>
+              <R10>0</R10>
+              <R11>1</R11>
+              <R12>0</R12>
+              <R20>0</R20>
+              <R21>0</R21>
+              <R22>1</R22>
+            </CoordinateFrame>
+          </Properties>
+        </Item>
+        <Item class="Part" referent="191">
+          <Properties>
+            <string name="Name">LootPrompt</string>
+            <bool name="Anchored">true</bool>
+            <bool name="CanCollide">false</bool>
+            <bool name="CanTouch">false</bool>
+            <bool name="CanQuery">true</bool>
+            <float name="Transparency">1</float>
+            <Vector3 name="Size">
+              <X>2</X>
+              <Y>1</Y>
+              <Z>2</Z>
+            </Vector3>
+            <CoordinateFrame name="CFrame">
+              <X>12</X>
+              <Y>2</Y>
+              <Z>-4</Z>
+              <R00>1</R00>
+              <R01>0</R01>
+              <R02>0</R02>
+              <R10>0</R10>
+              <R11>1</R11>
+              <R12>0</R12>
+              <R20>0</R20>
+              <R21>0</R21>
+              <R22>1</R22>
+            </CoordinateFrame>
+          </Properties>
+          <Item class="ProximityPrompt" referent="192">
+            <Properties>
+              <string name="Name">Prompt</string>
+            </Properties>
+          </Item>
+        </Item>
+        <Item class="Part" referent="193">
+          <Properties>
+            <string name="Name">Doorway_East</string>
+            <bool name="Anchored">true</bool>
+            <bool name="CanCollide">true</bool>
+            <bool name="CanTouch">false</bool>
+            <bool name="CanQuery">true</bool>
+            <float name="Transparency">1</float>
+            <Vector3 name="Size">
+              <X>6</X>
+              <Y>8</Y>
+              <Z>2</Z>
+            </Vector3>
+            <CoordinateFrame name="CFrame">
+              <X>22</X>
+              <Y>4</Y>
+              <Z>-2</Z>
+              <R00>1</R00>
+              <R01>0</R01>
+              <R02>0</R02>
+              <R10>0</R10>
+              <R11>1</R11>
+              <R12>0</R12>
+              <R20>0</R20>
+              <R21>0</R21>
+              <R22>1</R22>
+            </CoordinateFrame>
+          </Properties>
+          <Item class="ProximityPrompt" referent="194">
+            <Properties>
+              <string name="Name">Prompt</string>
             </Properties>
           </Item>
         </Item>
       </Item>
-      <Item class="Part" referent="135">
+      <Item class="Folder">
         <Properties>
-          <string name="Name">SpawnMarker</string>
-          <bool name="Anchored">true</bool>
+          <string name="Name">Scenery</string>
         </Properties>
+        <Item class="Model" referent="195">
+          <Properties>
+            <string name="Name">maze.3dm</string>
+          </Properties>
+          <Item class="Model" referent="196">
+            <Properties>
+              <string name="Name">terrain</string>
+            </Properties>
+            <Item class="Part" referent="197">
+              <Properties>
+                <string name="Name">Ground</string>
+                <bool name="Anchored">true</bool>
+                <bool name="CanCollide">true</bool>
+                <bool name="CanTouch">false</bool>
+                <bool name="CanQuery">true</bool>
+                <Vector3 name="Size">
+                  <X>160</X>
+                  <Y>8</Y>
+                  <Z>160</Z>
+                </Vector3>
+                <CoordinateFrame name="CFrame">
+                  <X>0</X>
+                  <Y>-4</Y>
+                  <Z>0</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <Color3 name="Color">
+                  <R>0.29411765933036804</R>
+                  <G>0.3176470696926117</G>
+                  <B>0.2823529541492462</B>
+                </Color3>
+              </Properties>
+            </Item>
+            <Item class="Part" referent="198">
+              <Properties>
+                <string name="Name">NorthShelf</string>
+                <bool name="Anchored">true</bool>
+                <bool name="CanCollide">true</bool>
+                <bool name="CanTouch">false</bool>
+                <bool name="CanQuery">true</bool>
+                <Vector3 name="Size">
+                  <X>68</X>
+                  <Y>4</Y>
+                  <Z>40</Z>
+                </Vector3>
+                <CoordinateFrame name="CFrame">
+                  <X>-40</X>
+                  <Y>2</Y>
+                  <Z>-40</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <Color3 name="Color">
+                  <R>0.3607843220233917</R>
+                  <G>0.3490196168422699</G>
+                  <B>0.32156863808631897</B>
+                </Color3>
+              </Properties>
+            </Item>
+            <Item class="Part" referent="199">
+              <Properties>
+                <string name="Name">SouthShelf</string>
+                <bool name="Anchored">true</bool>
+                <bool name="CanCollide">true</bool>
+                <bool name="CanTouch">false</bool>
+                <bool name="CanQuery">true</bool>
+                <Vector3 name="Size">
+                  <X>54</X>
+                  <Y>4</Y>
+                  <Z>32</Z>
+                </Vector3>
+                <CoordinateFrame name="CFrame">
+                  <X>48</X>
+                  <Y>2</Y>
+                  <Z>40</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <Color3 name="Color">
+                  <R>0.3607843220233917</R>
+                  <G>0.3490196168422699</G>
+                  <B>0.32156863808631897</B>
+                </Color3>
+              </Properties>
+            </Item>
+          </Item>
+          <Item class="Model" referent="200">
+            <Properties>
+              <string name="Name">walls</string>
+            </Properties>
+            <Item class="Part" referent="201">
+              <Properties>
+                <string name="Name">NorthWall</string>
+                <bool name="Anchored">true</bool>
+                <bool name="CanCollide">true</bool>
+                <bool name="CanTouch">false</bool>
+                <bool name="CanQuery">true</bool>
+                <Vector3 name="Size">
+                  <X>156</X>
+                  <Y>20</Y>
+                  <Z>6</Z>
+                </Vector3>
+                <CoordinateFrame name="CFrame">
+                  <X>0</X>
+                  <Y>10</Y>
+                  <Z>-77</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <Color3 name="Color">
+                  <R>0.1568627506494522</R>
+                  <G>0.16470588743686676</G>
+                  <B>0.18039216101169586</B>
+                </Color3>
+              </Properties>
+            </Item>
+            <Item class="Part" referent="202">
+              <Properties>
+                <string name="Name">SouthWall</string>
+                <bool name="Anchored">true</bool>
+                <bool name="CanCollide">true</bool>
+                <bool name="CanTouch">false</bool>
+                <bool name="CanQuery">true</bool>
+                <Vector3 name="Size">
+                  <X>156</X>
+                  <Y>20</Y>
+                  <Z>6</Z>
+                </Vector3>
+                <CoordinateFrame name="CFrame">
+                  <X>0</X>
+                  <Y>10</Y>
+                  <Z>77</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <Color3 name="Color">
+                  <R>0.1568627506494522</R>
+                  <G>0.16470588743686676</G>
+                  <B>0.18039216101169586</B>
+                </Color3>
+              </Properties>
+            </Item>
+            <Item class="Part" referent="203">
+              <Properties>
+                <string name="Name">WestWall</string>
+                <bool name="Anchored">true</bool>
+                <bool name="CanCollide">true</bool>
+                <bool name="CanTouch">false</bool>
+                <bool name="CanQuery">true</bool>
+                <Vector3 name="Size">
+                  <X>6</X>
+                  <Y>20</Y>
+                  <Z>156</Z>
+                </Vector3>
+                <CoordinateFrame name="CFrame">
+                  <X>-77</X>
+                  <Y>10</Y>
+                  <Z>0</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <Color3 name="Color">
+                  <R>0.1568627506494522</R>
+                  <G>0.16470588743686676</G>
+                  <B>0.18039216101169586</B>
+                </Color3>
+              </Properties>
+            </Item>
+            <Item class="Part" referent="204">
+              <Properties>
+                <string name="Name">EastWall</string>
+                <bool name="Anchored">true</bool>
+                <bool name="CanCollide">true</bool>
+                <bool name="CanTouch">false</bool>
+                <bool name="CanQuery">true</bool>
+                <Vector3 name="Size">
+                  <X>6</X>
+                  <Y>20</Y>
+                  <Z>156</Z>
+                </Vector3>
+                <CoordinateFrame name="CFrame">
+                  <X>77</X>
+                  <Y>10</Y>
+                  <Z>0</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <Color3 name="Color">
+                  <R>0.1568627506494522</R>
+                  <G>0.16470588743686676</G>
+                  <B>0.18039216101169586</B>
+                </Color3>
+              </Properties>
+            </Item>
+            <Item class="Part" referent="205">
+              <Properties>
+                <string name="Name">CentralSpine</string>
+                <bool name="Anchored">true</bool>
+                <bool name="CanCollide">true</bool>
+                <bool name="CanTouch">false</bool>
+                <bool name="CanQuery">true</bool>
+                <Vector3 name="Size">
+                  <X>18</X>
+                  <Y>16</Y>
+                  <Z>92</Z>
+                </Vector3>
+                <CoordinateFrame name="CFrame">
+                  <X>8</X>
+                  <Y>8</Y>
+                  <Z>6</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <Color3 name="Color">
+                  <R>0.1882352977991104</R>
+                  <G>0.19607843458652496</G>
+                  <B>0.21176470816135406</B>
+                </Color3>
+              </Properties>
+            </Item>
+            <Item class="Part" referent="206">
+              <Properties>
+                <string name="Name">SouthBranch</string>
+                <bool name="Anchored">true</bool>
+                <bool name="CanCollide">true</bool>
+                <bool name="CanTouch">false</bool>
+                <bool name="CanQuery">true</bool>
+                <Vector3 name="Size">
+                  <X>74</X>
+                  <Y>16</Y>
+                  <Z>14</Z>
+                </Vector3>
+                <CoordinateFrame name="CFrame">
+                  <X>32</X>
+                  <Y>8</Y>
+                  <Z>28</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <Color3 name="Color">
+                  <R>0.1882352977991104</R>
+                  <G>0.19607843458652496</G>
+                  <B>0.21176470816135406</B>
+                </Color3>
+              </Properties>
+            </Item>
+          </Item>
+          <Item class="Model" referent="207">
+            <Properties>
+              <string name="Name">water</string>
+            </Properties>
+            <Item class="Part" referent="208">
+              <Properties>
+                <string name="Name">CentralPool</string>
+                <bool name="Anchored">true</bool>
+                <bool name="CanCollide">false</bool>
+                <bool name="CanTouch">false</bool>
+                <bool name="CanQuery">true</bool>
+                <float name="Transparency">0.35</float>
+                <Vector3 name="Size">
+                  <X>42</X>
+                  <Y>2</Y>
+                  <Z>24</Z>
+                </Vector3>
+                <CoordinateFrame name="CFrame">
+                  <X>28</X>
+                  <Y>1</Y>
+                  <Z>48</Z>
+                  <R00>1</R00>
+                  <R01>0</R01>
+                  <R02>0</R02>
+                  <R10>0</R10>
+                  <R11>1</R11>
+                  <R12>0</R12>
+                  <R20>0</R20>
+                  <R21>0</R21>
+                  <R22>1</R22>
+                </CoordinateFrame>
+                <Color3 name="Color">
+                  <R>0.125490203499794</R>
+                  <G>0.4117647111415863</G>
+                  <B>0.7607843279838562</B>
+                </Color3>
+              </Properties>
+            </Item>
+          </Item>
+        </Item>
       </Item>
     </Item>
   </Item>

--- a/places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau
@@ -72,11 +72,6 @@ local function getMazeAssets()
 end
 
 local function createRoot()
-    local existing = Workspace:FindFirstChild(MazeStaticWorldContract.RootName)
-    if existing ~= nil then
-        existing:Destroy()
-    end
-
     local root = Instance.new('Folder')
     root.Name = MazeStaticWorldContract.RootName
     root.Parent = Workspace
@@ -89,6 +84,26 @@ local function createRoot()
     return root, sceneryRoot
 end
 
+local function requireSceneryRoot(root, contextLabel)
+    local sceneryRoot = root:FindFirstChild(MazeStaticWorldContract.SceneryFolderName)
+    if sceneryRoot == nil then
+        sceneryRoot = Instance.new('Folder')
+        sceneryRoot.Name = MazeStaticWorldContract.SceneryFolderName
+        sceneryRoot.Parent = root
+    elseif not sceneryRoot:IsA('Folder') then
+        error(
+            string.format(
+                '%s must keep "%s" authored as a Folder.',
+                contextLabel,
+                MazeStaticWorldContract.SceneryFolderName
+            ),
+            0
+        )
+    end
+
+    return sceneryRoot
+end
+
 local function stabilizeChunkGeometry(chunkModel)
     for _, descendant in ipairs(chunkModel:GetDescendants()) do
         if descendant:IsA('BasePart') then
@@ -98,6 +113,63 @@ local function stabilizeChunkGeometry(chunkModel)
             descendant:SetAttribute('IsScenery', true)
         end
     end
+end
+
+local function applyRoomAttributes(room, definition)
+    for attributeName, attributeValue in pairs(definition) do
+        room:SetAttribute(attributeName, attributeValue)
+    end
+end
+
+local function validateRoot(root, contextLabel)
+    if not (root:IsA('Folder') or root:IsA('Model')) then
+        error(string.format('%s must be a Folder or Model.', contextLabel), 0)
+    end
+
+    root:SetAttribute('BuildFingerprint', MazeStaticWorldContract.BuildFingerprint)
+    requireSceneryRoot(root, contextLabel)
+
+    for _, partName in ipairs(MazeStaticWorldOverlayManifest.RootParts) do
+        requireBasePart(root, partName, contextLabel)
+    end
+
+    requirePrompt(requireBasePart(root, 'ReturnHoldPad', contextLabel), contextLabel)
+
+    for roomName, definition in pairs(MazeStaticWorldOverlayManifest.Rooms) do
+        local room = root:FindFirstChild(roomName)
+        if room == nil or not room:IsA('Model') then
+            error(
+                string.format('%s is missing required room model "%s".', contextLabel, roomName),
+                0
+            )
+        end
+
+        applyRoomAttributes(room, definition)
+    end
+
+    local lootRoom = root:FindFirstChild('Room_Loot')
+    if lootRoom == nil then
+        error(string.format('%s must define Room_Loot.', contextLabel), 0)
+    end
+
+    for _, nodeName in ipairs(MazeStaticWorldOverlayManifest.RequiredInteractionNodes) do
+        local node = root:FindFirstChild(nodeName, true)
+        if node == nil then
+            error(
+                string.format(
+                    '%s is missing required interaction node "%s".',
+                    contextLabel,
+                    nodeName
+                ),
+                0
+            )
+        end
+    end
+
+    requirePrompt(requireBasePart(lootRoom, 'LootPrompt', contextLabel), contextLabel)
+    requirePrompt(requireBasePart(lootRoom, 'Doorway_East', contextLabel), contextLabel)
+
+    return root
 end
 
 local function cloneChunkAsset(chunkAsset, chunkDefinition, sceneryRoot)
@@ -120,73 +192,19 @@ local function cloneChunkAsset(chunkAsset, chunkDefinition, sceneryRoot)
     end
 end
 
-local function applyRoomAttributes(room, definition)
-    for attributeName, attributeValue in pairs(definition) do
-        room:SetAttribute(attributeName, attributeValue)
-    end
-end
-
 local function cloneOverlayAsset(overlayAsset, root)
     for _, child in ipairs(overlayAsset:GetChildren()) do
         local clone = child:Clone()
         clone.Parent = root
     end
-
-    for _, partName in ipairs(MazeStaticWorldOverlayManifest.RootParts) do
-        requireBasePart(root, partName, 'Maze static world overlay')
-    end
-
-    requirePrompt(
-        requireBasePart(root, 'ReturnHoldPad', 'Maze static world overlay'),
-        'Maze static world overlay'
-    )
-
-    for roomName, definition in pairs(MazeStaticWorldOverlayManifest.Rooms) do
-        local room = root:FindFirstChild(roomName)
-        if room == nil or not room:IsA('Model') then
-            error(
-                string.format(
-                    'Maze static world overlay is missing required room model "%s".',
-                    roomName
-                ),
-                0
-            )
-        end
-
-        applyRoomAttributes(room, definition)
-    end
-
-    local lootRoom = root:FindFirstChild('Room_Loot')
-    if lootRoom == nil then
-        error('Maze static world overlay must define Room_Loot.', 0)
-    end
-
-    for _, nodeName in ipairs(MazeStaticWorldOverlayManifest.RequiredInteractionNodes) do
-        local node = root:FindFirstChild(nodeName, true)
-        if node == nil then
-            error(
-                string.format(
-                    'Maze static world overlay is missing required interaction node "%s".',
-                    nodeName
-                ),
-                0
-            )
-        end
-    end
-
-    -- MazeWorldScanner only binds gameplay nodes that are direct room children,
-    -- so the overlay authoring contract keeps these prompt parts at that level.
-    requirePrompt(
-        requireBasePart(lootRoom, 'LootPrompt', 'Maze static world overlay'),
-        'Maze static world overlay'
-    )
-    requirePrompt(
-        requireBasePart(lootRoom, 'Doorway_East', 'Maze static world overlay'),
-        'Maze static world overlay'
-    )
 end
 
 function MazeStaticWorldAssembler.assemble()
+    local existing = Workspace:FindFirstChild(MazeStaticWorldContract.RootName)
+    if existing ~= nil then
+        return validateRoot(existing, 'Authored MazeStaticWorld')
+    end
+
     local chunkAssets, overlayAssets = getMazeAssets()
     local root, sceneryRoot = createRoot()
 
@@ -214,7 +232,7 @@ function MazeStaticWorldAssembler.assemble()
         error('Maze chunk manifest must enable at least one geometry chunk.', 0)
     end
 
-    return root
+    return validateRoot(root, 'Maze scaffold static world')
 end
 
 return MazeStaticWorldAssembler

--- a/scripts/build-harnesses.ps1
+++ b/scripts/build-harnesses.ps1
@@ -23,6 +23,10 @@ try {
         }
 
         rojo build $ProjectPath -o $OutputPath
+
+        if ($OutputPath -eq 'places/maze/harness/maze.rbxlx') {
+            python scripts/hydrate-maze-harness.py $OutputPath
+        }
     }
 
     Build-Harness places/run/default.project.json places/run/harness/run.rbxlx

--- a/scripts/build-harnesses.sh
+++ b/scripts/build-harnesses.sh
@@ -19,6 +19,10 @@ build_harness() {
   fi
 
   rojo build "$project_path" -o "$output_path"
+
+  if [[ "$output_path" == "places/maze/harness/maze.rbxlx" ]]; then
+    python3 scripts/hydrate-maze-harness.py "$output_path"
+  fi
 }
 
 build_harness places/run/default.project.json places/run/harness/run.rbxlx

--- a/scripts/hydrate-maze-harness.py
+++ b/scripts/hydrate-maze-harness.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import copy
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+REFERENT_RE = re.compile(r"^-?\d+$")
+WORKSPACE_NAME = 'Workspace'
+STATIC_WORLD_NAME = 'MazeStaticWorld'
+SCENERY_NAME = 'Scenery'
+CHUNK_NAME = 'maze.3dm'
+OVERLAY_PATH = Path('places/maze/assets/Overlays/MazeStaticWorldOverlay_Default.rbxmx')
+CHUNK_PATH = Path('places/maze/assets/Chunks/MazeChunk_maze_v1.rbxmx')
+
+
+def get_name(item: ET.Element) -> str | None:
+    props = item.find('Properties')
+    if props is None:
+        return None
+    for child in props:
+        if child.get('name') == 'Name':
+            return child.text or ''
+    return None
+
+
+
+def set_name(item: ET.Element, value: str) -> None:
+    props = item.find('Properties')
+    if props is None:
+        props = ET.SubElement(item, 'Properties')
+
+    for child in props:
+        if child.get('name') == 'Name':
+            child.text = value
+            return
+
+    name_prop = ET.Element('string', {'name': 'Name'})
+    name_prop.text = value
+    props.insert(0, name_prop)
+
+
+
+def find_top_level_child(parent: ET.Element, name: str) -> tuple[int | None, ET.Element | None]:
+    for index, child in enumerate(list(parent)):
+        if get_name(child) == name:
+            return index, child
+    return None, None
+
+
+
+def collect_referents(element: ET.Element) -> set[str]:
+    referents: set[str] = set()
+    for node in element.iter():
+        referent = node.get('referent')
+        if referent:
+            referents.add(referent)
+        if node.tag == 'Ref' and node.text:
+            referents.add(node.text)
+    return referents
+
+
+
+def next_referent(used: set[str]) -> str:
+    numeric = [int(value) for value in used if REFERENT_RE.match(value)]
+    candidate = max(numeric, default=0) + 1
+    while str(candidate) in used:
+        candidate += 1
+    return str(candidate)
+
+
+
+def remap_subtree_referents(element: ET.Element, used: set[str]) -> None:
+    mapping: dict[str, str] = {}
+
+    for node in element.iter():
+        referent = node.get('referent')
+        if referent:
+            replacement = next_referent(used)
+            used.add(replacement)
+            mapping[referent] = replacement
+            node.set('referent', replacement)
+
+    for node in element.iter('Ref'):
+        if node.text in mapping:
+            node.text = mapping[node.text]
+
+
+
+def make_folder(name: str) -> ET.Element:
+    item = ET.Element('Item', {'class': 'Folder'})
+    props = ET.SubElement(item, 'Properties')
+    name_prop = ET.SubElement(props, 'string', {'name': 'Name'})
+    name_prop.text = name
+    return item
+
+
+
+def load_single_item(path: Path) -> ET.Element:
+    tree = ET.parse(path)
+    root = tree.getroot()
+    items = root.findall('Item')
+    if len(items) != 1:
+        raise ValueError(f'{path} must contain exactly one top-level Item')
+    return items[0]
+
+
+
+def build_authored_static_world(repo_root: Path) -> ET.Element:
+    overlay_root = load_single_item(repo_root / OVERLAY_PATH)
+    chunk_root = load_single_item(repo_root / CHUNK_PATH)
+
+    authored_root = make_folder(STATIC_WORLD_NAME)
+    for child in overlay_root.findall('Item'):
+        authored_root.append(copy.deepcopy(child))
+
+    scenery_root = make_folder(SCENERY_NAME)
+    chunk_clone = copy.deepcopy(chunk_root)
+    set_name(chunk_clone, CHUNK_NAME)
+    scenery_root.append(chunk_clone)
+    authored_root.append(scenery_root)
+
+    return authored_root
+
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('harness_path')
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    harness_path = Path(args.harness_path).resolve()
+
+    tree = ET.parse(harness_path)
+    root = tree.getroot()
+
+    _, workspace = find_top_level_child(root, WORKSPACE_NAME)
+    if workspace is None:
+        raise ValueError(f'{harness_path} is missing top-level Workspace')
+
+    existing_index, existing_root = find_top_level_child(workspace, STATIC_WORLD_NAME)
+    if existing_root is not None and existing_index is not None:
+        workspace.remove(existing_root)
+
+    used_referents = collect_referents(root)
+    authored_root = build_authored_static_world(repo_root)
+    remap_subtree_referents(authored_root, used_referents)
+    workspace.append(authored_root)
+
+    ET.indent(tree, space='  ')
+    tree.write(harness_path, encoding='unicode', short_empty_elements=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/src/Shared/MazeStaticWorldAssembler.spec.luau
+++ b/tests/src/Shared/MazeStaticWorldAssembler.spec.luau
@@ -9,6 +9,161 @@ return function()
     local MazeStaticWorldContract = require(mazeModules:WaitForChild('MazeStaticWorldContract'))
     local MazeWorldBuilder = require(mazeModules:WaitForChild('MazeWorldBuilder'))
 
+    local function createAuthoredRoot()
+        local root = Instance.new('Folder')
+        root.Name = MazeStaticWorldContract.RootName
+        root.Parent = Workspace
+
+        local spawnMarker = Instance.new('Part')
+        spawnMarker.Name = 'SpawnMarker'
+        spawnMarker.Anchored = true
+        spawnMarker.CFrame = CFrame.new(-12, 4, 0)
+        spawnMarker.Parent = root
+
+        local returnHoldPad = Instance.new('Part')
+        returnHoldPad.Name = 'ReturnHoldPad'
+        returnHoldPad.Anchored = true
+        returnHoldPad.CFrame = CFrame.new(-12, 0.5, -10)
+        returnHoldPad.Parent = root
+        Instance.new('ProximityPrompt').Parent = returnHoldPad
+
+        local sceneryRoot = Instance.new('Folder')
+        sceneryRoot.Name = MazeStaticWorldContract.SceneryFolderName
+        sceneryRoot.Parent = root
+
+        local floor = Instance.new('Part')
+        floor.Name = 'Floor'
+        floor.Anchored = true
+        floor.Size = Vector3.new(64, 1, 64)
+        floor.CFrame = CFrame.new(0, 0, 0)
+        floor.Parent = sceneryRoot
+
+        local campRoom = Instance.new('Model')
+        campRoom.Name = 'Room_Camp'
+        campRoom:SetAttribute('RoomType', 'OpenHub')
+        campRoom:SetAttribute('IsCamp', true)
+        campRoom:SetAttribute('DifficultyTier', 0)
+        campRoom.Parent = root
+
+        local campShell = Instance.new('Part')
+        campShell.Name = 'Shell'
+        campShell.Anchored = true
+        campShell.Size = Vector3.new(20, 12, 20)
+        campShell.CFrame = CFrame.new(-20, 6, 0)
+        campShell.Parent = campRoom
+
+        local lootRoom = Instance.new('Model')
+        lootRoom.Name = 'Room_Loot'
+        lootRoom:SetAttribute('RoomType', 'DeadEnd')
+        lootRoom:SetAttribute('DifficultyTier', 2)
+        lootRoom:SetAttribute('MonsterBudget', 2)
+        lootRoom:SetAttribute('LootBudget', 1)
+        lootRoom.Parent = root
+
+        local lootShell = Instance.new('Part')
+        lootShell.Name = 'Shell'
+        lootShell.Anchored = true
+        lootShell.Size = Vector3.new(24, 12, 24)
+        lootShell.CFrame = CFrame.new(12, 6, 0)
+        lootShell.Parent = lootRoom
+
+        local monsterSpawns = Instance.new('Folder')
+        monsterSpawns.Name = 'MonsterSpawns'
+        monsterSpawns.Parent = lootRoom
+
+        local spawnPoint = Instance.new('Part')
+        spawnPoint.Name = 'SpawnPoint_1'
+        spawnPoint.Anchored = true
+        spawnPoint.CFrame = CFrame.new(8, 2, 0)
+        spawnPoint.Parent = monsterSpawns
+
+        local lootSocket = Instance.new('Part')
+        lootSocket.Name = 'LootSocket_1'
+        lootSocket.Anchored = true
+        lootSocket.CFrame = CFrame.new(16, 2, 0)
+        lootSocket.Parent = lootRoom
+
+        local lootPromptPart = Instance.new('Part')
+        lootPromptPart.Name = 'LootPrompt'
+        lootPromptPart.Anchored = true
+        lootPromptPart.CFrame = CFrame.new(16, 2, 0)
+        lootPromptPart.Parent = lootRoom
+        Instance.new('ProximityPrompt').Parent = lootPromptPart
+
+        local doorwayPart = Instance.new('Part')
+        doorwayPart.Name = 'Doorway_East'
+        doorwayPart.Anchored = true
+        doorwayPart.CFrame = CFrame.new(22, 4, 0)
+        doorwayPart.Parent = lootRoom
+        Instance.new('ProximityPrompt').Parent = doorwayPart
+
+        return root, sceneryRoot, floor
+    end
+
+    local authoredRoot, authoredSceneryRoot, authoredFloor = createAuthoredRoot()
+    local mazeAssets = ReplicatedStorage.Assets.Maze
+    local chunkAssets = mazeAssets:FindFirstChild('Chunks')
+    local overlayAssets = mazeAssets:FindFirstChild('Overlays')
+
+    if chunkAssets ~= nil then
+        chunkAssets.Parent = nil
+    end
+    if overlayAssets ~= nil then
+        overlayAssets.Parent = nil
+    end
+
+    local authoredOk, authoredResult = pcall(function()
+        return MazeStaticWorldAssembler.assemble()
+    end)
+
+    if chunkAssets ~= nil then
+        chunkAssets.Parent = mazeAssets
+    end
+    if overlayAssets ~= nil then
+        overlayAssets.Parent = mazeAssets
+    end
+
+    assert(
+        authoredOk == true,
+        string.format(
+            'Assembler should prefer authored Workspace content: %s',
+            tostring(authoredResult)
+        )
+    )
+    assert(
+        authoredResult == authoredRoot,
+        'Assembler should reuse the existing authored MazeStaticWorld instead of rebuilding it'
+    )
+    assert(
+        authoredRoot:FindFirstChild(MazeStaticWorldContract.SceneryFolderName)
+            == authoredSceneryRoot,
+        'Existing authored worlds should keep their scenery folder'
+    )
+    assert(
+        authoredFloor.Parent == authoredSceneryRoot,
+        'Existing authored scenery should remain in place when the assembler reuses the root'
+    )
+
+    local authoredRoomIds = shared.Runtime.MazeWorldScanner.GetRoomIds(
+        shared.Runtime.MazeWorldScanner.Scan(authoredRoot)
+    )
+    assert(
+        #authoredRoomIds == 2,
+        'Authored roots should still expose only gameplay rooms to the runtime scanner'
+    )
+
+    local authoredScene = MazeWorldBuilder.build()
+    assert(
+        authoredScene.Root == authoredRoot,
+        'World builder should reuse the authored MazeStaticWorld when it is already present'
+    )
+    assert(
+        authoredScene:getLootNode('Room_Loot') ~= nil,
+        'World builder should still produce gameplay nodes from the authored MazeStaticWorld'
+    )
+
+    authoredRoot:Destroy()
+
     local root = MazeStaticWorldAssembler.assemble()
     assert(
         root.Name == MazeStaticWorldContract.RootName,
@@ -61,6 +216,7 @@ return function()
         world.Doorways['Room_Loot:Doorway_East'] ~= nil,
         'Assembled world should still expose overlay-authored doorway nodes'
     )
+
     local scene = MazeWorldBuilder.build()
     assert(
         scene.Root.Name == MazeStaticWorldContract.RootName,
@@ -70,6 +226,8 @@ return function()
         scene:getLootNode('Room_Loot') ~= nil,
         'World builder should produce a MazeScene from the assembled static world'
     )
+
+    root:Destroy()
 
     local overlayAsset = ReplicatedStorage.Assets.Maze.Overlays:FindFirstChild(
         MazeStaticWorldContract.OverlayAssetName
@@ -101,6 +259,72 @@ return function()
         string.find(tostring(brokenErr), 'SpawnMarker', 1, true) ~= nil,
         'Missing overlay marker failures should mention the missing authored node'
     )
+
+    local brokenRoot = Workspace:FindFirstChild(MazeStaticWorldContract.RootName)
+    if brokenRoot ~= nil then
+        brokenRoot:Destroy()
+    end
+
+    local invalidRoot = Instance.new('Folder')
+    invalidRoot.Name = MazeStaticWorldContract.RootName
+    invalidRoot.Parent = Workspace
+
+    local invalidReturnHoldPad = Instance.new('Part')
+    invalidReturnHoldPad.Name = 'ReturnHoldPad'
+    invalidReturnHoldPad.Anchored = true
+    invalidReturnHoldPad.Parent = invalidRoot
+    Instance.new('ProximityPrompt').Parent = invalidReturnHoldPad
+
+    local invalidRoom = Instance.new('Model')
+    invalidRoom.Name = 'Room_Loot'
+    invalidRoom:SetAttribute('RoomType', 'DeadEnd')
+    invalidRoom.Parent = invalidRoot
+
+    local invalidShell = Instance.new('Part')
+    invalidShell.Name = 'Shell'
+    invalidShell.Anchored = true
+    invalidShell.Parent = invalidRoom
+
+    local invalidMonsterSpawns = Instance.new('Folder')
+    invalidMonsterSpawns.Name = 'MonsterSpawns'
+    invalidMonsterSpawns.Parent = invalidRoom
+
+    local invalidSpawnPoint = Instance.new('Part')
+    invalidSpawnPoint.Name = 'SpawnPoint_1'
+    invalidSpawnPoint.Anchored = true
+    invalidSpawnPoint.Parent = invalidMonsterSpawns
+
+    local invalidLootSocket = Instance.new('Part')
+    invalidLootSocket.Name = 'LootSocket_1'
+    invalidLootSocket.Anchored = true
+    invalidLootSocket.Parent = invalidRoom
+
+    local invalidLootPrompt = Instance.new('Part')
+    invalidLootPrompt.Name = 'LootPrompt'
+    invalidLootPrompt.Anchored = true
+    invalidLootPrompt.Parent = invalidRoom
+    Instance.new('ProximityPrompt').Parent = invalidLootPrompt
+
+    local invalidDoorway = Instance.new('Part')
+    invalidDoorway.Name = 'Doorway_East'
+    invalidDoorway.Anchored = true
+    invalidDoorway.Parent = invalidRoom
+    Instance.new('ProximityPrompt').Parent = invalidDoorway
+
+    local invalidExistingOk, invalidExistingErr = pcall(function()
+        MazeStaticWorldAssembler.assemble()
+    end)
+
+    assert(
+        invalidExistingOk == false,
+        'Assembler should fail loudly when an authored MazeStaticWorld exists but is incomplete'
+    )
+    assert(
+        string.find(tostring(invalidExistingErr), 'SpawnMarker', 1, true) ~= nil,
+        'Incomplete authored root failures should still identify the missing authored node'
+    )
+
+    invalidRoot:Destroy()
 
     local finalRoot = Workspace:FindFirstChild(MazeStaticWorldContract.RootName)
     if finalRoot ~= nil then


### PR DESCRIPTION
## What changed

- Teach `MazeStaticWorldAssembler` to reuse an authored `Workspace/MazeStaticWorld` when it already exists, and only fall back to scaffold assembly when it is absent.
- Add `scripts/hydrate-maze-harness.py` and wire the harness build scripts to hydrate the Maze harness with visible `MazeStaticWorld/Scenery` content.
- Update Maze harness/static-world docs and include the hydrated harness/scaffold asset updates.
- Add deterministic coverage for authored-root reuse and incomplete authored-root failures.

## Why

This separates the Maze authoring workflow from the deadline-slice gameplay work. The PR can be refined later if #321/#324 need to lean on the authored-world path, but it does not carry deadline-slice payoff metadata.

## Impact

- Changes Maze harness authoring behavior and the `maze.rbxlx` harness artifact.
- Runtime still validates required Maze static-world nodes before building the scene.
- Does not implement Pages language, corpse clues, sound predator behavior, or payoff metadata; those stay in the issue mainline.

## Validation

- `stylua --check places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau tests/src/Shared/MazeStaticWorldAssembler.spec.luau`
- `selene places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau tests/src/Shared/MazeStaticWorldAssembler.spec.luau`
- `rojo build places/maze/default.project.json -o tmp/maze-harness-check.rbxlx`
- `python3 scripts/hydrate-maze-harness.py tmp/maze-harness-check.rbxlx`

Note: `rojo build` emitted a non-fatal XML warning for the existing `Material` property shape in the chunk asset and completed successfully.

## Follow-up

- Keep this draft separate while the deadline-slice issue PRs progress.
- If #321 requires Studio-authored Maze metadata, update this PR or rebase the issue PR accordingly.
