### PR TITLE
feat(maze): unify playtest HUD and direct boot flow

### DIFF
--- a/places/maze/content-harness/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
+++ b/places/maze/content-harness/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
@@ -358,7 +358,7 @@ end
 local topHudFrame = Instance.new('Frame')
 topHudFrame.Name = 'TopHud'
 topHudFrame.AnchorPoint = Vector2.zero
-topHudFrame.Position = UDim2.new(0, 16, 0, 16)
+topHudFrame.Position = UDim2.fromOffset(16, 16)
 topHudFrame.Size = UDim2.fromOffset(380, 190)
 topHudFrame.BackgroundTransparency = 1
 topHudFrame.Parent = screenGui
@@ -418,7 +418,7 @@ staminaTrackCorner.Parent = staminaTrack
 
 local staminaFill = Instance.new('Frame')
 staminaFill.Name = 'StaminaFill'
-staminaFill.Size = UDim2.new(0, 0, 1, 0)
+staminaFill.Size = UDim2.fromScale(0, 1)
 staminaFill.BackgroundColor3 = Theme.Accent
 staminaFill.BorderSizePixel = 0
 staminaFill.Parent = staminaTrack
@@ -463,7 +463,7 @@ heldStatusLabel.Text = '当前手持：空手'
 local panel = makePanel(
     screenGui,
     'MazePanel',
-    UDim2.new(0, 16, 0, 220),
+    UDim2.fromOffset(16, 220),
     UDim2.fromOffset(360, 382),
     Vector2.zero,
     0.1
@@ -631,7 +631,7 @@ local function updateStaminaDisplay(currentStamina, maxStamina, movementStatus, 
 
     staminaValueLabel.Text =
         string.format('%d / %d', math.floor(currentValue + 0.5), math.floor(maxValue + 0.5))
-    staminaFill.Size = UDim2.new(ratio, 0, 1, 0)
+    staminaFill.Size = UDim2.fromScale(ratio, 1)
     if ratio >= 0.6 then
         staminaFill.BackgroundColor3 = Theme.Accent
     elseif ratio >= 0.25 then

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -8,6 +8,7 @@ local CAMP_SESSION_LOCK_WAIT_SECONDS = 0.05
 local SNAPSHOT_INTERVAL_SECONDS = 0.25
 local TELEPORT_DATA_WAIT_SECONDS = 3
 local TELEPORT_DATA_WAIT_STEP_SECONDS = 0.05
+local CHARACTER_SPAWN_LIFT_STUDS = 3
 local MAZE_DIAG_PREFIX = '[MazeDiag]'
 local CORPSE_COLOR = Color3.fromRGB(92, 92, 92)
 local CORPSE_MATERIAL = Enum.Material.Slate
@@ -142,12 +143,7 @@ local function bindCharacterTeleport(self, player)
             return
         end
 
-        local targetCFrame = self.World.SpawnCFrame
-        if not self.RunTracker:isPlayerActive(player.UserId) then
-            targetCFrame = self.World.ReturnHoldCFrame
-        end
-
-        character:PivotTo(targetCFrame)
+        character:PivotTo(self:_getCharacterSpawnCFrameFor(player))
         self:_applyMovementMode(player)
     end)
 end
@@ -1107,6 +1103,18 @@ function MazeSessionService:_getPlayerArea(player)
     end
 
     return string.format('%s Room', room.Kind)
+end
+
+function MazeSessionService:_getCharacterSpawnCFrameFor(player)
+    if not self.World then
+        return CFrame.new()
+    end
+
+    if not self.RunTracker:isPlayerActive(player.UserId) then
+        return self.World.ReturnHoldCFrame
+    end
+
+    return self.World.SpawnCFrame + Vector3.new(0, CHARACTER_SPAWN_LIFT_STUDS, 0)
 end
 
 function MazeSessionService:_getObjectiveFor()

--- a/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeSessionService.luau
@@ -18,6 +18,11 @@ local SOUND_PRESSURE = table.freeze({
     Door = 34,
     Tool = 28,
 })
+local DIRECT_BOOT_TEST_TOOL_ITEM_IDS = table.freeze({
+    'tool-flashlight',
+    'tool-crowbar',
+    'tool-potion',
+})
 local WORLD_BUILD_SOURCE = table.freeze({
     DirectBootDefault = 'DirectBootDefault',
     JoinDataMergedBeforeBuild = 'JoinDataMergedBeforeBuild',
@@ -562,6 +567,12 @@ function MazeSessionService.new(options)
     self.SnapshotThread = nil
     self.CampSessionLock = false
     self.DiagnosticSequence = 0
+    self.DirectBootTestToolsEnabled = if runtimeOptions.DirectBootTestToolsEnabled ~= nil
+        then runtimeOptions.DirectBootTestToolsEnabled == true
+        else RunService:IsStudio()
+    self.DirectBootLocalReturnEnabled = if runtimeOptions.DirectBootLocalReturnEnabled ~= nil
+        then runtimeOptions.DirectBootLocalReturnEnabled == true
+        else RunService:IsStudio()
     self.HasAcceptedTeleportData = false
     self.HasAcceptedTeleportDataBeforeBuild = false
     self.HasAuthoritativeSessionSeed = false
@@ -615,6 +626,7 @@ function MazeSessionService.new(options)
     self.SurfacePalette = Shared.Runtime.MazeLightingProfile.SurfacePalette
     self.RoundSignalBus = runtimeOptions.RoundSignalBus or RoundSignalBus.new()
     self.RoundSignalConnection = nil
+    self.RoundSignalSubscriptionVersion = 0
     self.RoundClosureInProgress = false
 
     self:_emitDiagnostic('InitDefaultState', {
@@ -692,12 +704,31 @@ function MazeSessionService:_subscribeToRoundSignals()
         self.RoundSignalConnection = nil
     end
 
-    local connection, ok = self.RoundSignalBus:subscribe(self.CampSession, function(payload)
-        self:_handleRoundSignal(payload)
+    self.RoundSignalSubscriptionVersion += 1
+    local subscriptionVersion = self.RoundSignalSubscriptionVersion
+    local campSession = self.CampSession
+
+    task.spawn(function()
+        local connection, ok, reason = self.RoundSignalBus:subscribe(campSession, function(payload)
+            self:_handleRoundSignal(payload)
+        end)
+
+        if subscriptionVersion ~= self.RoundSignalSubscriptionVersion then
+            if connection and connection.Disconnect then
+                connection:Disconnect()
+            end
+            return
+        end
+
+        if ok then
+            self.RoundSignalConnection = connection
+            return
+        end
+
+        self:_emitDiagnostic('RoundSignalSubscribeSkipped', {
+            Reason = reason or 'SubscribeFailed',
+        })
     end)
-    if ok then
-        self.RoundSignalConnection = connection
-    end
 end
 
 function MazeSessionService:_setBootPhase(phase)
@@ -936,6 +967,36 @@ function MazeSessionService:_hydratePlayerInventory(player, teleportData)
     )
 end
 
+function MazeSessionService:_seedDirectBootTestTools(player)
+    if self.DirectBootTestToolsEnabled ~= true or self.IsDirectBoot ~= true then
+        return false
+    end
+
+    local inventorySummary = self.InventoryService:getSummary(player)
+    if inventorySummary.Count > 0 then
+        return false
+    end
+
+    for _, itemId in ipairs(DIRECT_BOOT_TEST_TOOL_ITEM_IDS) do
+        local itemDef = Gameplay.Config.ToolItems[itemId]
+        if itemDef then
+            local success, reason = self.InventoryService:pickup(player, itemDef)
+            if not success then
+                error(
+                    string.format(
+                        'Failed to seed direct-boot test tool %s (%s).',
+                        itemId,
+                        tostring(reason)
+                    ),
+                    0
+                )
+            end
+        end
+    end
+
+    return true
+end
+
 function MazeSessionService:_addPlayerState(player)
     local added = self.RunTracker:addPlayer({
         UserId = player.UserId,
@@ -947,6 +1008,7 @@ function MazeSessionService:_addPlayerState(player)
     end
 
     self.InventoryService:addPlayer(player)
+    self:_seedDirectBootTestTools(player)
     self.CampSession = CampMazeSessionContract.markPlayerEntered(self.CampSession, {
         UserId = player.UserId,
         Name = player.DisplayName,
@@ -1063,6 +1125,48 @@ function MazeSessionService:_getObjectiveFor()
     return 'Read the room, dodge the threat, recover Pages, and bring them back to the ship alive.'
 end
 
+function MazeSessionService:_buildSnapshotFor(player, snapshotContext)
+    local context = snapshotContext or {}
+    local worldBuildFields = context.WorldBuildFields or self:_getWorldBuildMetadataFields()
+    local playerSummary = self.PlayerService:getSummary(player)
+    local controlState = self.ControlStateService:getSummary(player)
+
+    return {
+        IsLaunched = true,
+        Status = self.Status,
+        Area = self:_getPlayerArea(player),
+        Objective = self:_getObjectiveFor(),
+        State = self.RunTracker:getState(),
+        SessionPhase = context.SessionPhase,
+        HostUserId = self.CampSession.HostUserId,
+        RoundStarted = self.CampSession.RoundStarted == true,
+        DangerActive = self.CampSession.DangerActive == true,
+        RoundTimeRemainingSeconds = context.RoundTimeRemainingSeconds,
+        SettlementReason = self.CampSession.SettlementReason,
+        CurrentRound = self.CampSession.CurrentRound,
+        MaxRounds = self.CampSession.MaxRounds,
+        BankedItemCount = self.CampSession.BankedItemCount,
+        TargetItemCount = self.CampSession.TargetItemCount,
+        RoundOutcome = self.CampSession.RoundOutcome,
+        SessionOutcome = self.CampSession.SessionOutcome,
+        Inventory = self.InventoryService:getSummary(player),
+        Movement = FormalLocomotion.summarize(playerSummary, controlState),
+        ControlState = controlState,
+        PlayerState = playerSummary and playerSummary.PlayerState or nil,
+        Roster = context.Roster or {},
+        SessionId = self.CampSession.SessionId,
+        MazeAccessCode = self.CampSession.MazeAccessCode,
+        MazeStatus = context.MazeStatus or self:_getMazeStatus(),
+        ReturnedPlayerSummaries = context.ReturnedPlayerSummaries or {},
+        IsDirectBoot = self.IsDirectBoot,
+        WorldBuildSeed = worldBuildFields.WorldBuildSeed,
+        WorldBuildSessionId = worldBuildFields.WorldBuildSessionId,
+        WorldBuildMazeAccessCode = worldBuildFields.WorldBuildMazeAccessCode,
+        WorldBuildIsDirectBoot = worldBuildFields.WorldBuildIsDirectBoot,
+        WorldBuildSource = worldBuildFields.WorldBuildSource,
+    }
+end
+
 function MazeSessionService:_broadcastSnapshot()
     if not self.IsLaunched then
         return
@@ -1096,42 +1200,17 @@ function MazeSessionService:_broadcastSnapshot()
     }
     local sessionPhase = SessionPhase.resolveFromCampSession(sessionPhaseInput)
     local worldBuildFields = self:_getWorldBuildMetadataFields()
+    local snapshotContext = {
+        MazeStatus = mazeStatus,
+        ReturnedPlayerSummaries = returnedSummaries,
+        Roster = roster,
+        RoundTimeRemainingSeconds = roundTimeRemainingSeconds,
+        SessionPhase = sessionPhase,
+        WorldBuildFields = worldBuildFields,
+    }
 
     for _, player in ipairs(Players:GetPlayers()) do
-        self.Remotes.MazeState:FireClient(player, {
-            IsLaunched = true,
-            Status = self.Status,
-            Area = self:_getPlayerArea(player),
-            Objective = self:_getObjectiveFor(),
-            State = self.RunTracker:getState(),
-            SessionPhase = sessionPhase,
-            HostUserId = self.CampSession.HostUserId,
-            RoundStarted = self.CampSession.RoundStarted == true,
-            DangerActive = self.CampSession.DangerActive == true,
-            RoundTimeRemainingSeconds = roundTimeRemainingSeconds,
-            SettlementReason = self.CampSession.SettlementReason,
-            CurrentRound = self.CampSession.CurrentRound,
-            MaxRounds = self.CampSession.MaxRounds,
-            BankedItemCount = self.CampSession.BankedItemCount,
-            TargetItemCount = self.CampSession.TargetItemCount,
-            RoundOutcome = self.CampSession.RoundOutcome,
-            SessionOutcome = self.CampSession.SessionOutcome,
-            Inventory = self.InventoryService:getSummary(player),
-            Movement = self:_getMovementSummaryFor(player),
-            ControlState = self.ControlStateService:getSummary(player),
-            PlayerState = self.PlayerService:getSummary(player).PlayerState,
-            Roster = roster,
-            SessionId = self.CampSession.SessionId,
-            MazeAccessCode = self.CampSession.MazeAccessCode,
-            MazeStatus = mazeStatus,
-            ReturnedPlayerSummaries = returnedSummaries,
-            IsDirectBoot = self.IsDirectBoot,
-            WorldBuildSeed = worldBuildFields.WorldBuildSeed,
-            WorldBuildSessionId = worldBuildFields.WorldBuildSessionId,
-            WorldBuildMazeAccessCode = worldBuildFields.WorldBuildMazeAccessCode,
-            WorldBuildIsDirectBoot = worldBuildFields.WorldBuildIsDirectBoot,
-            WorldBuildSource = worldBuildFields.WorldBuildSource,
-        })
+        self.Remotes.MazeState:FireClient(player, self:_buildSnapshotFor(player, snapshotContext))
 
         self.Remotes.MazePrivateState:FireClient(player, nil)
     end
@@ -1284,6 +1363,12 @@ end
 
 function MazeSessionService:_canReturnToCamp()
     return SessionConfig.PlaceIds.Run ~= 0 and self.CampSession.CampAccessCode ~= 'local-debug-camp'
+end
+
+function MazeSessionService:_shouldStayLocalAfterDirectBootReturn()
+    return self.DirectBootLocalReturnEnabled == true
+        and self.IsDirectBoot == true
+        and not self:_canReturnToCamp()
 end
 
 function MazeSessionService:_teleportToCamp(players, summaries, mazeCompleted, countInventory)
@@ -1686,6 +1771,17 @@ function MazeSessionService:_returnPlayerToRunEntrance(player, returnReason)
     self:_clearPlayerMovement(player)
 
     self:_publishMazePresence()
+
+    if self:_shouldStayLocalAfterDirectBootReturn() then
+        self:_setStatus(
+            string.format(
+                '%s completed this local Maze PlayTest with %d Page(s). Stay in Studio to inspect the authored MazeStaticWorld.',
+                player.DisplayName,
+                bankedCount
+            )
+        )
+        return
+    end
 
     if self:_teleportToCamp({ player }, { summary }, mazeCompleted, true) then
         self:_setStatus(

--- a/places/maze/src/StarterPlayer/Legacy/MazeClientLegacy.client.luau
+++ b/places/maze/src/StarterPlayer/Legacy/MazeClientLegacy.client.luau
@@ -1,0 +1,529 @@
+local Players = game:GetService('Players')
+local ReplicatedStorage = game:GetService('ReplicatedStorage')
+local RunService = game:GetService('RunService')
+local UserInputService = game:GetService('UserInputService')
+
+local localPlayer = Players.LocalPlayer
+local playerGui = localPlayer:WaitForChild('PlayerGui')
+
+local Packages = ReplicatedStorage:WaitForChild('Packages')
+local Gameplay = require(Packages:WaitForChild('Gameplay'))
+local Shared = require(Packages:WaitForChild('Shared'))
+local UI = require(Packages:WaitForChild('UI'))
+local ItemPresentation = Gameplay.Config.ItemPresentation
+
+local FormalLocomotion = Shared.Runtime.FormalLocomotion
+local HeldToolVisual = Shared.Client.HeldToolVisual
+local heldItemController = Shared.Client.HeldItemController.new(localPlayer)
+local Theme = UI.Hud.Theme
+local REMOTE_WAIT_TIMEOUT_SECONDS = 10
+local WAITING_STATUS_TEXT = 'Waiting for maze snapshot...'
+local INITIAL_DIAGNOSTIC_TEXT = 'Diagnostic: waiting for bootstrap signal...'
+local REMOTE_WAIT_TIMEOUT_TEXT =
+    'Still waiting for the server snapshot. Remotes may be late or the maze server bootstrap may have failed.'
+
+Shared.Client.FirstPersonController.start(localPlayer)
+
+local Remotes
+local actionInputConnection
+local sprintInputEndedConnection
+local visibleBackpackItems = {}
+local didReceiveInitialSnapshot = false
+local lastToolUseRequestAt = -math.huge
+local heldToolCooldownSeconds = 0.2
+local mazeInventoryForSwing: { [string]: any }? = nil
+
+local function presentationIconSuffix(itemEntry: { [string]: any }?)
+    if type(itemEntry) ~= 'table' then
+        return ''
+    end
+    local uri = ItemPresentation.formatIconContentId(itemEntry.IconAssetId)
+    if uri ~= '' then
+        return ' | 2D icon'
+    end
+    return ''
+end
+
+local function readBootstrapDiagnostic()
+    local failed = ReplicatedStorage:GetAttribute('MazeBootstrapFailed')
+    local phase = ReplicatedStorage:GetAttribute('MazeBootstrapPhase')
+    local err = ReplicatedStorage:GetAttribute('MazeBootstrapError')
+    if failed ~= true and phase == nil and err == nil then
+        return nil
+    end
+
+    local lines = {}
+    if phase ~= nil then
+        table.insert(lines, string.format('Phase: %s', tostring(phase)))
+    end
+    if err ~= nil then
+        table.insert(lines, string.format('Error: %s', tostring(err)))
+    end
+
+    if #lines == 0 then
+        return nil
+    end
+
+    return table.concat(lines, '\n')
+end
+
+local screenGui = Instance.new('ScreenGui')
+screenGui.Name = 'MazeHud'
+screenGui.IgnoreGuiInset = true
+screenGui.ResetOnSpawn = false
+screenGui.Parent = playerGui
+
+-- Watch HUD: shows game time and remaining round time
+local watchFrame = Instance.new('Frame')
+watchFrame.Name = 'WatchHud'
+watchFrame.AnchorPoint = Vector2.new(1, 0)
+watchFrame.Position = UDim2.new(1, -16, 0, 16)
+watchFrame.Size = UDim2.fromOffset(130, 58)
+watchFrame.BackgroundColor3 = Color3.fromRGB(12, 10, 8)
+watchFrame.BackgroundTransparency = 0.15
+watchFrame.BorderSizePixel = 0
+watchFrame.Visible = false
+watchFrame.Parent = screenGui
+local watchCorner = Instance.new('UICorner')
+watchCorner.CornerRadius = UDim.new(0, 10)
+watchCorner.Parent = watchFrame
+local watchStroke = Instance.new('UIStroke')
+watchStroke.Color = Theme.Text
+watchStroke.Transparency = 0.7
+watchStroke.Thickness = 1
+watchStroke.Parent = watchFrame
+
+local watchClockIcon = Instance.new('TextLabel')
+watchClockIcon.Name = 'ClockIcon'
+watchClockIcon.Size = UDim2.fromOffset(16, 16)
+watchClockIcon.Position = UDim2.fromOffset(10, 10)
+watchClockIcon.BackgroundTransparency = 1
+watchClockIcon.Font = Enum.Font.GothamBold
+watchClockIcon.TextColor3 = Theme.Accent
+watchClockIcon.TextSize = 14
+watchClockIcon.Text = '\u{1F551}'
+watchClockIcon.Parent = watchFrame
+
+local watchTimeLabel = Instance.new('TextLabel')
+watchTimeLabel.Name = 'GameTime'
+watchTimeLabel.Size = UDim2.new(1, -36, 0, 22)
+watchTimeLabel.Position = UDim2.fromOffset(30, 6)
+watchTimeLabel.BackgroundTransparency = 1
+watchTimeLabel.Font = Enum.Font.GothamBold
+watchTimeLabel.TextColor3 = Theme.Text
+watchTimeLabel.TextSize = 18
+watchTimeLabel.TextXAlignment = Enum.TextXAlignment.Left
+watchTimeLabel.TextYAlignment = Enum.TextYAlignment.Center
+watchTimeLabel.Text = '07:00'
+watchTimeLabel.Parent = watchFrame
+
+local watchRemainLabel = Instance.new('TextLabel')
+watchRemainLabel.Name = 'Remaining'
+watchRemainLabel.Size = UDim2.new(1, -20, 0, 18)
+watchRemainLabel.Position = UDim2.fromOffset(10, 34)
+watchRemainLabel.BackgroundTransparency = 1
+watchRemainLabel.Font = Theme.Font
+watchRemainLabel.TextColor3 = Theme.SubtleText
+watchRemainLabel.TextSize = 13
+watchRemainLabel.TextXAlignment = Enum.TextXAlignment.Left
+watchRemainLabel.TextYAlignment = Enum.TextYAlignment.Center
+watchRemainLabel.Text = '\u{21BB} 15:00'
+watchRemainLabel.Parent = watchFrame
+
+local function formatGameTimeMaze(gameHour)
+    local totalMinutes = math.floor(gameHour * 60)
+    local h = math.floor(totalMinutes / 60)
+    local m = totalMinutes % 60
+    return string.format('%02d:%02d', h, m)
+end
+
+local function formatRemainingMaze(seconds)
+    local m = math.floor(seconds / 60)
+    local s = math.floor(seconds % 60)
+    return string.format('\u{21BB} %02d:%02d', m, s)
+end
+
+local _todConnectionMaze = nil
+local lastTodStateMaze = nil
+
+local function updateWatchMaze(todState)
+    if not todState then
+        watchFrame.Visible = false
+        return
+    end
+    local gameHour = todState.GameHour or 7
+    local remaining = todState.RoundTimeRemaining or 0
+    watchTimeLabel.Text = formatGameTimeMaze(gameHour)
+    watchRemainLabel.Text = formatRemainingMaze(remaining)
+    watchFrame.Visible = true
+    if remaining < 180 then
+        watchTimeLabel.TextColor3 = Color3.fromRGB(220, 80, 80)
+        watchRemainLabel.TextColor3 = Color3.fromRGB(220, 80, 80)
+    else
+        watchTimeLabel.TextColor3 = Theme.Text
+        watchRemainLabel.TextColor3 = Theme.SubtleText
+    end
+end
+
+task.spawn(function()
+    local remoteFolder = ReplicatedStorage:WaitForChild('Remotes', 5)
+    if not remoteFolder then
+        return
+    end
+    local todRemote = remoteFolder:WaitForChild('TODState', 3)
+    if not todRemote then
+        return
+    end
+    _todConnectionMaze = todRemote.OnClientEvent:Connect(function(todState)
+        lastTodStateMaze = todState
+        updateWatchMaze(todState)
+    end)
+    if lastTodStateMaze then
+        updateWatchMaze(lastTodStateMaze)
+    end
+end)
+
+local function makeTextLabel(parent, size, color, textSize, bold)
+    local label = Instance.new('TextLabel')
+    label.Size = size
+    label.BackgroundTransparency = 1
+    label.Font = bold and Enum.Font.GothamBold or Theme.Font
+    label.TextColor3 = color
+    label.TextSize = textSize
+    label.TextWrapped = true
+    label.TextXAlignment = Enum.TextXAlignment.Left
+    label.TextYAlignment = Enum.TextYAlignment.Top
+    label.Parent = parent
+    return label
+end
+
+local panel = Instance.new('Frame')
+panel.Name = 'MazePanel'
+panel.AnchorPoint = Vector2.new(0, 0)
+panel.Position = UDim2.fromScale(0.03, 0.05)
+panel.Size = UDim2.fromOffset(440, 560)
+panel.BackgroundColor3 = Theme.Background
+panel.BorderSizePixel = 0
+panel.Parent = screenGui
+
+local panelCorner = Instance.new('UICorner')
+panelCorner.CornerRadius = UDim.new(0, 16)
+panelCorner.Parent = panel
+
+local panelPadding = Instance.new('UIPadding')
+panelPadding.PaddingTop = UDim.new(0, 18)
+panelPadding.PaddingLeft = UDim.new(0, 18)
+panelPadding.PaddingRight = UDim.new(0, 18)
+panelPadding.PaddingBottom = UDim.new(0, 18)
+panelPadding.Parent = panel
+
+local list = Instance.new('UIListLayout')
+list.Padding = UDim.new(0, 10)
+list.Parent = panel
+
+local title = makeTextLabel(panel, UDim2.new(1, 0, 0, 36), Theme.Text, 28, true)
+title.Text = 'Maze Status'
+
+local statusLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 78), Theme.SubtleText, 18, false)
+statusLabel.Text = WAITING_STATUS_TEXT
+
+local diagnosticLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 88), Theme.Warning, 16, false)
+diagnosticLabel.Text = INITIAL_DIAGNOSTIC_TEXT
+
+local function showSnapshotTimeout(fallbackDiagnosticText)
+    local diagnostic = readBootstrapDiagnostic()
+    statusLabel.Text = string.format('%s\n%s', WAITING_STATUS_TEXT, REMOTE_WAIT_TIMEOUT_TEXT)
+    diagnosticLabel.Text = diagnostic or fallbackDiagnosticText
+end
+
+task.delay(REMOTE_WAIT_TIMEOUT_SECONDS, function()
+    if didReceiveInitialSnapshot then
+        diagnosticLabel.Text = ''
+        return
+    end
+
+    showSnapshotTimeout('Diagnostic: no maze bootstrap attributes reached the client.')
+end)
+
+local objectiveLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 66), Theme.Accent, 18, false)
+objectiveLabel.Text = 'Objective: --'
+
+local promptLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 86), Theme.Text, 16, false)
+-- === 修改：加上了按 F 键使用道具的提示 ===
+promptLabel.Text =
+    'In-world prompts:\n- Pages pickups\n- Blue return marker -> bring Pages back alive\n- Double Door controls\nKeyboard: Hold LeftShift to sprint\nKeyboard: Press F to use held tool'
+
+if RunService:IsStudio() then
+    promptLabel.Text ..= '\nStudio debug: H light damage | J heavy damage'
+end
+
+local inventoryLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 44), Theme.Warning, 16, false)
+inventoryLabel.Text = 'Inventory: --'
+
+local inventoryDetailLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 126), Theme.Text, 15, false)
+inventoryDetailLabel.Text = ''
+
+local playerStateLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 86), Theme.Warning, 16, false)
+playerStateLabel.Text = 'Health: --\nStamina: --\nState: --\nMovement: --'
+
+local rosterLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 94), Theme.SubtleText, 16, false)
+rosterLabel.Text = ''
+
+local returnedLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 104), Theme.SubtleText, 16, false)
+returnedLabel.Text = ''
+
+actionInputConnection = UserInputService.InputBegan:Connect(function(input, gameProcessedEvent)
+    if gameProcessedEvent or input.UserInputType ~= Enum.UserInputType.Keyboard then
+        return
+    end
+    if Remotes == nil then
+        return
+    end
+
+    if input.KeyCode == Enum.KeyCode.LeftShift then
+        Remotes.MazeAction:FireServer({
+            Type = 'RequestSprintStart',
+        })
+        return
+    end
+
+    -- === 新增：监听 F 键并发送 RequestUseTool ===
+    if input.KeyCode == Enum.KeyCode.F then
+        local now = os.clock()
+        if now - lastToolUseRequestAt < heldToolCooldownSeconds then
+            return
+        end
+
+        lastToolUseRequestAt = now
+        local heldForSwing = mazeInventoryForSwing and mazeInventoryForSwing.HeldItem
+        if heldForSwing and heldForSwing.ToolCategory == 'Crowbar' then
+            HeldToolVisual.playCrowbarSwingFeedback(localPlayer.Character)
+        end
+        Remotes.MazeAction:FireServer({
+            Type = 'RequestUseTool',
+        })
+        return
+    end
+
+    if RunService:IsStudio() and input.KeyCode == Enum.KeyCode.H then
+        Remotes.MazeAction:FireServer({
+            Type = 'RequestDebugLightDamage',
+        })
+        return
+    end
+
+    if RunService:IsStudio() and input.KeyCode == Enum.KeyCode.J then
+        Remotes.MazeAction:FireServer({
+            Type = 'RequestDebugHeavyDamage',
+        })
+        return
+    end
+
+    if input.KeyCode == Enum.KeyCode.X then
+        Remotes.MazeAction:FireServer({
+            Type = 'RequestUnequipItem',
+        })
+        return
+    end
+
+    local slotIndexByKeyCode = {
+        [Enum.KeyCode.One] = 1,
+        [Enum.KeyCode.Two] = 2,
+        [Enum.KeyCode.Three] = 3,
+    }
+    local slotIndex = slotIndexByKeyCode[input.KeyCode]
+    if slotIndex == nil then
+        return
+    end
+
+    local itemEntry = visibleBackpackItems[slotIndex]
+    if not itemEntry then
+        return
+    end
+
+    Remotes.MazeAction:FireServer({
+        Type = 'RequestEquipItem',
+        ItemInstanceId = itemEntry.InstanceId,
+    })
+end)
+
+sprintInputEndedConnection = UserInputService.InputEnded:Connect(function(input, gameProcessedEvent)
+    if gameProcessedEvent or input.UserInputType ~= Enum.UserInputType.Keyboard then
+        return
+    end
+    if Remotes == nil then
+        return
+    end
+
+    if input.KeyCode ~= Enum.KeyCode.LeftShift then
+        return
+    end
+
+    Remotes.MazeAction:FireServer({
+        Type = 'RequestSprintStop',
+    })
+end)
+
+script.Destroying:Connect(function()
+    if actionInputConnection then
+        actionInputConnection:Disconnect()
+        actionInputConnection = nil
+    end
+
+    if sprintInputEndedConnection then
+        sprintInputEndedConnection:Disconnect()
+        sprintInputEndedConnection = nil
+    end
+
+    heldItemController:destroy()
+end)
+
+local function connectMazeRemotes(remotes)
+    remotes.MazePrivateState.OnClientEvent:Connect(function()
+        -- The first maze HUD does not surface per-player private state yet.
+    end)
+
+    remotes.MazeState.OnClientEvent:Connect(function(snapshot)
+        if snapshot.IsLaunched ~= true then
+            return
+        end
+
+        didReceiveInitialSnapshot = true
+        diagnosticLabel.Text = ''
+        local diagnosticSeed = snapshot.WorldBuildSeed ~= nil and tostring(snapshot.WorldBuildSeed)
+            or '--'
+        local diagnosticDirect = snapshot.WorldBuildIsDirectBoot == true and 'true' or 'false'
+        local diagnosticSource = snapshot.WorldBuildSource or 'Pending'
+        statusLabel.Text = string.format(
+            '%s\nArea: %s | Expedition: %s | Session: %s | Maze: %s%s\nBuild: %s | Seed: %s | Direct: %s',
+            snapshot.Status or 'Maze ready.',
+            snapshot.Area or 'Unknown',
+            snapshot.State or 'Camp',
+            snapshot.SessionPhase or 'MazeActive',
+            snapshot.MazeStatus or 'active',
+            snapshot.IsDirectBoot and ' | Direct Boot' or '',
+            diagnosticSource,
+            diagnosticSeed,
+            diagnosticDirect
+        )
+
+        objectiveLabel.Text = string.format('Objective: %s', snapshot.Objective or '--')
+
+        local inventory = snapshot.Inventory or {}
+        mazeInventoryForSwing = inventory
+        visibleBackpackItems = inventory.BackpackItems or {}
+        heldItemController:applyInventory(inventory)
+        local pageCount = inventory.MissionCount or inventory.LootCount or 0
+        inventoryLabel.Text = string.format(
+            'Inventory: %d total | %d Pages | %d clue | %d tool | %d/%d slots',
+            inventory.Count or 0,
+            pageCount,
+            inventory.ClueCount or 0,
+            inventory.ToolCount or 0,
+            inventory.Count or 0,
+            inventory.Capacity or 0
+        )
+
+        local heldItem = inventory.HeldItem
+        if heldItem and type(heldItem.CooldownSeconds) == 'number' then
+            heldToolCooldownSeconds = math.max(heldItem.CooldownSeconds, 0)
+        else
+            heldToolCooldownSeconds = 0.2
+        end
+
+        local detailLines = {
+            heldItem and string.format(
+                'Held: %s | %s%s%s',
+                heldItem.Name,
+                heldItem.ItemCategory or 'Loot',
+                heldItem.Light and ' | Glow active' or '',
+                presentationIconSuffix(heldItem)
+            ) or 'Held: Empty hands',
+            'Backpack:',
+        }
+
+        if #visibleBackpackItems == 0 then
+            table.insert(detailLines, '- Empty')
+        else
+            for itemIndex = 1, math.min(#visibleBackpackItems, 3) do
+                local itemEntry = visibleBackpackItems[itemIndex]
+                table.insert(
+                    detailLines,
+                    string.format(
+                        '- [%d] %s | %s%s',
+                        itemIndex,
+                        itemEntry.Name,
+                        itemEntry.ItemCategory or 'Loot',
+                        presentationIconSuffix(itemEntry)
+                    )
+                )
+            end
+        end
+
+        table.insert(detailLines, '')
+        table.insert(detailLines, 'Keys: 1-3 equip listed item | X unequip held item')
+        inventoryDetailLabel.Text = table.concat(detailLines, '\n')
+
+        local playerState = snapshot.PlayerState or {}
+        local movement = snapshot.Movement or {}
+        playerStateLabel.Text = string.format(
+            'Health: %d/%d pips\nStamina: %d/%d\nState: %s\nMovement: %s | Sprint: %s',
+            playerState.HealthPips or 0,
+            playerState.MaxHealthPips or 0,
+            math.floor((playerState.CurrentStamina or 0) + 0.5),
+            math.floor((playerState.MaxStamina or 0) + 0.5),
+            playerState.IsDead and 'Dead' or 'Alive',
+            movement.Mode or 'Walk',
+            FormalLocomotion.formatStatus(playerState, movement)
+        )
+
+        local rosterLines = { 'Crew:' }
+        for _, rosterEntry in ipairs(snapshot.Roster or {}) do
+            local youMarker = rosterEntry.UserId == localPlayer.UserId and ' (You)' or ''
+            local stateMarker = rosterEntry.InMaze == false and ' - Returned' or ' - Active'
+            table.insert(
+                rosterLines,
+                string.format('- %s%s%s', rosterEntry.Name, youMarker, stateMarker)
+            )
+        end
+        rosterLabel.Text = table.concat(rosterLines, '\n')
+
+        local returnedLines = { 'Returned Pages:' }
+        local returned = snapshot.ReturnedPlayerSummaries or {}
+        if #returned == 0 then
+            table.insert(returnedLines, '- No one has returned yet.')
+        else
+            for _, entry in ipairs(returned) do
+                table.insert(
+                    returnedLines,
+                    string.format(
+                        '- %s: %d Page(s) (%s)',
+                        entry.Name,
+                        entry.MissionCount or entry.LootItemCount or 0,
+                        entry.ReturnReason or 'unknown'
+                    )
+                )
+            end
+        end
+        returnedLabel.Text = table.concat(returnedLines, '\n')
+    end)
+end
+
+task.spawn(function()
+    local ok, resolvedRemotes = pcall(function()
+        return Shared.Network.Remotes.waitForScope(
+            Shared.Network.Remotes.Scope.Maze,
+            REMOTE_WAIT_TIMEOUT_SECONDS
+        )
+    end)
+
+    if not ok then
+        showSnapshotTimeout(
+            'Diagnostic: remotes did not appear before timeout; waiting indefinitely now.'
+        )
+        resolvedRemotes = Shared.Network.Remotes.waitForScope(Shared.Network.Remotes.Scope.Maze)
+    end
+
+    Remotes = resolvedRemotes
+    connectMazeRemotes(Remotes)
+end)

--- a/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
+++ b/places/maze/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau
@@ -7,22 +7,29 @@ local localPlayer = Players.LocalPlayer
 local playerGui = localPlayer:WaitForChild('PlayerGui')
 
 local Packages = ReplicatedStorage:WaitForChild('Packages')
-local Gameplay = require(Packages:WaitForChild('Gameplay'))
-local Shared = require(Packages:WaitForChild('Shared'))
-local UI = require(Packages:WaitForChild('UI'))
-local ItemPresentation = Gameplay.Config.ItemPresentation
+local GameplayPackage = Packages:WaitForChild('Gameplay')
+local SharedPackage = Packages:WaitForChild('Shared')
+local UIPackage = Packages:WaitForChild('UI')
 
-local FormalLocomotion = Shared.Runtime.FormalLocomotion
-local HeldToolVisual = Shared.Client.HeldToolVisual
-local heldItemController = Shared.Client.HeldItemController.new(localPlayer)
-local Theme = UI.Hud.Theme
+local ItemPresentation =
+    require(GameplayPackage:WaitForChild('Config'):WaitForChild('ItemPresentation'))
+local FormalLocomotion =
+    require(SharedPackage:WaitForChild('Runtime'):WaitForChild('FormalLocomotion'))
+local HeldToolVisual = require(SharedPackage:WaitForChild('Client'):WaitForChild('HeldToolVisual'))
+local HeldItemController =
+    require(SharedPackage:WaitForChild('Client'):WaitForChild('HeldItemController'))
+local FirstPersonController =
+    require(SharedPackage:WaitForChild('Client'):WaitForChild('FirstPersonController'))
+local RemotesModule = require(SharedPackage:WaitForChild('Network'):WaitForChild('Remotes'))
+local Theme = require(UIPackage:WaitForChild('Hud'):WaitForChild('Theme'))
+local heldItemController = HeldItemController.new(localPlayer)
 local REMOTE_WAIT_TIMEOUT_SECONDS = 10
-local WAITING_STATUS_TEXT = 'Waiting for maze snapshot...'
-local INITIAL_DIAGNOSTIC_TEXT = 'Diagnostic: waiting for bootstrap signal...'
+local WAITING_STATUS_TEXT = '正在等待迷宫状态同步...'
+local INITIAL_DIAGNOSTIC_TEXT = '诊断信息：正在等待启动信号...'
 local REMOTE_WAIT_TIMEOUT_TEXT =
-    'Still waiting for the server snapshot. Remotes may be late or the maze server bootstrap may have failed.'
+    '仍在等待服务端快照。可能是 remote 还没准备好，或者迷宫启动失败了。'
 
-Shared.Client.FirstPersonController.start(localPlayer)
+FirstPersonController.start(localPlayer)
 
 local Remotes
 local actionInputConnection
@@ -39,9 +46,81 @@ local function presentationIconSuffix(itemEntry: { [string]: any }?)
     end
     local uri = ItemPresentation.formatIconContentId(itemEntry.IconAssetId)
     if uri ~= '' then
-        return ' | 2D icon'
+        return ' | 2D 图标'
     end
     return ''
+end
+
+local function localizeSessionPhase(sessionPhase)
+    local labels = {
+        MazeActive = '迷宫进行中',
+        RunIntermission = '本轮完成',
+        FinalDebrief = '最终结算',
+        SessionClosed = '会话关闭',
+        RunPrep = '准备阶段',
+        RunField = '外场阶段',
+    }
+    return labels[sessionPhase] or tostring(sessionPhase or '迷宫进行中')
+end
+
+local function localizeLoopState(state)
+    local labels = {
+        Staging = '准备中',
+        Expedition = '探索中',
+        Extraction = '撤离中',
+        Settlement = '结算中',
+        Completed = '已完成',
+        Camp = '营地',
+    }
+    return labels[state] or tostring(state or '探索中')
+end
+
+local function localizeMazeStatus(mazeStatus)
+    local labels = {
+        active = '进行中',
+        completed = '已完成',
+        idle = '未开始',
+    }
+    return labels[mazeStatus] or tostring(mazeStatus or '进行中')
+end
+
+local function localizeBuildSource(source)
+    local labels = {
+        ContentHarness = '内容测试场',
+        DirectBootDefault = '本地直启',
+        JoinDataMergedBeforeBuild = '进场前合并',
+        JoinDataMergedAfterBuild = '进场后合并',
+    }
+    return labels[source] or tostring(source or '内容测试场')
+end
+
+local function localizeReturnReason(reason)
+    local labels = {
+        returned = '已返回',
+        death = '死亡',
+        settled = '强制结算',
+        timeout = '超时',
+    }
+    return labels[reason] or tostring(reason or '未知')
+end
+
+local function localizeRoomArea(areaText)
+    local labels = {
+        ['Maze Staging'] = '迷宫准备区',
+        ['Loot Room'] = '战利品房',
+        ['Camp Room'] = '营地区',
+        ['Monster Room'] = '怪物房',
+    }
+    return labels[areaText] or tostring(areaText or '未知区域')
+end
+
+local function localizeMovementStatus(status)
+    local labels = {
+        Disabled = '不可行动',
+        Ready = '可冲刺',
+        Recovering = '恢复中',
+    }
+    return labels[status] or tostring(status or '未知')
 end
 
 local function readBootstrapDiagnostic()
@@ -54,10 +133,10 @@ local function readBootstrapDiagnostic()
 
     local lines = {}
     if phase ~= nil then
-        table.insert(lines, string.format('Phase: %s', tostring(phase)))
+        table.insert(lines, string.format('阶段：%s', tostring(phase)))
     end
     if err ~= nil then
-        table.insert(lines, string.format('Error: %s', tostring(err)))
+        table.insert(lines, string.format('错误：%s', tostring(err)))
     end
 
     if #lines == 0 then
@@ -197,42 +276,227 @@ local function makeTextLabel(parent, size, color, textSize, bold)
     return label
 end
 
-local panel = Instance.new('Frame')
-panel.Name = 'MazePanel'
-panel.AnchorPoint = Vector2.new(0, 0)
-panel.Position = UDim2.fromScale(0.03, 0.05)
-panel.Size = UDim2.fromOffset(440, 560)
-panel.BackgroundColor3 = Theme.Background
-panel.BorderSizePixel = 0
-panel.Parent = screenGui
+local function applyPanelStyle(frame, cornerRadius, backgroundTransparency)
+    frame.BackgroundColor3 = Theme.Background
+    frame.BackgroundTransparency = backgroundTransparency or 0.18
+    frame.BorderSizePixel = 0
 
-local panelCorner = Instance.new('UICorner')
-panelCorner.CornerRadius = UDim.new(0, 16)
-panelCorner.Parent = panel
+    local corner = Instance.new('UICorner')
+    corner.CornerRadius = UDim.new(0, cornerRadius or 14)
+    corner.Parent = frame
+
+    local stroke = Instance.new('UIStroke')
+    stroke.Color = Theme.Text
+    stroke.Transparency = 0.72
+    stroke.Thickness = 1
+    stroke.Parent = frame
+end
+
+local function makePanel(parent, name, position, size, anchorPoint, transparency)
+    local frame = Instance.new('Frame')
+    frame.Name = name
+    frame.AnchorPoint = anchorPoint or Vector2.zero
+    frame.Position = position
+    frame.Size = size
+    frame.Parent = parent
+    applyPanelStyle(frame, 14, transparency)
+    return frame
+end
+
+local function makeSectionTitle(parent, text)
+    local label = makeTextLabel(parent, UDim2.new(1, 0, 0, 18), Theme.SubtleText, 12, true)
+    label.TextYAlignment = Enum.TextYAlignment.Center
+    label.Text = text
+    return label
+end
+
+local function makeDivider(parent)
+    local divider = Instance.new('Frame')
+    divider.Size = UDim2.new(1, 0, 0, 1)
+    divider.BackgroundColor3 = Theme.Text
+    divider.BackgroundTransparency = 0.82
+    divider.BorderSizePixel = 0
+    divider.Parent = parent
+    return divider
+end
+
+local function buildQuickSlotGlyph(itemEntry)
+    if type(itemEntry) ~= 'table' then
+        return ''
+    end
+
+    local toolCategory = itemEntry.ToolCategory
+    if toolCategory == 'Flashlight' then
+        return '灯'
+    elseif toolCategory == 'Crowbar' then
+        return '撬'
+    elseif toolCategory == 'Potion' then
+        return '药'
+    end
+
+    local itemCategory = itemEntry.ItemCategory
+    if itemCategory == 'Loot' then
+        return '资'
+    elseif itemCategory == 'Clue' then
+        return '线'
+    elseif itemCategory == 'Tool' then
+        return '工'
+    end
+
+    return '包'
+end
+
+local function truncateText(text, maxLength)
+    local value = tostring(text or '')
+    if #value <= maxLength then
+        return value
+    end
+
+    return string.sub(value, 1, math.max(0, maxLength - 1)) .. '…'
+end
+
+local topHudFrame = Instance.new('Frame')
+topHudFrame.Name = 'TopHud'
+topHudFrame.AnchorPoint = Vector2.zero
+topHudFrame.Position = UDim2.fromOffset(16, 16)
+topHudFrame.Size = UDim2.fromOffset(380, 190)
+topHudFrame.BackgroundTransparency = 1
+topHudFrame.Parent = screenGui
+
+local healthPanel = makePanel(
+    topHudFrame,
+    'HealthPanel',
+    UDim2.fromOffset(0, 0),
+    UDim2.fromOffset(130, 76),
+    Vector2.zero,
+    0.16
+)
+local healthTitle = makeSectionTitle(healthPanel, '生命')
+healthTitle.Position = UDim2.fromOffset(12, 8)
+local healthValueLabel =
+    makeTextLabel(healthPanel, UDim2.new(1, -24, 0, 18), Theme.SubtleText, 13, false)
+healthValueLabel.Position = UDim2.fromOffset(12, 52)
+healthValueLabel.Text = '等待同步'
+
+local healthHearts = {}
+for index = 1, 4 do
+    local heart = makeTextLabel(healthPanel, UDim2.fromOffset(22, 26), Theme.Warning, 24, true)
+    heart.Position = UDim2.fromOffset(12 + (index - 1) * 24, 22)
+    heart.TextXAlignment = Enum.TextXAlignment.Center
+    heart.TextYAlignment = Enum.TextYAlignment.Center
+    heart.Text = '♥'
+    heart.Visible = false
+    healthHearts[index] = heart
+end
+
+local staminaPanel = makePanel(
+    topHudFrame,
+    'StaminaPanel',
+    UDim2.fromOffset(142, 0),
+    UDim2.fromOffset(238, 76),
+    Vector2.zero,
+    0.16
+)
+local staminaTitle = makeSectionTitle(staminaPanel, '体力 / 冲刺')
+staminaTitle.Position = UDim2.fromOffset(12, 8)
+local staminaValueLabel =
+    makeTextLabel(staminaPanel, UDim2.new(1, -24, 0, 18), Theme.Text, 16, true)
+staminaValueLabel.Position = UDim2.fromOffset(12, 24)
+staminaValueLabel.Text = '-- / --'
+
+local staminaTrack = Instance.new('Frame')
+staminaTrack.Name = 'StaminaTrack'
+staminaTrack.Size = UDim2.new(1, -24, 0, 12)
+staminaTrack.Position = UDim2.fromOffset(12, 48)
+staminaTrack.BackgroundColor3 = Theme.Surface
+staminaTrack.BackgroundTransparency = 0.25
+staminaTrack.BorderSizePixel = 0
+staminaTrack.Parent = staminaPanel
+local staminaTrackCorner = Instance.new('UICorner')
+staminaTrackCorner.CornerRadius = UDim.new(0, 6)
+staminaTrackCorner.Parent = staminaTrack
+
+local staminaFill = Instance.new('Frame')
+staminaFill.Name = 'StaminaFill'
+staminaFill.Size = UDim2.fromScale(0, 1)
+staminaFill.BackgroundColor3 = Theme.Accent
+staminaFill.BorderSizePixel = 0
+staminaFill.Parent = staminaTrack
+local staminaFillCorner = Instance.new('UICorner')
+staminaFillCorner.CornerRadius = UDim.new(0, 6)
+staminaFillCorner.Parent = staminaFill
+
+local staminaStatusLabel =
+    makeTextLabel(staminaPanel, UDim2.new(1, -24, 0, 16), Theme.SubtleText, 13, false)
+staminaStatusLabel.Position = UDim2.fromOffset(12, 62)
+staminaStatusLabel.Text = '等待同步'
+
+local statusPanel = makePanel(
+    topHudFrame,
+    'StatusPanel',
+    UDim2.fromOffset(0, 88),
+    UDim2.fromOffset(380, 102),
+    Vector2.zero,
+    0.16
+)
+local statusAreaLabel =
+    makeTextLabel(statusPanel, UDim2.new(1, -24, 0, 18), Theme.SubtleText, 13, true)
+statusAreaLabel.Position = UDim2.fromOffset(12, 10)
+statusAreaLabel.Text = '区域：等待同步'
+
+local statusSummaryLabel =
+    makeTextLabel(statusPanel, UDim2.new(1, -24, 0, 24), Theme.Text, 20, true)
+statusSummaryLabel.Position = UDim2.fromOffset(12, 28)
+statusSummaryLabel.Text = WAITING_STATUS_TEXT
+statusSummaryLabel.TextYAlignment = Enum.TextYAlignment.Center
+
+local objectiveSummaryLabel =
+    makeTextLabel(statusPanel, UDim2.new(1, -24, 0, 18), Theme.Accent, 15, false)
+objectiveSummaryLabel.Position = UDim2.fromOffset(12, 58)
+objectiveSummaryLabel.Text = '目标：--'
+
+local heldStatusLabel =
+    makeTextLabel(statusPanel, UDim2.new(1, -24, 0, 16), Theme.SubtleText, 13, false)
+heldStatusLabel.Position = UDim2.fromOffset(12, 78)
+heldStatusLabel.Text = '当前手持：空手'
+
+local panel = makePanel(
+    screenGui,
+    'MazePanel',
+    UDim2.fromOffset(16, 220),
+    UDim2.fromOffset(360, 382),
+    Vector2.zero,
+    0.1
+)
 
 local panelPadding = Instance.new('UIPadding')
-panelPadding.PaddingTop = UDim.new(0, 18)
-panelPadding.PaddingLeft = UDim.new(0, 18)
-panelPadding.PaddingRight = UDim.new(0, 18)
-panelPadding.PaddingBottom = UDim.new(0, 18)
+panelPadding.PaddingTop = UDim.new(0, 16)
+panelPadding.PaddingLeft = UDim.new(0, 16)
+panelPadding.PaddingRight = UDim.new(0, 16)
+panelPadding.PaddingBottom = UDim.new(0, 16)
 panelPadding.Parent = panel
 
 local list = Instance.new('UIListLayout')
 list.Padding = UDim.new(0, 10)
 list.Parent = panel
 
-local title = makeTextLabel(panel, UDim2.new(1, 0, 0, 36), Theme.Text, 28, true)
-title.Text = 'Maze Status'
+local title = makeTextLabel(panel, UDim2.new(1, 0, 0, 24), Theme.Text, 22, true)
+title.Text = '详细信息'
+title.TextYAlignment = Enum.TextYAlignment.Center
 
-local statusLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 78), Theme.SubtleText, 18, false)
+local statusLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 56), Theme.SubtleText, 16, false)
 statusLabel.Text = WAITING_STATUS_TEXT
 
-local diagnosticLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 88), Theme.Warning, 16, false)
+local diagnosticLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 64), Theme.Warning, 15, false)
 diagnosticLabel.Text = INITIAL_DIAGNOSTIC_TEXT
 
 local function showSnapshotTimeout(fallbackDiagnosticText)
     local diagnostic = readBootstrapDiagnostic()
     statusLabel.Text = string.format('%s\n%s', WAITING_STATUS_TEXT, REMOTE_WAIT_TIMEOUT_TEXT)
+    statusSummaryLabel.Text = '迷宫还没准备好'
+    statusAreaLabel.Text = '区域：等待同步'
+    objectiveSummaryLabel.Text = '目标：等待服务端状态'
+    heldStatusLabel.Text = '当前手持：空手'
     diagnosticLabel.Text = diagnostic or fallbackDiagnosticText
 end
 
@@ -242,40 +506,167 @@ task.delay(REMOTE_WAIT_TIMEOUT_SECONDS, function()
         return
     end
 
-    showSnapshotTimeout('Diagnostic: no maze bootstrap attributes reached the client.')
+    showSnapshotTimeout('诊断信息：客户端还没有收到任何迷宫启动属性。')
 end)
 
-local objectiveLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 66), Theme.Accent, 18, false)
-objectiveLabel.Text = 'Objective: --'
+makeDivider(panel)
 
-local promptLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 86), Theme.Text, 16, false)
--- === 修改：加上了按 F 键使用道具的提示 ===
+local objectiveLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 50), Theme.Accent, 16, false)
+objectiveLabel.Text = '目标：--'
+
+local promptLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 72), Theme.Text, 14, false)
 promptLabel.Text =
-    'In-world prompts:\n- Pages pickups\n- Blue return marker -> bring Pages back alive\n- Double Door controls\nKeyboard: Hold LeftShift to sprint\nKeyboard: Press F to use held tool'
+    '交互：拾取战利品 / 开关门 / 返回\n按键：1-3 装备 | F 使用 | X 收起 | Shift 冲刺'
 
 if RunService:IsStudio() then
-    promptLabel.Text ..= '\nStudio debug: H light damage | J heavy damage'
+    promptLabel.Text ..= '\nStudio 调试：H 轻伤 | J 重伤'
 end
 
-local inventoryLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 44), Theme.Warning, 16, false)
-inventoryLabel.Text = 'Inventory: --'
+makeDivider(panel)
 
-local inventoryDetailLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 126), Theme.Text, 15, false)
+local inventoryLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 40), Theme.Warning, 15, false)
+inventoryLabel.Text = '背包：--'
+
+local inventoryDetailLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 102), Theme.Text, 14, false)
 inventoryDetailLabel.Text = ''
 
-local playerStateLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 86), Theme.Warning, 16, false)
-playerStateLabel.Text = 'Health: --\nStamina: --\nState: --\nMovement: --'
+makeDivider(panel)
 
-local rosterLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 94), Theme.SubtleText, 16, false)
+local playerStateLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 72), Theme.Warning, 15, false)
+playerStateLabel.Text = '生命：--\n体力：--\n状态：--\n移动：--'
+
+local rosterLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 78), Theme.SubtleText, 14, false)
 rosterLabel.Text = ''
 
-local returnedLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 104), Theme.SubtleText, 16, false)
+local returnedLabel = makeTextLabel(panel, UDim2.new(1, 0, 0, 86), Theme.SubtleText, 14, false)
 returnedLabel.Text = ''
+
+local quickbarPanel = makePanel(
+    screenGui,
+    'QuickbarPanel',
+    UDim2.new(1, -18, 0.5, -84),
+    UDim2.fromOffset(94, 244),
+    Vector2.new(1, 0.5),
+    0.08
+)
+local quickbarPadding = Instance.new('UIPadding')
+quickbarPadding.PaddingTop = UDim.new(0, 10)
+quickbarPadding.PaddingLeft = UDim.new(0, 10)
+quickbarPadding.PaddingRight = UDim.new(0, 10)
+quickbarPadding.PaddingBottom = UDim.new(0, 10)
+quickbarPadding.Parent = quickbarPanel
+local quickbarTitle = makeSectionTitle(quickbarPanel, '快捷栏')
+quickbarTitle.Position = UDim2.fromOffset(0, 0)
+
+local quickbarSlots = {}
+for slotIndex = 1, 3 do
+    local slotFrame = makePanel(
+        quickbarPanel,
+        string.format('QuickSlot_%d', slotIndex),
+        UDim2.fromOffset(0, 24 + (slotIndex - 1) * 68),
+        UDim2.fromOffset(74, 58),
+        Vector2.zero,
+        0.02
+    )
+    slotFrame.BackgroundTransparency = 0.02
+
+    local keyLabel = makeTextLabel(slotFrame, UDim2.fromOffset(18, 16), Theme.SubtleText, 12, true)
+    keyLabel.Position = UDim2.fromOffset(8, 6)
+    keyLabel.Text = tostring(slotIndex)
+    keyLabel.TextXAlignment = Enum.TextXAlignment.Center
+    keyLabel.TextYAlignment = Enum.TextYAlignment.Center
+
+    local glyphLabel = makeTextLabel(slotFrame, UDim2.fromOffset(54, 24), Theme.Accent, 24, true)
+    glyphLabel.Position = UDim2.fromOffset(10, 18)
+    glyphLabel.Text = '—'
+    glyphLabel.TextXAlignment = Enum.TextXAlignment.Center
+    glyphLabel.TextYAlignment = Enum.TextYAlignment.Center
+
+    local nameLabel = makeTextLabel(slotFrame, UDim2.new(1, -16, 0, 16), Theme.Text, 12, false)
+    nameLabel.Position = UDim2.fromOffset(8, 40)
+    nameLabel.TextXAlignment = Enum.TextXAlignment.Center
+    nameLabel.TextYAlignment = Enum.TextYAlignment.Center
+    nameLabel.Text = '空'
+
+    quickbarSlots[slotIndex] = {
+        Frame = slotFrame,
+        Glyph = glyphLabel,
+        Name = nameLabel,
+    }
+end
+
+local hintsPanel = makePanel(
+    screenGui,
+    'HintsPanel',
+    UDim2.new(0.5, 0, 1, -16),
+    UDim2.fromOffset(426, 70),
+    Vector2.new(0.5, 1),
+    0.08
+)
+local hintsTitle = makeSectionTitle(hintsPanel, '常用按键')
+hintsTitle.Position = UDim2.fromOffset(14, 8)
+
+local hintsLabel = makeTextLabel(hintsPanel, UDim2.new(1, -28, 0, 36), Theme.Text, 14, false)
+hintsLabel.Position = UDim2.fromOffset(14, 26)
+hintsLabel.Text = 'Shift 冲刺   F 使用工具   X 收起手持   1-3 快速装备'
+hintsLabel.TextYAlignment = Enum.TextYAlignment.Center
+
+local function updateHealthDisplay(currentHealthPips, maxHealthPips)
+    local maxPips = math.clamp(math.floor(tonumber(maxHealthPips) or 0), 0, #healthHearts)
+    local currentPips = math.clamp(math.floor(tonumber(currentHealthPips) or 0), 0, maxPips)
+
+    for index, heart in ipairs(healthHearts) do
+        heart.Visible = index <= math.max(maxPips, 1)
+        heart.TextColor3 = if index <= currentPips then Theme.Warning else Theme.SubtleText
+        heart.TextTransparency = if index <= currentPips then 0 else 0.35
+    end
+
+    healthValueLabel.Text = string.format('%d / %d 格', currentPips, math.max(maxPips, 1))
+end
+
+local function updateStaminaDisplay(currentStamina, maxStamina, movementStatus, isSprinting)
+    local currentValue = math.max(0, tonumber(currentStamina) or 0)
+    local maxValue = math.max(1, tonumber(maxStamina) or 1)
+    local ratio = math.clamp(currentValue / maxValue, 0, 1)
+
+    staminaValueLabel.Text =
+        string.format('%d / %d', math.floor(currentValue + 0.5), math.floor(maxValue + 0.5))
+    staminaFill.Size = UDim2.fromScale(ratio, 1)
+    if ratio >= 0.6 then
+        staminaFill.BackgroundColor3 = Theme.Accent
+    elseif ratio >= 0.25 then
+        staminaFill.BackgroundColor3 = Theme.Warning
+    else
+        staminaFill.BackgroundColor3 = Color3.fromRGB(220, 80, 80)
+    end
+
+    staminaStatusLabel.Text =
+        string.format('%s%s', movementStatus, isSprinting and ' | 正在冲刺' or '')
+end
+
+local function updateQuickbarDisplay(inventory)
+    local backpackItems = if type(inventory) == 'table' then inventory.BackpackItems or {} else {}
+    for slotIndex, slot in ipairs(quickbarSlots) do
+        local itemEntry = backpackItems[slotIndex]
+        if itemEntry then
+            slot.Glyph.Text = buildQuickSlotGlyph(itemEntry)
+            slot.Glyph.TextColor3 = Theme.Accent
+            slot.Name.Text = truncateText(itemEntry.Name or itemEntry.ItemCategory or '物品', 5)
+            slot.Name.TextColor3 = Theme.Text
+        else
+            slot.Glyph.Text = '—'
+            slot.Glyph.TextColor3 = Theme.SubtleText
+            slot.Name.Text = '空'
+            slot.Name.TextColor3 = Theme.SubtleText
+        end
+    end
+end
 
 actionInputConnection = UserInputService.InputBegan:Connect(function(input, gameProcessedEvent)
     if gameProcessedEvent or input.UserInputType ~= Enum.UserInputType.Keyboard then
         return
     end
+
     if Remotes == nil then
         return
     end
@@ -374,6 +765,10 @@ script.Destroying:Connect(function()
         sprintInputEndedConnection:Disconnect()
         sprintInputEndedConnection = nil
     end
+    if _todConnectionMaze then
+        _todConnectionMaze:Disconnect()
+        _todConnectionMaze = nil
+    end
 
     heldItemController:destroy()
 end)
@@ -390,34 +785,48 @@ local function connectMazeRemotes(remotes)
 
         didReceiveInitialSnapshot = true
         diagnosticLabel.Text = ''
-        local diagnosticSeed = snapshot.WorldBuildSeed ~= nil and tostring(snapshot.WorldBuildSeed)
-            or '--'
-        local diagnosticDirect = snapshot.WorldBuildIsDirectBoot == true and 'true' or 'false'
-        local diagnosticSource = snapshot.WorldBuildSource or 'Pending'
+        local diagnosticSource = localizeBuildSource(snapshot.WorldBuildSource)
+        local localizedArea = localizeRoomArea(snapshot.Area)
+        local localizedLoopState = localizeLoopState(snapshot.State)
+        local localizedSessionPhase = localizeSessionPhase(snapshot.SessionPhase)
+        local localizedMazeStatus = localizeMazeStatus(snapshot.MazeStatus)
         statusLabel.Text = string.format(
-            '%s\nArea: %s | Expedition: %s | Session: %s | Maze: %s%s\nBuild: %s | Seed: %s | Direct: %s',
-            snapshot.Status or 'Maze ready.',
-            snapshot.Area or 'Unknown',
-            snapshot.State or 'Camp',
-            snapshot.SessionPhase or 'MazeActive',
-            snapshot.MazeStatus or 'active',
-            snapshot.IsDirectBoot and ' | Direct Boot' or '',
-            diagnosticSource,
-            diagnosticSeed,
-            diagnosticDirect
+            '%s\n区域：%s | 流程：%s | 会话：%s | 迷宫：%s%s',
+            snapshot.Status or '迷宫已准备就绪。',
+            localizedArea,
+            localizedLoopState,
+            localizedSessionPhase,
+            localizedMazeStatus,
+            snapshot.IsDirectBoot and ' | 本地直启' or ''
         )
+        if RunService:IsStudio() then
+            local diagnosticSeed = snapshot.WorldBuildSeed ~= nil
+                    and tostring(snapshot.WorldBuildSeed)
+                or '--'
+            local diagnosticDirect = snapshot.WorldBuildIsDirectBoot == true and '是' or '否'
+            statusLabel.Text ..= string.format(
+                '\nStudio 诊断：构建来源：%s | 会话种子：%s | 直启：%s',
+                diagnosticSource,
+                diagnosticSeed,
+                diagnosticDirect
+            )
+        end
+        statusAreaLabel.Text = string.format('区域：%s', localizedArea)
+        statusSummaryLabel.Text =
+            string.format('%s | %s', localizedLoopState, localizedSessionPhase)
+        objectiveSummaryLabel.Text = string.format('目标：%s', snapshot.Objective or '--')
 
-        objectiveLabel.Text = string.format('Objective: %s', snapshot.Objective or '--')
+        objectiveLabel.Text = string.format('目标：%s', snapshot.Objective or '--')
 
         local inventory = snapshot.Inventory or {}
         mazeInventoryForSwing = inventory
         visibleBackpackItems = inventory.BackpackItems or {}
         heldItemController:applyInventory(inventory)
-        local pageCount = inventory.MissionCount or inventory.LootCount or 0
+        updateQuickbarDisplay(inventory)
         inventoryLabel.Text = string.format(
-            'Inventory: %d total | %d Pages | %d clue | %d tool | %d/%d slots',
+            '背包：共 %d 件 | 战利品 %d | 线索 %d | 工具 %d | 槽位 %d/%d',
             inventory.Count or 0,
-            pageCount,
+            inventory.LootCount or 0,
             inventory.ClueCount or 0,
             inventory.ToolCount or 0,
             inventory.Count or 0,
@@ -430,20 +839,27 @@ local function connectMazeRemotes(remotes)
         else
             heldToolCooldownSeconds = 0.2
         end
+        heldStatusLabel.Text = heldItem
+                and string.format(
+                    '当前手持：%s%s',
+                    heldItem.Name,
+                    heldItem.Light and ' | 发光中' or ''
+                )
+            or '当前手持：空手'
 
         local detailLines = {
             heldItem and string.format(
-                'Held: %s | %s%s%s',
+                '当前手持：%s | %s%s%s',
                 heldItem.Name,
-                heldItem.ItemCategory or 'Loot',
-                heldItem.Light and ' | Glow active' or '',
+                heldItem.ItemCategory or '战利品',
+                heldItem.Light and ' | 发光中' or '',
                 presentationIconSuffix(heldItem)
-            ) or 'Held: Empty hands',
-            'Backpack:',
+            ) or '当前手持：空手',
+            '背包内容：',
         }
 
         if #visibleBackpackItems == 0 then
-            table.insert(detailLines, '- Empty')
+            table.insert(detailLines, '- 空')
         else
             for itemIndex = 1, math.min(#visibleBackpackItems, 3) do
                 local itemEntry = visibleBackpackItems[itemIndex]
@@ -453,7 +869,7 @@ local function connectMazeRemotes(remotes)
                         '- [%d] %s | %s%s',
                         itemIndex,
                         itemEntry.Name,
-                        itemEntry.ItemCategory or 'Loot',
+                        itemEntry.ItemCategory or '战利品',
                         presentationIconSuffix(itemEntry)
                     )
                 )
@@ -461,26 +877,35 @@ local function connectMazeRemotes(remotes)
         end
 
         table.insert(detailLines, '')
-        table.insert(detailLines, 'Keys: 1-3 equip listed item | X unequip held item')
+        table.insert(detailLines, '按键：1-3 装备列表物品 | X 收起当前手持')
         inventoryDetailLabel.Text = table.concat(detailLines, '\n')
 
         local playerState = snapshot.PlayerState or {}
         local movement = snapshot.Movement or {}
+        local movementStatus =
+            localizeMovementStatus(FormalLocomotion.formatStatus(playerState, movement))
+        updateHealthDisplay(playerState.HealthPips or 0, playerState.MaxHealthPips or 0)
+        updateStaminaDisplay(
+            playerState.CurrentStamina or 0,
+            playerState.MaxStamina or 0,
+            movementStatus,
+            movement.Mode == 'Sprint'
+        )
         playerStateLabel.Text = string.format(
-            'Health: %d/%d pips\nStamina: %d/%d\nState: %s\nMovement: %s | Sprint: %s',
+            '生命：%d/%d 格\n体力：%d/%d\n状态：%s\n移动：%s | 冲刺：%s',
             playerState.HealthPips or 0,
             playerState.MaxHealthPips or 0,
             math.floor((playerState.CurrentStamina or 0) + 0.5),
             math.floor((playerState.MaxStamina or 0) + 0.5),
-            playerState.IsDead and 'Dead' or 'Alive',
-            movement.Mode or 'Walk',
-            FormalLocomotion.formatStatus(playerState, movement)
+            playerState.IsDead and '已死亡' or '存活',
+            movement.Mode == 'Sprint' and '冲刺' or '行走',
+            movementStatus
         )
 
-        local rosterLines = { 'Crew:' }
+        local rosterLines = { '队伍：' }
         for _, rosterEntry in ipairs(snapshot.Roster or {}) do
-            local youMarker = rosterEntry.UserId == localPlayer.UserId and ' (You)' or ''
-            local stateMarker = rosterEntry.InMaze == false and ' - Returned' or ' - Active'
+            local youMarker = rosterEntry.UserId == localPlayer.UserId and ' (你)' or ''
+            local stateMarker = rosterEntry.InMaze == false and ' - 已返回' or ' - 仍在迷宫'
             table.insert(
                 rosterLines,
                 string.format('- %s%s%s', rosterEntry.Name, youMarker, stateMarker)
@@ -488,19 +913,19 @@ local function connectMazeRemotes(remotes)
         end
         rosterLabel.Text = table.concat(rosterLines, '\n')
 
-        local returnedLines = { 'Returned Pages:' }
+        local returnedLines = { '返回记录：' }
         local returned = snapshot.ReturnedPlayerSummaries or {}
         if #returned == 0 then
-            table.insert(returnedLines, '- No one has returned yet.')
+            table.insert(returnedLines, '- 还没有人返回。')
         else
             for _, entry in ipairs(returned) do
                 table.insert(
                     returnedLines,
                     string.format(
-                        '- %s: %d Page(s) (%s)',
+                        '- %s：%d 件战利品（%s）',
                         entry.Name,
-                        entry.MissionCount or entry.LootItemCount or 0,
-                        entry.ReturnReason or 'unknown'
+                        entry.LootItemCount or entry.MissionCount or 0,
+                        localizeReturnReason(entry.ReturnReason)
                     )
                 )
             end
@@ -511,17 +936,14 @@ end
 
 task.spawn(function()
     local ok, resolvedRemotes = pcall(function()
-        return Shared.Network.Remotes.waitForScope(
-            Shared.Network.Remotes.Scope.Maze,
-            REMOTE_WAIT_TIMEOUT_SECONDS
-        )
+        return RemotesModule.waitForScope(RemotesModule.Scope.Maze, REMOTE_WAIT_TIMEOUT_SECONDS)
     end)
 
     if not ok then
         showSnapshotTimeout(
-            'Diagnostic: remotes did not appear before timeout; waiting indefinitely now.'
+            '诊断信息：超时前没有等到 remotes，接下来会继续无限等待。'
         )
-        resolvedRemotes = Shared.Network.Remotes.waitForScope(Shared.Network.Remotes.Scope.Maze)
+        resolvedRemotes = RemotesModule.waitForScope(RemotesModule.Scope.Maze)
     end
 
     Remotes = resolvedRemotes

--- a/tests/src/Shared/MazeSessionServiceDirectBootExperience.spec.luau
+++ b/tests/src/Shared/MazeSessionServiceDirectBootExperience.spec.luau
@@ -28,6 +28,7 @@ return function()
         service._publishMazePresence = function() end
         service._clearPlayerMovement = function() end
         service.World = {
+            SpawnCFrame = CFrame.new(0, 10, 0),
             ReturnHoldCFrame = CFrame.new(),
         }
         return service
@@ -73,6 +74,17 @@ return function()
     assert(
         type(missingStateSnapshot.Movement) == 'table',
         'Snapshot should still provide safe movement fallback data'
+    )
+
+    local spawnLiftService = createService({
+        DirectBootTestToolsEnabled = false,
+    })
+    local spawnLiftPlayer = createPlayer(505, 'Echo')
+    spawnLiftService:_addPlayerState(spawnLiftPlayer)
+    local characterSpawnCFrame = spawnLiftService:_getCharacterSpawnCFrameFor(spawnLiftPlayer)
+    assert(
+        math.abs(characterSpawnCFrame.Position.Y - 13) < 0.001,
+        'Active players should spawn above the authored SpawnMarker instead of inside it'
     )
 
     local localReturnService = createService({

--- a/tests/src/Shared/MazeSessionServiceDirectBootExperience.spec.luau
+++ b/tests/src/Shared/MazeSessionServiceDirectBootExperience.spec.luau
@@ -1,0 +1,100 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local mazeModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
+    local MazeSessionService = require(mazeModules:WaitForChild('MazeSessionService'))
+
+    local function createPlayer(userId, displayName)
+        return {
+            UserId = userId,
+            DisplayName = displayName,
+        }
+    end
+
+    local function createService(options)
+        local runtimeOptions = options or {}
+        runtimeOptions.MonsterServiceFactory = runtimeOptions.MonsterServiceFactory
+            or function()
+                return {
+                    destroy = function() end,
+                    setDeterministicSeed = function() end,
+                    spawn = function() end,
+                }
+            end
+
+        local service = MazeSessionService.new(runtimeOptions)
+        service._setStatus = function(self, status)
+            self.Status = status
+        end
+        service._publishMazePresence = function() end
+        service._clearPlayerMovement = function() end
+        service.World = {
+            ReturnHoldCFrame = CFrame.new(),
+        }
+        return service
+    end
+
+    local directToolService = createService({
+        DirectBootTestToolsEnabled = true,
+    })
+    local directToolPlayer = createPlayer(101, 'Alpha')
+    directToolService:_addPlayerState(directToolPlayer)
+    local directInventory = directToolService.InventoryService:getSummary(directToolPlayer)
+    assert(directInventory.Count == 3, 'Direct boot should seed the empty test backpack')
+    assert(
+        directInventory.ToolCount == 3,
+        'Direct boot should seed flashlight/crowbar/potion tools'
+    )
+
+    local formalEntryService = createService({
+        DirectBootTestToolsEnabled = true,
+    })
+    formalEntryService.IsDirectBoot = false
+    local formalEntryPlayer = createPlayer(202, 'Bravo')
+    formalEntryService:_addPlayerState(formalEntryPlayer)
+    local formalInventory = formalEntryService.InventoryService:getSummary(formalEntryPlayer)
+    assert(
+        formalInventory.Count == 0,
+        'Formal Maze entry should not receive direct-boot test tools'
+    )
+
+    local snapshotService = createService()
+    snapshotService.IsLaunched = true
+    local missingStateSnapshot = snapshotService:_buildSnapshotFor(createPlayer(303, 'Charlie'), {
+        MazeStatus = 'active',
+        ReturnedPlayerSummaries = {},
+        Roster = {},
+        SessionPhase = 'MazeActive',
+        WorldBuildFields = {},
+    })
+    assert(
+        missingStateSnapshot.PlayerState == nil,
+        'Snapshot should tolerate players whose player runtime has not been added yet'
+    )
+    assert(
+        type(missingStateSnapshot.Movement) == 'table',
+        'Snapshot should still provide safe movement fallback data'
+    )
+
+    local localReturnService = createService({
+        DirectBootLocalReturnEnabled = true,
+        DirectBootTestToolsEnabled = false,
+    })
+    local localReturnPlayer = createPlayer(404, 'Delta')
+    localReturnService:_addPlayerState(localReturnPlayer)
+    assert(
+        localReturnService.RunTracker:beginExpedition() == true,
+        'Local return spec should enter expedition'
+    )
+    local teleportCalled = false
+    localReturnService._teleportToCamp = function()
+        teleportCalled = true
+        return true
+    end
+
+    localReturnService:_returnPlayerToRunEntrance(localReturnPlayer, 'returned')
+    assert(teleportCalled == false, 'Direct boot return should stay local instead of teleporting')
+    assert(
+        string.find(localReturnService.Status, 'local Maze PlayTest', 1, true) ~= nil,
+        'Direct boot return should report local PlayTest completion'
+    )
+end

--- a/tests/src/Shared/MazeSessionServiceRoundSignal.spec.luau
+++ b/tests/src/Shared/MazeSessionServiceRoundSignal.spec.luau
@@ -1,0 +1,52 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local mazeModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
+    local MazeSessionService = require(mazeModules:WaitForChild('MazeSessionService'))
+
+    local subscribeFinished = false
+    local fakeRoundSignalConnection = {
+        Disconnect = function() end,
+    }
+    local fakeRoundSignalBus = {
+        publish = function()
+            return true
+        end,
+        subscribe = function()
+            task.wait(0.2)
+            subscribeFinished = true
+            return fakeRoundSignalConnection, true
+        end,
+    }
+
+    local service = MazeSessionService.new({
+        RoundSignalBus = fakeRoundSignalBus,
+        MonsterServiceFactory = function()
+            return {
+                destroy = function() end,
+                setDeterministicSeed = function() end,
+                spawn = function() end,
+            }
+        end,
+    })
+
+    local startedAt = os.clock()
+    service:_subscribeToRoundSignals()
+    local elapsed = os.clock() - startedAt
+
+    assert(
+        elapsed < 0.05,
+        'Maze round-signal subscription should not block direct PlayTest startup'
+    )
+    assert(
+        subscribeFinished == false,
+        'Round-signal subscription should continue in the background after startup continues'
+    )
+
+    task.wait(0.25)
+
+    assert(subscribeFinished == true, 'Background round-signal subscription should still run')
+    assert(
+        service.RoundSignalConnection == fakeRoundSignalConnection,
+        'Successful background round-signal subscription should be retained'
+    )
+end


### PR DESCRIPTION
## Summary
- promote the newer Maze HUD/quickbar experience into the normal Maze PlayTest client while keeping the old client as a non-loaded legacy reference
- keep the authored `Workspace.MazeStaticWorld` flow intact while hardening snapshot delivery and non-blocking round signal subscription
- improve Studio/direct boot by seeding empty test backpacks and keeping ReturnHoldPad completion local

## Tests
- `stylua --check .`
- `selene .`
- `rojo build tests/default.project.json -o tmp/roblox_experience-tests.rbxlx`
- `run-in-roblox --place tmp/roblox_experience-tests.rbxlx --script tests/run-in-roblox.lua`
- `rojo build places/maze/default.project.json -o tmp/maze.rbxlx`

## Notes
- Does not include the unrelated local `packages/shared/src/Runtime/MazeWorldScanner.luau` change.
- `seed` remains internal; normal HUD hides it and Studio diagnostics label it as a session seed.