### PR TITLE
fix(maze): reinforce Pages loop feedback

### DIFF
--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -518,7 +518,8 @@ function MazeSessionService.new(options)
         MazeAccessCode = 'local-debug-maze',
         MazeStatus = CampMazeSessionContract.MazeStatus.Active,
     })
-    self.Status = 'Direct boot: maze session is live. Explore, loot, and find a return point.'
+    self.Status =
+        'Direct boot: maze session is live. Recover Pages, read the threat, and find a return point.'
     self.World = nil
     self.WorldInteractions = nil
     self.IsDirectBoot = true
@@ -763,7 +764,7 @@ function MazeSessionService:_mergeTeleportData(teleportData, resetInventoryServi
     self.IsDirectBoot = false
     self.CampSession.MaxRounds = self.SessionData.Mission.RoundCount
     self.CampSession.TargetItemCount = self.SessionData.Mission.TargetItemCount
-    self.Status = 'Maze session is live. Explore, loot, and find a return point.'
+    self.Status = 'Maze session is live. Recover Pages, read the threat, and find a return point.'
     self:_subscribeToRoundSignals()
     result.AcceptedBeforeBuild = self:_markAcceptedTeleportData(teleportData)
     result.Merged = true
@@ -1024,7 +1025,7 @@ function MazeSessionService:_getObjectiveFor()
         return 'This was the last round and the crew missed the quota. Return to the ship for final debrief.'
     end
 
-    return 'Read the room, dodge the threat, grab loot, and bring it back to the ship alive.'
+    return 'Read the room, dodge the threat, recover Pages, and bring them back to the ship alive.'
 end
 
 function MazeSessionService:_broadcastSnapshot()
@@ -1333,7 +1334,9 @@ function MazeSessionService:_beginFormalExpedition()
     local patrolPoints, initialPatrolIndex = self.World:getPatrolPoints()
     self:_setBootPhase('SpawnMonster')
     self.MonsterService:spawn(patrolPoints, initialPatrolIndex)
-    self:_setStatus('Maze session is live. Explore, loot, and find a return point.')
+    self:_setStatus(
+        'Maze session is live. Recover Pages, watch your noise, and find a return point.'
+    )
 end
 
 function MazeSessionService:_canManageInventory(player)
@@ -1502,7 +1505,7 @@ function MazeSessionService:_handlePlayerDeath(player, damageKind)
 
     self:_setStatus(
         string.format(
-            '%s took %s damage and died, dropping their pack in the maze.',
+            '%s took %s damage and died, dropping their pack in the maze. Next time, make less noise and leave with Pages sooner.',
             player.DisplayName,
             string.lower(damageKind)
         )
@@ -1548,14 +1551,14 @@ end
 
 function MazeSessionService:_pickupLoot(player, roomId)
     if self.RunTracker:getState() ~= 'Expedition' then
-        self:_setStatus('Loot can only be collected during the expedition phase.')
+        self:_setStatus('Pages can only be recovered during the expedition phase.')
         return
     end
 
     if not self.RunTracker:isPlayerActive(player.UserId) then
         self:_setStatus(
             string.format(
-                '%s has already returned and cannot collect more loot.',
+                '%s has already returned and cannot recover more Pages this round.',
                 player.DisplayName
             )
         )
@@ -1584,12 +1587,13 @@ function MazeSessionService:_pickupLoot(player, roomId)
     self:_markLootCollected(roomId)
 
     local inventorySummary = self.InventoryService:getSummary(player)
+    local pageCount = inventorySummary.MissionCount or inventorySummary.LootCount or 0
     self:_setStatus(
         string.format(
-            '%s collected %s. They are now carrying %d loot item(s).',
+            '%s recovered a Page from %s. They are carrying %d Page(s): return now or risk more.',
             player.DisplayName,
             lootEntry.ItemDef.Name,
-            inventorySummary.LootCount or 0
+            pageCount
         )
     )
 end
@@ -1609,7 +1613,10 @@ function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason)
 
     if self:_isPlayerDead(player) then
         self:_setStatus(
-            string.format('%s is dead and must wait for the round to end.', player.DisplayName)
+            string.format(
+                '%s is dead and dropped their pack. Survivors should leave with the Pages they can carry.',
+                player.DisplayName
+            )
         )
         return
     end
@@ -1643,7 +1650,7 @@ function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason)
     if self:_teleportToCamp({ player }, { summary }, mazeCompleted, true) then
         self:_setStatus(
             string.format(
-                '%s returned to run with %d banked loot item(s) (%s).',
+                '%s returned alive with %d Page(s). Banking Pages alive is progress, even if you could have risked more. (%s)',
                 player.DisplayName,
                 bankedCount,
                 summary.ReturnReason
@@ -1659,7 +1666,7 @@ function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason)
 
     self:_setStatus(
         string.format(
-            '%s reached the return point with %d banked loot item(s), but the handoff back to run failed.',
+            '%s reached the return point with %d Page(s), but the handoff back to run failed.',
             player.DisplayName,
             bankedCount
         )

--- a/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
+++ b/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
@@ -251,7 +251,7 @@ objectiveLabel.Text = 'Objective: --'
 local promptLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 86), Theme.Text, 16, false)
 -- === 修改：加上了按 F 键使用道具的提示 ===
 promptLabel.Text =
-    'In-world prompts:\n- Loot pickups\n- Blue return marker -> Run\n- Double Door controls\nKeyboard: Hold LeftShift to sprint\nKeyboard: Press F to use held tool'
+    'In-world prompts:\n- Pages pickups\n- Blue return marker -> bring Pages back alive\n- Double Door controls\nKeyboard: Hold LeftShift to sprint\nKeyboard: Press F to use held tool'
 
 if RunService:IsStudio() then
     promptLabel.Text ..= '\nStudio debug: H light damage | J heavy damage'
@@ -413,10 +413,11 @@ local function connectMazeRemotes(remotes)
         mazeInventoryForSwing = inventory
         visibleBackpackItems = inventory.BackpackItems or {}
         heldItemController:applyInventory(inventory)
+        local pageCount = inventory.MissionCount or inventory.LootCount or 0
         inventoryLabel.Text = string.format(
-            'Inventory: %d total | %d loot | %d clue | %d tool | %d/%d slots',
+            'Inventory: %d total | %d Pages | %d clue | %d tool | %d/%d slots',
             inventory.Count or 0,
-            inventory.LootCount or 0,
+            pageCount,
             inventory.ClueCount or 0,
             inventory.ToolCount or 0,
             inventory.Count or 0,
@@ -487,7 +488,7 @@ local function connectMazeRemotes(remotes)
         end
         rosterLabel.Text = table.concat(rosterLines, '\n')
 
-        local returnedLines = { 'Returned summaries:' }
+        local returnedLines = { 'Returned Pages:' }
         local returned = snapshot.ReturnedPlayerSummaries or {}
         if #returned == 0 then
             table.insert(returnedLines, '- No one has returned yet.')
@@ -496,9 +497,9 @@ local function connectMazeRemotes(remotes)
                 table.insert(
                     returnedLines,
                     string.format(
-                        '- %s: %d loot item(s) (%s)',
+                        '- %s: %d Page(s) (%s)',
                         entry.Name,
-                        entry.LootItemCount or entry.MissionCount or 0,
+                        entry.MissionCount or entry.LootItemCount or 0,
                         entry.ReturnReason or 'unknown'
                     )
                 )

--- a/tests/src/Shared/MazeSessionServiceLoopFeedback.spec.luau
+++ b/tests/src/Shared/MazeSessionServiceLoopFeedback.spec.luau
@@ -1,0 +1,122 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local packages = ReplicatedStorage:WaitForChild('Packages')
+    local gameplay = require(packages:WaitForChild('Gameplay'))
+    local mazeModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
+    local MazeSessionService = require(mazeModules:WaitForChild('MazeSessionService'))
+
+    local function createPlayer(userId, displayName)
+        return {
+            UserId = userId,
+            DisplayName = displayName,
+        }
+    end
+
+    local function createService()
+        local service = MazeSessionService.new({
+            MonsterServiceFactory = function()
+                return {
+                    destroy = function() end,
+                    spawn = function() end,
+                }
+            end,
+        })
+
+        service._setStatus = function(self, status)
+            self.Status = status
+        end
+        service._publishMazePresence = function() end
+        service._clearPlayerMovement = function() end
+        service.World = {
+            ReturnHoldCFrame = CFrame.new(),
+        }
+
+        return service
+    end
+
+    local objectiveService = createService()
+    assert(
+        string.find(objectiveService:_getObjectiveFor(), 'recover Pages', 1, true) ~= nil,
+        'Maze objective should tell players to recover Pages'
+    )
+    assert(
+        string.find(objectiveService:_getObjectiveFor(), 'grab loot', 1, true) == nil,
+        'Maze objective should not call the assignment loot'
+    )
+
+    local pickupService = createService()
+    local pickupPlayer = createPlayer(101, 'Alpha')
+    pickupService:_addPlayerState(pickupPlayer)
+    assert(
+        pickupService.RunTracker:beginExpedition() == true,
+        'Pickup feedback spec should enter expedition'
+    )
+
+    local lootNode = {
+        Collected = false,
+        ItemDef = gameplay.Config.Items[1],
+        markCollected = function(self)
+            self.Collected = true
+        end,
+    }
+    pickupService.World.getLootNode = function(_, roomId)
+        if roomId == 'Room_Loot' then
+            return lootNode
+        end
+        return nil
+    end
+
+    pickupService:_pickupLoot(pickupPlayer, 'Room_Loot')
+    assert(
+        string.find(pickupService.Status, 'recovered a Page', 1, true) ~= nil,
+        'Pickup feedback should name the recovered objective as a Page'
+    )
+    assert(
+        string.find(pickupService.Status, 'return now or risk more', 1, true) ~= nil,
+        'Pickup feedback should teach the retreat versus greed decision'
+    )
+
+    local returnService = createService()
+    local returnPlayer = createPlayer(202, 'Bravo')
+    returnService:_addPlayerState(returnPlayer)
+    assert(
+        returnService.RunTracker:beginExpedition() == true,
+        'Return feedback spec should enter expedition'
+    )
+    returnService.InventoryService:pickup(returnPlayer, gameplay.Config.Items[1])
+    returnService._teleportToCamp = function()
+        return true
+    end
+
+    returnService:_returnPlayerToRunEntrance(returnPlayer, 'returned')
+    assert(
+        string.find(returnService.Status, 'returned alive with 1 Page', 1, true) ~= nil,
+        'Return feedback should state the Page count brought back alive'
+    )
+    assert(
+        string.find(returnService.Status, 'Banking Pages alive is progress', 1, true) ~= nil,
+        'Return feedback should reinforce alive return value'
+    )
+
+    local deathService = createService()
+    local deathPlayer = createPlayer(303, 'Charlie')
+    deathService:_addPlayerState(deathPlayer)
+    assert(
+        deathService.RunTracker:beginExpedition() == true,
+        'Death feedback spec should enter expedition'
+    )
+
+    deathService:_handlePlayerDeath(deathPlayer, 'Heavy')
+    assert(
+        string.find(deathService.Status, 'dropping their pack', 1, true) ~= nil,
+        'Death feedback should mention dropped pack consequence'
+    )
+    assert(
+        string.find(deathService.Status, 'make less noise', 1, true) ~= nil,
+        'Death feedback should teach less noise next time'
+    )
+    assert(
+        string.find(deathService.Status, 'leave with Pages sooner', 1, true) ~= nil,
+        'Death feedback should teach earlier Page extraction'
+    )
+end


### PR DESCRIPTION
## Summary
- Updates Maze-facing feedback so the loop reads as Pages recovery instead of generic loot.
- Reinforces the pickup decision: return now with Pages or risk more.
- Reinforces successful returns as alive Page banking progress.
- Reinforces death as dropped-pack consequence plus a next-time lesson: make less noise and leave with Pages sooner.

## Scope / Boundaries
- Maze server status/objective and Maze client HUD/returned summaries only.
- Keeps `LootCount`, `MissionCount`, `LootItemCount`, `BankedItemCount`, and `CampMazeSessionContract` payload shape unchanged for compatibility.
- Does not touch Run final feedback; #319 already aligned the basic Run return Pages language.
- Does not add economy, shop, five-round tuning, new remotes, inventory schema, item schema, or runtime threat logic.

## Validation
- `stylua --check places/maze/src/ServerScriptService/Maze/MazeSessionService.luau places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau tests/src/Shared/MazeSessionServiceLoopFeedback.spec.luau`
- `selene places/maze/src/ServerScriptService/Maze/MazeSessionService.luau places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau tests/src/Shared/MazeSessionServiceLoopFeedback.spec.luau`
- `rojo build places/maze/default.project.json -o tmp/maze-issue-323.rbxlx`
- `rojo build tests/default.project.json -o tmp/roblox_experience-tests-323.rbxlx`
- `run-in-roblox --place tmp/roblox_experience-tests-323.rbxlx --script tests/run-in-roblox.lua`
- `rg -n "grab loot|loot item\\(s\\)|Loot pickups|%d loot|Explore, loot|collect more loot|banked loot|bring loot" places/maze/src -g '*.luau'` returned no matches.

Closes #323
