### PR TITLE
fix(maze): stabilize authored map collision

### DIFF
--- a/places/maze/src/ServerScriptService/Maze/MazeCollisionOverlay.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeCollisionOverlay.luau
@@ -1,0 +1,243 @@
+local MazeCollisionOverlay = {}
+
+local COLLISION_FOLDER_NAME = 'Collision'
+local PRIMARY_MAP_MODEL_NAME = 'maze-roblox'
+local LEGACY_MAP_MODEL_NAME = 'maze00'
+local COLLISION_BOX_FOLDER_NAME = 'CollisionBoxes'
+local GENERATED_ATTRIBUTE = 'GeneratedByMazeCollisionOverlay'
+local SOURCE_MESH_ATTRIBUTE = 'SourceMeshName'
+local SCENERY_ATTRIBUTE = 'IsScenery'
+local MIN_FLOOR_SPAN = 6
+local MAX_FLOOR_THICKNESS = 4
+local MIN_WALL_HEIGHT = 6
+local MIN_WALL_SPAN = 8
+local MAX_WALL_THICKNESS = 5
+local MIN_COLLIDER_THICKNESS = 1
+local SPAWN_LIGHT_NAME = 'SpawnMarkerCyanGuideLight'
+local SPAWN_FILL_LIGHT_NAME = 'SpawnMarkerCyanFillLight'
+local SPAWN_MARKER_COLOR = Color3.fromRGB(0, 255, 255)
+local SPAWN_MARKER_TRANSPARENCY = 0.2
+local SPAWN_LIGHT_RANGE = 42
+local SPAWN_LIGHT_BRIGHTNESS = 3.2
+local SPAWN_FILL_LIGHT_RANGE = 24
+local SPAWN_FILL_LIGHT_BRIGHTNESS = 0.85
+
+local function isDoorLikeName(name)
+    local lowerName = string.lower(tostring(name or ''))
+    return string.find(lowerName, 'door', 1, true) ~= nil
+end
+
+local function isSemanticPart(part)
+    return part.Name == 'SpawnMarker'
+        or part.Name == 'ReturnHoldPad'
+        or string.match(part.Name, '^SpawnPoint_') ~= nil
+        or string.match(part.Name, '^LootSocket_') ~= nil
+        or string.match(part.Name, '^Doorway_') ~= nil
+end
+
+local function sanitizeName(name)
+    return string.gsub(tostring(name), '[^%w_%-]+', '_')
+end
+
+local function getMapModel(staticWorldRoot)
+    local collisionRoot = staticWorldRoot:FindFirstChild(COLLISION_FOLDER_NAME)
+    if collisionRoot == nil then
+        return nil
+    end
+
+    return collisionRoot:FindFirstChild(PRIMARY_MAP_MODEL_NAME)
+        or collisionRoot:FindFirstChild(LEGACY_MAP_MODEL_NAME)
+end
+
+local function ensurePointLight(parent, name, range, brightness)
+    local light = parent:FindFirstChild(name)
+    if light == nil or not light:IsA('PointLight') then
+        if light ~= nil then
+            light:Destroy()
+        end
+
+        light = Instance.new('PointLight')
+        light.Name = name
+        light.Parent = parent
+    end
+
+    light.Color = SPAWN_MARKER_COLOR
+    light.Range = range
+    light.Brightness = brightness
+    light.Shadows = false
+    light.Enabled = true
+
+    return light
+end
+
+local function styleSpawnMarker(staticWorldRoot)
+    local spawnMarker = staticWorldRoot:FindFirstChild('SpawnMarker', true)
+    if spawnMarker == nil or not spawnMarker:IsA('BasePart') then
+        return nil
+    end
+
+    spawnMarker.Material = Enum.Material.Neon
+    spawnMarker.Color = SPAWN_MARKER_COLOR
+    spawnMarker.Transparency = SPAWN_MARKER_TRANSPARENCY
+    spawnMarker.CanCollide = false
+    spawnMarker.CanQuery = true
+    spawnMarker.CanTouch = false
+
+    ensurePointLight(spawnMarker, SPAWN_LIGHT_NAME, SPAWN_LIGHT_RANGE, SPAWN_LIGHT_BRIGHTNESS)
+    ensurePointLight(
+        spawnMarker,
+        SPAWN_FILL_LIGHT_NAME,
+        SPAWN_FILL_LIGHT_RANGE,
+        SPAWN_FILL_LIGHT_BRIGHTNESS
+    )
+
+    return spawnMarker
+end
+
+local function classifyCollisionPart(part)
+    local size = part.Size
+    local xzSpan = math.max(size.X, size.Z)
+    local horizontalSpan = math.min(size.X, size.Z)
+    local thinnestAxis = math.min(size.X, size.Z)
+
+    if size.Y <= MAX_FLOOR_THICKNESS and horizontalSpan >= MIN_FLOOR_SPAN then
+        return 'Floor'
+    end
+
+    if
+        size.Y >= MIN_WALL_HEIGHT
+        and xzSpan >= MIN_WALL_SPAN
+        and thinnestAxis <= MAX_WALL_THICKNESS
+    then
+        return 'Wall'
+    end
+
+    return nil
+end
+
+local function getColliderSize(sourcePart, kind)
+    local size = sourcePart.Size
+    if kind == 'Floor' then
+        return Vector3.new(size.X, math.max(size.Y, MIN_COLLIDER_THICKNESS), size.Z)
+    end
+
+    return Vector3.new(
+        math.max(size.X, MIN_COLLIDER_THICKNESS),
+        math.max(size.Y, MIN_COLLIDER_THICKNESS),
+        math.max(size.Z, MIN_COLLIDER_THICKNESS)
+    )
+end
+
+local function createCollisionBox(folder, sourcePart, kind, index)
+    local box = Instance.new('Part')
+    box.Name = string.format('%sBox_%03d_%s', kind, index, sanitizeName(sourcePart.Name))
+    box.Size = getColliderSize(sourcePart, kind)
+    box.CFrame = sourcePart.CFrame
+    box.Anchored = true
+    box.CanCollide = true
+    box.CanQuery = true
+    box.CanTouch = false
+    box.Transparency = 1
+    box.CastShadow = false
+    box:SetAttribute(GENERATED_ATTRIBUTE, true)
+    box:SetAttribute(SOURCE_MESH_ATTRIBUTE, sourcePart.Name)
+    box.Parent = folder
+    return box
+end
+
+local function resetGeneratedCollisionBoxes(folder)
+    for _, child in ipairs(folder:GetChildren()) do
+        if child:GetAttribute(GENERATED_ATTRIBUTE) == true then
+            child:Destroy()
+        end
+    end
+end
+
+local function prepareMapPart(part)
+    part.Anchored = true
+    part.CanQuery = true
+    part.CanTouch = false
+
+    if isDoorLikeName(part.Name) then
+        -- Imported door meshes often have a solid simplified collision hull that fills the doorway.
+        part.CanCollide = false
+        return false
+    end
+
+    part.CanCollide = true
+    return true
+end
+
+local function ensureCollisionBoxes(mapModel)
+    local collisionBoxes = mapModel:FindFirstChild(COLLISION_BOX_FOLDER_NAME)
+    if collisionBoxes == nil then
+        collisionBoxes = Instance.new('Folder')
+        collisionBoxes.Name = COLLISION_BOX_FOLDER_NAME
+        collisionBoxes.Parent = mapModel
+    end
+
+    collisionBoxes:SetAttribute(SCENERY_ATTRIBUTE, true)
+    resetGeneratedCollisionBoxes(collisionBoxes)
+
+    local created = 0
+    local floorCount = 0
+    local wallCount = 0
+
+    for _, descendant in ipairs(mapModel:GetDescendants()) do
+        if descendant:IsA('BasePart') and not descendant:IsDescendantOf(collisionBoxes) then
+            local usableForGeneratedCollision = prepareMapPart(descendant)
+            if usableForGeneratedCollision and not isSemanticPart(descendant) then
+                local kind = classifyCollisionPart(descendant)
+                if kind ~= nil then
+                    created += 1
+                    createCollisionBox(collisionBoxes, descendant, kind, created)
+
+                    if kind == 'Floor' then
+                        floorCount += 1
+                    elseif kind == 'Wall' then
+                        wallCount += 1
+                    end
+                end
+            end
+        end
+    end
+
+    return {
+        Folder = collisionBoxes,
+        Created = created,
+        Floors = floorCount,
+        Walls = wallCount,
+    }
+end
+
+function MazeCollisionOverlay.apply(staticWorldRoot)
+    if staticWorldRoot == nil then
+        return {
+            Applied = false,
+            Reason = 'MissingStaticWorldRoot',
+        }
+    end
+
+    local spawnMarker = styleSpawnMarker(staticWorldRoot)
+    local mapModel = getMapModel(staticWorldRoot)
+    if mapModel == nil then
+        return {
+            Applied = false,
+            Reason = 'MissingMazeMapCollisionRoot',
+            SpawnMarker = spawnMarker,
+        }
+    end
+
+    local collisionSummary = ensureCollisionBoxes(mapModel)
+    return {
+        Applied = true,
+        MapModel = mapModel,
+        SpawnMarker = spawnMarker,
+        CollisionBoxes = collisionSummary.Folder,
+        CreatedCollisionBoxes = collisionSummary.Created,
+        FloorCollisionBoxes = collisionSummary.Floors,
+        WallCollisionBoxes = collisionSummary.Walls,
+    }
+end
+
+return MazeCollisionOverlay

--- a/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeWorldBuilder.luau
@@ -7,6 +7,7 @@ local Shared = require(Packages:WaitForChild('Shared'))
 local MazeScene = require(script.Parent.MazeScene)
 local MazeStaticWorldAssembler = require(script.Parent.MazeStaticWorldAssembler)
 local MazeStaticWorldContract = require(script.Parent.MazeStaticWorldContract)
+local MazeCollisionOverlay = require(script.Parent.MazeCollisionOverlay)
 
 local MazeWorldBuilder = {}
 
@@ -17,6 +18,8 @@ function MazeWorldBuilder.build()
     if not (staticWorldRoot:IsA('Folder') or staticWorldRoot:IsA('Model')) then
         error('MazeStaticWorld must be a Folder or Model.', 0)
     end
+
+    MazeCollisionOverlay.apply(staticWorldRoot)
 
     return MazeScene.new(Shared.Runtime.MazeWorldScanner.BuildStaticWorld(staticWorldRoot))
 end

--- a/tests/src/Shared/MazeCollisionOverlay.spec.luau
+++ b/tests/src/Shared/MazeCollisionOverlay.spec.luau
@@ -1,0 +1,127 @@
+return function()
+    local ReplicatedStorage = game:GetService('ReplicatedStorage')
+    local Workspace = game:GetService('Workspace')
+
+    local mazeModules = ReplicatedStorage:WaitForChild('PlaceModules'):WaitForChild('Maze')
+    local overlay = require(mazeModules:WaitForChild('MazeCollisionOverlay'))
+
+    local root = Instance.new('Folder')
+    root.Name = 'MazeStaticWorld'
+    root.Parent = Workspace
+
+    local spawnMarker = Instance.new('Part')
+    spawnMarker.Name = 'SpawnMarker'
+    spawnMarker.Anchored = true
+    spawnMarker.Size = Vector3.new(16, 1.2, 16)
+    spawnMarker.CFrame = CFrame.new(98, 77.94891357421875, -397)
+    spawnMarker.CanCollide = true
+    spawnMarker.Parent = root
+
+    local collisionRoot = Instance.new('Folder')
+    collisionRoot.Name = 'Collision'
+    collisionRoot.Parent = root
+
+    local mapModel = Instance.new('Model')
+    mapModel.Name = 'maze-roblox'
+    mapModel.Parent = collisionRoot
+
+    local floor = Instance.new('Part')
+    floor.Name = '物件_1326'
+    floor.Anchored = false
+    floor.Size = Vector3.new(24, 1, 24)
+    floor.CFrame = CFrame.new(98, 77.4, -397)
+    floor.CanCollide = false
+    floor.CanQuery = false
+    floor.CanTouch = true
+    floor.Parent = mapModel
+
+    local wall = Instance.new('Part')
+    wall.Name = 'Wall_001'
+    wall.Anchored = false
+    wall.Size = Vector3.new(2, 18, 24)
+    wall.CFrame = CFrame.new(110, 86, -397)
+    wall.CanCollide = false
+    wall.CanQuery = false
+    wall.CanTouch = true
+    wall.Parent = mapModel
+
+    local door = Instance.new('Part')
+    door.Name = 'door_001'
+    door.Anchored = false
+    door.Size = Vector3.new(8, 12, 1)
+    door.CFrame = CFrame.new(98, 84, -385)
+    door.CanCollide = true
+    door.CanQuery = false
+    door.CanTouch = true
+    door.Parent = mapModel
+
+    local doorwayFrame = Instance.new('Part')
+    doorwayFrame.Name = 'DoorwayFrame_003'
+    doorwayFrame.Anchored = false
+    doorwayFrame.Size = Vector3.new(16, 16, 2)
+    doorwayFrame.CFrame = CFrame.new(98, 86, -380)
+    doorwayFrame.CanCollide = true
+    doorwayFrame.CanQuery = false
+    doorwayFrame.CanTouch = true
+    doorwayFrame.Parent = mapModel
+
+    local originalSpawnCFrame = spawnMarker.CFrame
+    local summary = overlay.apply(root)
+
+    assert(summary.Applied == true, 'Collision overlay should apply when maze map geometry exists')
+    assert(summary.CreatedCollisionBoxes == 2, 'Overlay should create floor and wall boxes only')
+    assert(summary.FloorCollisionBoxes == 1, 'Overlay should create a floor collision box')
+    assert(summary.WallCollisionBoxes == 1, 'Overlay should create a wall collision box')
+    assert(
+        spawnMarker.CFrame == originalSpawnCFrame,
+        'Overlay must not move the authored SpawnMarker'
+    )
+    assert(spawnMarker.Material == Enum.Material.Neon, 'SpawnMarker should be restored to Neon')
+    assert(spawnMarker.Color == Color3.fromRGB(0, 255, 255), 'SpawnMarker should be cyan')
+    assert(
+        spawnMarker.CanCollide == false,
+        'SpawnMarker remains semantic and should not carry collision'
+    )
+    assert(
+        spawnMarker:FindFirstChild('SpawnMarkerCyanGuideLight') ~= nil,
+        'SpawnMarker should receive the cyan guide light'
+    )
+
+    local collisionBoxes = mapModel:FindFirstChild('CollisionBoxes')
+    assert(collisionBoxes ~= nil, 'Overlay should create a CollisionBoxes folder')
+    assert(
+        collisionBoxes:GetAttribute('IsScenery') == true,
+        'CollisionBoxes should be scenery so world scan does not promote it to gameplay'
+    )
+
+    local doorBoxCount = 0
+    for _, child in ipairs(collisionBoxes:GetChildren()) do
+        local sourceName = tostring(child:GetAttribute('SourceMeshName') or child.Name)
+        if string.find(string.lower(sourceName), 'door', 1, true) ~= nil then
+            doorBoxCount += 1
+        end
+    end
+    assert(doorBoxCount == 0, 'Overlay should not create solid boxes over door openings')
+    assert(door.CanCollide == false, 'Imported door leaf collision should not block openings')
+    assert(
+        doorwayFrame.CanCollide == false,
+        'Imported doorway frame collision should not fill openings'
+    )
+    assert(
+        floor.Anchored == true and floor.CanCollide == true,
+        'Map floors should be anchored and collidable'
+    )
+    assert(
+        wall.Anchored == true and wall.CanCollide == true,
+        'Map walls should be anchored and collidable'
+    )
+
+    local secondSummary = overlay.apply(root)
+    assert(
+        secondSummary.CreatedCollisionBoxes == 2,
+        'Reapplying the overlay should replace generated boxes without duplicating them'
+    )
+    assert(#collisionBoxes:GetChildren() == 2, 'CollisionBoxes should stay stable across reapply')
+
+    root:Destroy()
+end


### PR DESCRIPTION
## Summary
- add a Maze authored collision overlay that builds invisible floor/wall collision boxes from `Workspace.MazeStaticWorld.Collision.maze-roblox` / `maze00`
- restore `SpawnMarker` to cyan Neon guide styling without moving its authored CFrame
- wire the overlay into `MazeWorldBuilder` before authored world scanning

## Why
The current PlayTest issue is not the spawn selection path: the player can spawn at the authored marker but still fall because the imported maze mesh does not provide reliable Humanoid collision. This change keeps the authored map as the source of truth and adds a deterministic collision layer derived from that authored map.

## Notes
- Does not commit local ignored `maze_副本.rbxlx` or FBX files.
- Does not change Maze procgen/fallback behavior.
- Does not move `SpawnMarker`; it only restores visual/collision flags.
- Door-like imported meshes are skipped by the generated collision layer so rectangular helper boxes do not seal openings.

## Validation
- `stylua --check .` passed
- `selene .` reported 4 pre-existing warnings in `places/maze/content-harness/src/StarterPlayer/StarterPlayerScripts/MazeClient.client.luau`
- `rojo build tests/default.project.json -o tmp/roblox_experience-tests.rbxlx` passed
- `run-in-roblox --place tmp/roblox_experience-tests.rbxlx --script tests/run-in-roblox.lua` passed
- `rojo build places/maze/default.project.json -o tmp/maze.rbxlx` passed
