### PR TITLE
fix(run): align assignment language with Pages

### DIFF
--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -49,7 +49,7 @@ local RUN_MAZE_GATE_RETURN_REASONS = table.freeze({
     returned = true,
 })
 local INITIAL_TEMPLE_STATUS =
-    'Leave the ship, spot the tower, and decide when to push into the maze.'
+    'Leave the ship, spot the maze route, and decide when to push into the maze.'
 local OCEAN_SPLASH_MESSAGE = 'Sea spray crashes over you.'
 local OCEAN_SLOWDOWN_DELAY_SECONDS = 1
 local OCEAN_SLOWDOWN_WALK_SPEED = 12
@@ -475,7 +475,7 @@ function RunSessionService:_resetForNextRound()
     end
 
     self.Status = string.format(
-        'Round %d of %d ready. Regroup at the ship, review clues, then head for the tower again.',
+        'Round %d of %d ready. Regroup at the ship, review clues, then head for the maze again.',
         self.CampSession.CurrentRound,
         self.CampSession.MaxRounds
     )
@@ -975,7 +975,7 @@ function RunSessionService:_applyReturnedPlayersFromTeleportData(players, accept
         )
     else
         self.Status =
-            'The ship is ready. Explore the wilderness, read the signs, and choose when to push for the tower.'
+            'The ship is ready. Explore the wilderness, read the signs, and choose when to push for the maze.'
     end
 end
 

--- a/places/run/src/ServerScriptService/Run/RunSessionService.luau
+++ b/places/run/src/ServerScriptService/Run/RunSessionService.luau
@@ -445,8 +445,8 @@ function RunSessionService:_resetForNextRound()
         self.RoundClosureInProgress = false
         self.GateOpen = false
         self.Status = if self.CampSession.SessionOutcome == 'success'
-            then 'Mission complete. The crew is back at the ship for the final debrief.'
-            else 'Mission failed. The crew is back at the ship for the final debrief.'
+            then 'Assignment complete. The crew brought enough Pages back to the ship for the final debrief.'
+            else 'Assignment failed. The crew is back at the ship for the final debrief.'
         self:_broadcastSnapshot()
         return
     end
@@ -918,7 +918,7 @@ function RunSessionService:_getReturnStatusText(playerDisplayName, summary, tele
 
     if RUN_MAZE_GATE_RETURN_REASONS[summary.ReturnReason] then
         return string.format(
-            '%s made it back from the maze with %d loot item(s) and banked them at the ship.',
+            '%s made it back from the maze with %d Page(s) and brought them back alive.',
             playerDisplayName,
             lootCount
         )
@@ -926,7 +926,7 @@ function RunSessionService:_getReturnStatusText(playerDisplayName, summary, tele
 
     if teleportData.MazeReturn and teleportData.MazeReturn.MazeCompleted == true then
         return string.format(
-            '%s returned from the maze. The crew now has %d of %d required loot item(s).',
+            '%s returned from the maze. The crew now has %d of %d required Page(s).',
             playerDisplayName,
             self.CampSession.BankedItemCount,
             self.CampSession.TargetItemCount
@@ -934,7 +934,7 @@ function RunSessionService:_getReturnStatusText(playerDisplayName, summary, tele
     end
 
     return string.format(
-        '%s returned from the maze with %d loot item(s). Banked total: %d/%d.',
+        '%s returned from the maze with %d Page(s). Pages banked: %d/%d.',
         playerDisplayName,
         lootCount,
         self.CampSession.BankedItemCount,
@@ -969,7 +969,7 @@ function RunSessionService:_applyReturnedPlayersFromTeleportData(players, accept
         )
     elseif #returnedPlayers > 1 then
         self.Status = string.format(
-            'The crew returned from the maze. Banked loot: %d/%d.',
+            'The crew returned from the maze. Banked Pages: %d/%d.',
             self.CampSession.BankedItemCount,
             self.CampSession.TargetItemCount
         )
@@ -1151,11 +1151,11 @@ end
 
 function RunSessionService:_getObjectiveFor(player)
     if self.CampSession.SessionOutcome == 'success' then
-        return 'Mission complete. Stay at the ship, compare what everyone learned, and review the final haul.'
+        return 'Assignment complete. Stay at the ship and review the recovered Pages.'
     end
 
     if self.CampSession.SessionOutcome == 'failure' then
-        return 'Mission failed after five rounds. Review what went wrong and what clues were recovered.'
+        return 'Assignment failed after five rounds. Review what went wrong and what clues were recovered.'
     end
 
     if self:_isRoundClosing() then
@@ -1165,13 +1165,13 @@ function RunSessionService:_getObjectiveFor(player)
     if not self:_isRoundStarted() then
         if self.CampSession.HostUserId == player.UserId then
             return string.format(
-                'Open the ship door to begin round %d of %d. Players can still search the wilderness for clues before heading to the tower.',
+                'Open the ship door to begin round %d of %d. Search the wilderness for clues, then enter the maze for Pages.',
                 self.CampSession.CurrentRound,
                 self.CampSession.MaxRounds
             )
         end
 
-        return 'Stay at the ship, check any recovered clues, then head into the wilderness or toward the tower when the host starts the round.'
+        return 'Stay at the ship, check any recovered clues, then head into the wilderness or toward the maze when the host starts the round.'
     end
 
     if self:_isPlayerDead(player) then
@@ -1179,10 +1179,10 @@ function RunSessionService:_getObjectiveFor(player)
     end
 
     if self:_isPlayerInCamp(player) then
-        return 'The round is live. Step into the wilderness for clues or head straight for the tower to enter the maze.'
+        return 'The round is live. Step into the wilderness for clues or head straight to the maze for Pages.'
     end
 
-    return 'Search the wilderness for warning signs, then enter the maze and bring loot back alive.'
+    return 'Search the wilderness for warning signs, then enter the maze and bring Pages back alive.'
 end
 
 function RunSessionService:_setStatus(status)
@@ -1499,7 +1499,7 @@ function RunSessionService:_openGate(player)
         self.TODService:start()
         self:_beginExpedition()
         self.Status = string.format(
-            '%s opened the ship door. Round %d of %d is live: search the wilderness, then head for the tower.',
+            '%s opened the ship door. Round %d of %d is live: search the wilderness, then head for the maze.',
             player.DisplayName,
             self.CampSession.CurrentRound,
             self.CampSession.MaxRounds
@@ -1663,7 +1663,9 @@ function RunSessionService:_enterMaze(player)
         self.MazeEntryReasonCode = result.ReasonCode
         self.MazeEntryReason = result.Reason
         self.CampSession = result.NextSession
-        self:_setStatus(string.format('%s is entering the shared maze run.', player.DisplayName))
+        self:_setStatus(
+            string.format('%s is entering the maze to recover Pages.', player.DisplayName)
+        )
     end)
 end
 

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -19,10 +19,10 @@ local HeldToolVisual = Shared.Client.HeldToolVisual
 local heldItemController = Shared.Client.HeldItemController.new(localPlayer)
 local Theme = UI.Hud.Theme
 
-local TEMPLE_LABEL = 'Temple'
-local PAGE_LABEL = 'Banked Loot'
-local SAND_BOOK_LABEL = 'Mission'
-local SAND_BOOK_PROGRESS_LABEL = 'Mission Progress'
+local TEMPLE_LABEL = 'Ship'
+local PAGE_LABEL = 'Pages'
+local SAND_BOOK_LABEL = 'Assignment'
+local SAND_BOOK_PROGRESS_LABEL = 'Pages Recovered'
 
 local disconnectFirstPersonLock
 local ensureFirstPersonLock
@@ -406,7 +406,7 @@ objectiveLabel.Text = string.format('%s Objective: --', SAND_BOOK_LABEL)
 
 local guideLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 60), Theme.Text, 16, false)
 guideLabel.Text = string.format(
-    'In-world prompts:\n- %s Shop\n- Salvage Exchange\n- %s Board\n- %s Gate / Shared Maze Gate\nKeyboard: Hold LeftShift to sprint, tap C to toggle %s Status, %s to free mouse, 1-3 to equip, X to stow',
+    'In-world prompts:\n- %s Tools\n- Page Return\n- %s Board\n- %s Gate / Shared Maze Gate\nKeyboard: Hold LeftShift to sprint, tap C to toggle %s Status, %s to free mouse, 1-3 to equip, X to stow',
     TEMPLE_LABEL,
     SAND_BOOK_LABEL,
     TEMPLE_LABEL,
@@ -657,7 +657,7 @@ local shopTitle = makeTextLabel(shopPanel, UDim2.new(1, 0, 0, 32), Theme.Text, 2
 shopTitle.Text = 'Ship Locker'
 
 local shopPageLabel = makeTextLabel(shopPanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
-shopPageLabel.Text = 'Banked Loot: 0'
+shopPageLabel.Text = 'Pages: 0'
 
 local shopInventoryLabel =
     makeTextLabel(shopPanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
@@ -679,7 +679,7 @@ local sellTitle = makeTextLabel(sellPanel, UDim2.new(1, 0, 0, 32), Theme.Text, 2
 sellTitle.Text = 'Recovery Log'
 
 local sellPageLabel = makeTextLabel(sellPanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
-sellPageLabel.Text = 'Banked Loot: 0'
+sellPageLabel.Text = 'Pages: 0'
 
 local sellItemsFrame = Instance.new('Frame')
 sellItemsFrame.Size = UDim2.new(1, 0, 1, -160)
@@ -694,11 +694,11 @@ local sellCloseButton = makeButton(sellPanel, 'Close', 44, Theme.Warning)
 
 local objectivePanel = createModalPanel('ObjectivePanel', UDim2.fromOffset(440, 360))
 local objectiveTitle = makeTextLabel(objectivePanel, UDim2.new(1, 0, 0, 32), Theme.Text, 26, true)
-objectiveTitle.Text = 'Mission Board'
+objectiveTitle.Text = 'Assignment Board'
 
 local objectiveGoalLabel =
     makeTextLabel(objectivePanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
-objectiveGoalLabel.Text = 'Target: 0 item(s)'
+objectiveGoalLabel.Text = 'Assignment: recover 0 Pages'
 
 local objectiveProgressLabel =
     makeTextLabel(objectivePanel, UDim2.new(1, 0, 0, 24), Theme.SubtleText, 16, false)
@@ -744,7 +744,7 @@ end
 
 local function updateObjectiveUi()
     local clampedProgress = math.clamp(goalProgress, 0, 1)
-    objectiveGoalLabel.Text = string.format('Target: %d item(s)', goalAmount)
+    objectiveGoalLabel.Text = string.format('Assignment: recover %d Pages', goalAmount)
     objectiveProgressLabel.Text =
         string.format('%s: %d%%', SAND_BOOK_PROGRESS_LABEL, math.floor(clampedProgress * 100 + 0.5))
     progressBarFill.Size = UDim2.fromScale(clampedProgress, 1)
@@ -757,7 +757,7 @@ local function updatePageLabels()
 
     if inventorySummary then
         shopInventoryLabel.Text = string.format(
-            'Inventory: %d total | %d loot | %d clue | %d tool',
+            'Inventory: %d total | %d Page | %d clue | %d tool',
             inventorySummary.Count or 0,
             inventorySummary.LootCount or 0,
             inventorySummary.ClueCount or 0,
@@ -791,7 +791,7 @@ local function showToast(message, tone)
 end
 
 local function showGoalBanner()
-    goalBanner.Text = string.format('Quota reached! %s: %d', PAGE_LABEL, teamPages)
+    goalBanner.Text = string.format('Assignment met! %s: %d', PAGE_LABEL, teamPages)
     goalBanner.Visible = true
 
     task.delay(3, function()
@@ -1215,7 +1215,7 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
     heldItemController:applyInventory(inventory)
     updatePageLabels()
     inventoryLabel.Text = string.format(
-        'Inventory: %d total | %d loot | %d clue | %d tool | %d/%d slots',
+        'Inventory: %d total | %d Page | %d clue | %d tool | %d/%d slots',
         inventory.Count or 0,
         inventory.LootCount or 0,
         inventory.ClueCount or 0,
@@ -1235,7 +1235,7 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
         heldItem and string.format(
             'Held: %s | %s%s',
             heldItem.Name,
-            heldItem.ItemCategory or 'Loot',
+            heldItem.ItemCategory or 'Page',
             heldItem.Light and ' | Glow active' or ''
         ) or 'Held: Empty hands',
         'Backpack:',
@@ -1251,7 +1251,7 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
                     '- [%d] %s | %s',
                     itemIndex,
                     itemEntry.Name,
-                    itemEntry.ItemCategory or 'Loot'
+                    itemEntry.ItemCategory or 'Page'
                 )
             )
         end
@@ -1312,7 +1312,7 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
             table.insert(
                 mazeLines,
                 string.format(
-                    '- %s: %d loot item(s) (%s)',
+                    '- %s: %d Page(s) (%s)',
                     entry.Name,
                     entry.LootItemCount or entry.MissionCount or 0,
                     entry.ReturnReason or 'unknown'

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -1251,7 +1251,8 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
                     '- [%d] %s | %s',
                     itemIndex,
                     itemEntry.Name,
-                    itemEntry.ItemCategory == 'Loot' and 'Page' or (itemEntry.ItemCategory or 'Page')
+                    itemEntry.ItemCategory == 'Loot' and 'Page'
+                        or (itemEntry.ItemCategory or 'Page')
                 )
             )
         end

--- a/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
+++ b/places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau
@@ -757,7 +757,7 @@ local function updatePageLabels()
 
     if inventorySummary then
         shopInventoryLabel.Text = string.format(
-            'Inventory: %d total | %d Page | %d clue | %d tool',
+            'Inventory: %d total | %d Page(s) | %d clue | %d tool',
             inventorySummary.Count or 0,
             inventorySummary.LootCount or 0,
             inventorySummary.ClueCount or 0,
@@ -1215,7 +1215,7 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
     heldItemController:applyInventory(inventory)
     updatePageLabels()
     inventoryLabel.Text = string.format(
-        'Inventory: %d total | %d Page | %d clue | %d tool | %d/%d slots',
+        'Inventory: %d total | %d Page(s) | %d clue | %d tool | %d/%d slots',
         inventory.Count or 0,
         inventory.LootCount or 0,
         inventory.ClueCount or 0,
@@ -1235,7 +1235,7 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
         heldItem and string.format(
             'Held: %s | %s%s',
             heldItem.Name,
-            heldItem.ItemCategory or 'Page',
+            heldItem.ItemCategory == 'Loot' and 'Page' or (heldItem.ItemCategory or 'Page'),
             heldItem.Light and ' | Glow active' or ''
         ) or 'Held: Empty hands',
         'Backpack:',
@@ -1251,7 +1251,7 @@ Remotes.RunState.OnClientEvent:Connect(function(snapshot)
                     '- [%d] %s | %s',
                     itemIndex,
                     itemEntry.Name,
-                    itemEntry.ItemCategory or 'Page'
+                    itemEntry.ItemCategory == 'Loot' and 'Page' or (itemEntry.ItemCategory or 'Page')
                 )
             )
         end


### PR DESCRIPTION
## What changed

- Updates Run-side player-facing assignment copy to consistently describe the goal as recovering `Pages` and bringing them back alive.
- Replaces main Run HUD labels like `Banked Loot`, `Mission Progress`, `Target`, and `Quota reached` with `Pages` / `Assignment` language.
- Updates Run objective/status/return summaries so player-facing copy no longer presents the same goal as generic loot.

## Why

Issue #319 tracks the deadline-slice terminology pass for the first playable `Run -> Maze -> Run` loop. The player should understand the assignment as: enter the maze, recover Pages, and bring them back alive.

## Scope notes

- Run-only scope for this PR.
- Internal compatibility fields and variables are intentionally unchanged (`TeamPages`, `BookGoalAmount`, `BankedItemCount`, `CampMazeSessionContract`).
- Maze HUD, Maze pickup/death/retreat feedback, corpse clue content, sound stimulus behavior, and Maze payoff metadata are left for later child issues.
- Harness Impact: none. This is a player-facing copy alignment and does not introduce new harness behavior or world-authoring policy.

## Validation

- `stylua --check places/run/src/ServerScriptService/Run/RunSessionService.luau places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau`
- `selene places/run/src/ServerScriptService/Run/RunSessionService.luau places/run/src/StarterPlayer/StarterPlayerScripts/RunClient.client.luau`
- `rojo build places/run/default.project.json -o tmp/run-issue-319.rbxlx`
- `rg -n 'Banked Loot|Quota reached|"Target:|loot item\(s\)|Banked loot|bring loot|Mission Board|Mission complete|Mission failed' places/run/src -g '*.luau'` returned no matches.

## Manual checks still needed

- Open the Run HUD and confirm the objective reads as an Assignment to recover Pages.
- Confirm ship-side status and return summaries use Pages as the player-facing term.

Closes #319
