### PR TITLE
feat(maze): mark first sound-predator payoff chain

### DIFF
--- a/places/maze/src/ServerScriptService/Maze/MazeStaticWorldOverlayManifest.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeStaticWorldOverlayManifest.luau
@@ -7,10 +7,43 @@ local function freezeRoomDefinition(definition)
         LootBudget = definition.LootBudget or 0,
         RoomTemplateId = definition.RoomTemplateId or definition.RoomType,
         RoomCategory = definition.RoomCategory or definition.RoomType,
+        EncounterRole = definition.EncounterRole,
+        PayoffHintId = definition.PayoffHintId,
+    })
+end
+
+local function freezeChainStep(definition)
+    return table.freeze({
+        StepId = definition.StepId,
+        TargetId = definition.TargetId,
+        PayoffHintId = definition.PayoffHintId,
     })
 end
 
 local MazeStaticWorldOverlayManifest = table.freeze({
+    FirstPlayableChain = table.freeze({
+        freezeChainStep({
+            StepId = 'EntryBuffer',
+            TargetId = 'Room_Camp',
+        }),
+        freezeChainStep({
+            StepId = 'Warning',
+            TargetId = 'Room_Loot',
+        }),
+        freezeChainStep({
+            StepId = 'PagesTemptation',
+            TargetId = 'Room_Loot',
+        }),
+        freezeChainStep({
+            StepId = 'SoundPredatorPayoff',
+            TargetId = 'Room_Loot',
+            PayoffHintId = 'sound-predator',
+        }),
+        freezeChainStep({
+            StepId = 'ReturnDecision',
+            TargetId = 'ReturnHoldPad',
+        }),
+    }),
     RootParts = table.freeze({
         'SpawnMarker',
         'ReturnHoldPad',
@@ -22,6 +55,7 @@ local MazeStaticWorldOverlayManifest = table.freeze({
             DifficultyTier = 0,
             RoomTemplateId = 'CampHub',
             RoomCategory = 'CampHub',
+            EncounterRole = 'EntryBuffer',
         }),
         Room_Loot = freezeRoomDefinition({
             RoomType = 'DeadEnd',
@@ -30,6 +64,8 @@ local MazeStaticWorldOverlayManifest = table.freeze({
             LootBudget = 1,
             RoomTemplateId = 'SearchCluster',
             RoomCategory = 'SearchCluster',
+            EncounterRole = 'WarningPayoffResourceTemptation',
+            PayoffHintId = 'sound-predator',
         }),
     }),
     RequiredInteractionNodes = table.freeze({

--- a/tests/src/Shared/MazeStaticWorld.spec.luau
+++ b/tests/src/Shared/MazeStaticWorld.spec.luau
@@ -5,6 +5,40 @@ return function()
     local packages = ReplicatedStorage:WaitForChild('Packages')
     local shared = require(packages:WaitForChild('Shared'))
     local scanner = shared.Runtime.MazeWorldScanner
+    local mazeModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
+    local overlayManifest = require(mazeModules:WaitForChild('MazeStaticWorldOverlayManifest'))
+
+    local expectedChainSteps = {
+        'EntryBuffer',
+        'Warning',
+        'PagesTemptation',
+        'SoundPredatorPayoff',
+        'ReturnDecision',
+    }
+    assert(
+        #overlayManifest.FirstPlayableChain == #expectedChainSteps,
+        'First playable chain should expose exactly five authored payoff steps'
+    )
+    for index, expectedStepId in ipairs(expectedChainSteps) do
+        assert(
+            overlayManifest.FirstPlayableChain[index].StepId == expectedStepId,
+            'First playable chain should preserve the deadline-slice step order'
+        )
+    end
+    assert(
+        overlayManifest.FirstPlayableChain[4].TargetId == 'Room_Loot'
+            and overlayManifest.FirstPlayableChain[4].PayoffHintId == 'sound-predator',
+        'Sound predator payoff should point at the authored loot room and hint id'
+    )
+    assert(
+        overlayManifest.Rooms.Room_Loot.PayoffHintId
+            == overlayManifest.FirstPlayableChain[4].PayoffHintId,
+        'First playable chain payoff should match Room_Loot authored payoff metadata'
+    )
+    assert(
+        overlayManifest.FirstPlayableChain[5].TargetId == 'ReturnHoldPad',
+        'Return decision should point at the authored return hold node'
+    )
 
     local root = Instance.new('Folder')
     root.Name = 'MazeStaticWorld'
@@ -48,6 +82,7 @@ return function()
     createRoom('Room_Camp', 'OpenHub', Vector3.new(0, 6, 24), {
         IsCamp = true,
         DifficultyTier = 0,
+        EncounterRole = 'EntryBuffer',
     })
 
     local lootRoom = createRoom('Room_Loot', 'DeadEnd', Vector3.new(24, 6, 24), {
@@ -55,6 +90,8 @@ return function()
         DifficultyTier = 2,
         RoomTemplateId = 'SearchCluster',
         RoomCategory = 'SearchCluster',
+        EncounterRole = 'WarningPayoffResourceTemptation',
+        PayoffHintId = 'sound-predator',
     })
     lootRoom:AddTag('HasMonsterSpawner')
 
@@ -92,7 +129,24 @@ return function()
     local doorwayPrompt = Instance.new('ProximityPrompt')
     doorwayPrompt.Parent = doorwayPart
 
+    local scenery = Instance.new('Folder')
+    scenery.Name = 'Scenery'
+    scenery.Parent = root
+
+    local fakeSceneryRoom = Instance.new('Model')
+    fakeSceneryRoom.Name = 'Room_SceneryFake'
+    fakeSceneryRoom:SetAttribute('RoomType', 'DeadEnd')
+    fakeSceneryRoom.Parent = scenery
+
+    local fakeSceneryShell = Instance.new('Part')
+    fakeSceneryShell.Name = 'Shell'
+    fakeSceneryShell.Anchored = true
+    fakeSceneryShell.Position = Vector3.new(60, 6, 24)
+    fakeSceneryShell.Parent = fakeSceneryRoom
+
     local world = scanner.BuildStaticWorld(root)
+    local scanResult = scanner.Scan(root)
+    local roomIds = scanner.GetRoomIds(scanResult)
 
     assert(world.Root == root, 'Static maze world should preserve the authored root')
     assert(
@@ -112,6 +166,14 @@ return function()
         'Room lookup should resolve the nearest authored room'
     )
     assert(world.LootNodes.Room_Loot ~= nil, 'Loot rooms should create loot runtime nodes')
+    assert(
+        table.find(roomIds, 'Room_SceneryFake') == nil,
+        'Scanner should ignore scenery-authored geometry folders even when they contain room-like metadata'
+    )
+    assert(
+        world.RoomById.Room_SceneryFake == nil,
+        'BuildStaticWorld should not promote scenery-only content into gameplay rooms'
+    )
     assert(
         world.LootNodes.Room_Loot.Prompt == lootPrompt,
         'Loot runtime nodes should preserve the authored loot prompt'

--- a/tests/src/Shared/MazeStaticWorld.spec.luau
+++ b/tests/src/Shared/MazeStaticWorld.spec.luau
@@ -145,8 +145,7 @@ return function()
     fakeSceneryShell.Parent = fakeSceneryRoom
 
     local world = scanner.BuildStaticWorld(root)
-    local scanResult = scanner.Scan(root)
-    local roomIds = scanner.GetRoomIds(scanResult)
+    local roomIds = world.RoomIds
 
     assert(world.Root == root, 'Static maze world should preserve the authored root')
     assert(

--- a/tests/src/Shared/MazeStaticWorldAssembler.spec.luau
+++ b/tests/src/Shared/MazeStaticWorldAssembler.spec.luau
@@ -7,6 +7,8 @@ return function()
     local mazeModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
     local MazeStaticWorldAssembler = require(mazeModules:WaitForChild('MazeStaticWorldAssembler'))
     local MazeStaticWorldContract = require(mazeModules:WaitForChild('MazeStaticWorldContract'))
+    local MazeStaticWorldOverlayManifest =
+        require(mazeModules:WaitForChild('MazeStaticWorldOverlayManifest'))
     local MazeWorldBuilder = require(mazeModules:WaitForChild('MazeWorldBuilder'))
 
     local root = MazeStaticWorldAssembler.assemble()
@@ -56,6 +58,26 @@ return function()
     assert(
         world.LootNodes.Room_Loot ~= nil,
         'Assembled world should still expose overlay-authored loot nodes'
+    )
+    assert(
+        #MazeStaticWorldOverlayManifest.FirstPlayableChain == 5,
+        'Overlay manifest should publish the first playable payoff chain'
+    )
+    assert(
+        MazeStaticWorldOverlayManifest.FirstPlayableChain[4].PayoffHintId == 'sound-predator',
+        'Overlay manifest should bind the first payoff chain to the sound predator hint'
+    )
+    assert(
+        MazeStaticWorldOverlayManifest.FirstPlayableChain[5].TargetId == 'ReturnHoldPad',
+        'Overlay manifest should make return decision an explicit authored node'
+    )
+    assert(
+        root:FindFirstChild('Room_Camp'):GetAttribute('EncounterRole') == 'EntryBuffer',
+        'Assembler should apply the entry buffer role to the camp room'
+    )
+    assert(
+        root:FindFirstChild('Room_Loot'):GetAttribute('PayoffHintId') == 'sound-predator',
+        'Assembler should apply the first sound-predator payoff metadata to the loot room'
     )
     assert(
         world.Doorways['Room_Loot:Doorway_East'] ~= nil,


### PR DESCRIPTION
## Summary
- Adds explicit `FirstPlayableChain` metadata for the first authored Maze payoff path.
- Marks `Room_Camp` as the entry buffer and `Room_Loot` as the combined warning / Pages temptation / sound-predator payoff node.
- Keeps `ReturnHoldPad` as the explicit return decision node.
- Adds deterministic assertions that the chain stays ordered and tied to `PayoffHintId = "sound-predator"`.

## Context
- #320 places the first Run corpse clue that teaches the sound-predator suspicion.
- #322 wires the current headline predator toward sound stimulus behavior.
- This PR only makes the authored Maze payoff chain reviewable; it does not add runtime threat logic or #323 player-facing feedback.

## Validation
- `stylua --check places/maze/src/ServerScriptService/Maze/MazeStaticWorldOverlayManifest.luau tests/src/Shared/MazeStaticWorld.spec.luau tests/src/Shared/MazeStaticWorldAssembler.spec.luau`
- `selene places/maze/src/ServerScriptService/Maze/MazeStaticWorldOverlayManifest.luau tests/src/Shared/MazeStaticWorld.spec.luau tests/src/Shared/MazeStaticWorldAssembler.spec.luau`
- `rojo build places/maze/default.project.json -o tmp/maze-issue-321.rbxlx`
- `rojo build tests/default.project.json -o tmp/roblox_experience-tests-321.rbxlx`
- `run-in-roblox --place tmp/roblox_experience-tests-321.rbxlx --script tests/run-in-roblox.lua` (initial attempts timed out waiting for Studio; retry exited 0).

## Out Of Scope
- No authored layout expansion.
- No full encounter grammar platform.
- No #323 pickup/death/retreat feedback copy.
- No #322 runtime sound-predator changes.

Closes #321
