### PR TITLE
[codex] Tune maze scenery fire lighting

### DIFF
--- a/places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau
+++ b/places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau
@@ -7,6 +7,25 @@ local MazeStaticWorldOverlayManifest = require(script.Parent.MazeStaticWorldOver
 
 local MazeStaticWorldAssembler = {}
 
+local SCENERY_LIGHT_PROFILE_ATTRIBUTE = 'MazeSceneryLightProfile'
+local SCENERY_LIGHT_PROFILES = table.freeze({
+    Fire = table.freeze({
+        Brightness = 5.5,
+        Range = 40,
+        Shadows = false,
+        NameTokens = table.freeze({ 'fire', 'flame' }),
+    }),
+    Torch = table.freeze({
+        Brightness = 4.5,
+        Range = 32,
+        Shadows = false,
+        NameTokens = table.freeze({ 'torch' }),
+    }),
+})
+local SCENERY_LIGHT_PROFILE_ORDER = table.freeze({ 'Fire', 'Torch' })
+
+MazeStaticWorldAssembler.SceneryLightProfiles = SCENERY_LIGHT_PROFILES
+
 local function requireFolder(parent, name, contextLabel)
     local child = parent:FindFirstChild(name)
     if child == nil or not child:IsA('Folder') then
@@ -87,6 +106,71 @@ local function createRoot()
     sceneryRoot.Parent = root
 
     return root, sceneryRoot
+end
+
+local function isAuthoredSceneryLight(instance)
+    return instance:IsA('PointLight') or instance:IsA('SpotLight') or instance:IsA('SurfaceLight')
+end
+
+local function findProfileFromAttribute(instance)
+    local profileName = instance:GetAttribute(SCENERY_LIGHT_PROFILE_ATTRIBUTE)
+    if type(profileName) ~= 'string' then
+        return nil
+    end
+
+    local normalizedProfileName = string.lower(profileName)
+    for _, profileKey in ipairs(SCENERY_LIGHT_PROFILE_ORDER) do
+        if normalizedProfileName == string.lower(profileKey) then
+            return SCENERY_LIGHT_PROFILES[profileKey]
+        end
+    end
+
+    return nil
+end
+
+local function findProfileFromName(instance)
+    local lowerName = string.lower(instance.Name)
+    for _, profileName in ipairs(SCENERY_LIGHT_PROFILE_ORDER) do
+        local profile = SCENERY_LIGHT_PROFILES[profileName]
+        for _, token in ipairs(profile.NameTokens) do
+            if string.find(lowerName, token, 1, true) ~= nil then
+                return profile
+            end
+        end
+    end
+
+    return nil
+end
+
+local function findSceneryLightProfile(light, sceneryRoot)
+    local current = light
+    while current ~= nil and current ~= sceneryRoot do
+        local profile = findProfileFromAttribute(current) or findProfileFromName(current)
+        if profile ~= nil then
+            return profile
+        end
+
+        current = current.Parent
+    end
+
+    return nil
+end
+
+local function applySceneryLightProfile(light, profile)
+    light.Brightness = profile.Brightness
+    light.Range = profile.Range
+    light.Shadows = profile.Shadows
+end
+
+local function applySceneryLightingProfiles(sceneryRoot)
+    for _, descendant in ipairs(sceneryRoot:GetDescendants()) do
+        if isAuthoredSceneryLight(descendant) then
+            local profile = findSceneryLightProfile(descendant, sceneryRoot)
+            if profile ~= nil then
+                applySceneryLightProfile(descendant, profile)
+            end
+        end
+    end
 end
 
 local function stabilizeChunkGeometry(chunkModel)
@@ -213,6 +297,8 @@ function MazeStaticWorldAssembler.assemble()
     if enabledChunkCount == 0 then
         error('Maze chunk manifest must enable at least one geometry chunk.', 0)
     end
+
+    applySceneryLightingProfiles(sceneryRoot)
 
     return root
 end

--- a/tests/src/Shared/MazeStaticWorldAssembler.spec.luau
+++ b/tests/src/Shared/MazeStaticWorldAssembler.spec.luau
@@ -11,6 +11,36 @@ return function()
         require(mazeModules:WaitForChild('MazeStaticWorldOverlayManifest'))
     local MazeWorldBuilder = require(mazeModules:WaitForChild('MazeWorldBuilder'))
 
+    local chunkAsset = ReplicatedStorage.Assets.Maze.Chunks:FindFirstChild('MazeChunk_maze_v1')
+    assert(
+        chunkAsset ~= nil and chunkAsset:IsA('Model'),
+        'Tests should mount the maze chunk asset in ReplicatedStorage.Assets.Maze.Chunks'
+    )
+
+    local function createSceneryLightFixture(modelName, lightName)
+        local model = Instance.new('Model')
+        model.Name = modelName
+
+        local mount = Instance.new('Part')
+        mount.Name = 'LightMount'
+        mount.Anchored = true
+        mount.Parent = model
+
+        local light = Instance.new('PointLight')
+        light.Name = lightName
+        light.Brightness = 0.25
+        light.Range = 8
+        light.Shadows = true
+        light.Parent = mount
+
+        model.Parent = chunkAsset
+
+        return model
+    end
+
+    local torchFixture = createSceneryLightFixture('TorchWallSconce_Test', 'TorchLightProbe')
+    local fireFixture = createSceneryLightFixture('FireBowl_Test', 'FireLightProbe')
+
     local root = MazeStaticWorldAssembler.assemble()
     assert(
         root.Name == MazeStaticWorldContract.RootName,
@@ -52,6 +82,26 @@ return function()
     assert(
         table.find(roomIds, 'maze.3dm') == nil,
         'Geometry chunk containers under Scenery must be ignored by the runtime scanner'
+    )
+
+    local torchLight = root:FindFirstChild('TorchLightProbe', true)
+    assert(
+        torchLight ~= nil
+            and torchLight:IsA('PointLight')
+            and torchLight.Brightness == 4.5
+            and torchLight.Range == 32
+            and torchLight.Shadows == false,
+        'Assembler should normalize authored torch brightness and range inside scenery'
+    )
+
+    local fireLight = root:FindFirstChild('FireLightProbe', true)
+    assert(
+        fireLight ~= nil
+            and fireLight:IsA('PointLight')
+            and fireLight.Brightness == 5.5
+            and fireLight.Range == 40
+            and fireLight.Shadows == false,
+        'Assembler should normalize authored fire brightness and range inside scenery'
     )
 
     local world = shared.Runtime.MazeWorldScanner.BuildStaticWorld(root)
@@ -152,4 +202,7 @@ return function()
     if finalRoot ~= nil then
         finalRoot:Destroy()
     end
+
+    torchFixture:Destroy()
+    fireFixture:Destroy()
 end


### PR DESCRIPTION
## What changed

- Adds maze scenery light profiles for authored Torch and Fire/Flame lights.
- Normalizes matching `PointLight`, `SpotLight`, and `SurfaceLight` brightness/range when `MazeStaticWorld` is assembled.
- Supports explicit `MazeSceneryLightProfile = "Torch"` or `"Fire"` attributes in addition to name matching.
- Covers torch and fire fixture behavior in the static world assembler spec.

## Why

Scenery torch and fire lights were too dim from a distance. This keeps authored assets deterministic while giving fire sources a wider, brighter spread than regular torches.

## Validation

- `stylua --check places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau tests/src/Shared/MazeStaticWorldAssembler.spec.luau`
- `selene places/maze/src/ServerScriptService/Maze/MazeStaticWorldAssembler.luau tests/src/Shared/MazeStaticWorldAssembler.spec.luau`
- `rojo build tests/default.project.json -o ./tmp/roblox_experience-tests.rbxlx`

## Notes

This branch targets `codex/maze-playtest-unified-experience` so it only carries the scenery lighting change and does not push unrelated local work from the main checkout.
